### PR TITLE
Hotfix/cs/exporter file crash

### DIFF
--- a/imessage-database/src/message_types/variants.rs
+++ b/imessage-database/src/message_types/variants.rs
@@ -9,7 +9,9 @@ use crate::error::plist::PlistParseError;
 /// Reactions to iMessages
 ///
 /// `bp:` GUID prefix for bubble message reactions (links, apps, etc)
+/// 
 /// `p:0/` GUID prefix for normal messages (body text, attachments)
+/// 
 /// for `p:#/`, the # is the message index, so if a message has 3 attachments:
 /// - 0 is the first image
 /// - 1 is the second image

--- a/imessage-database/src/message_types/variants.rs
+++ b/imessage-database/src/message_types/variants.rs
@@ -8,16 +8,16 @@ use crate::error::plist::PlistParseError;
 
 /// Reactions to iMessages
 ///
-/// `bp:` GUID prefix for bubble message reactions (links, apps, etc)
+/// `bp:` GUID prefix for bubble message reactions (links, apps, etc).
 /// 
-/// `p:0/` GUID prefix for normal messages (body text, attachments)
+/// `p:0/` GUID prefix for normal messages (body text, attachments).
 /// 
-/// for `p:#/`, the # is the message index, so if a message has 3 attachments:
+/// In `p:#/`, the # represents the message index. If a message has 3 attachments:
 /// - 0 is the first image
 /// - 1 is the second image
 /// - 2 is the third image
 /// - 3 is the text of the message
-/// In this example, a Like on `p:2/` is a like on the second message
+/// In this example, a Like on `p:2/` is a like on the third image
 ///
 /// Reactions are normal messages in the database, but only the latest reaction
 /// is stored. For example:

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -483,12 +483,14 @@ impl Message {
     ///
     /// - `bp:` GUID prefix for bubble message reactions (links, apps, etc)
     /// - `p:0/` GUID prefix for normal messages (body text, attachments)
-    ///   - for `p:#/`, the # is the message index, so if a message has 3 attachments:
+    /// 
+    /// In `p:#/`, the # represents the message index. If a message has 3 attachments:
     ///     - 0 is the first image
     ///     - 1 is the second image
     ///     - 2 is the third image
     ///     - 3 is the text of the message
-    /// In this example, a Like on `p:2/` is a like on the second message
+    /// 
+    /// In this example, a Like on `p:2/` is a like on the third image
     fn clean_associated_guid(&self) -> Option<(usize, &str)> {
         // TODO: Test that the GUID length is correct!
         if let Some(guid) = &self.associated_message_guid {

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -479,18 +479,7 @@ impl Message {
         count
     }
 
-    /// In some special cases, the `guid` is stored with some additional data we need to parse out. There are two prefixes:
-    ///
-    /// - `bp:` GUID prefix for bubble message reactions (links, apps, etc)
-    /// - `p:0/` GUID prefix for normal messages (body text, attachments)
-    /// 
-    /// In `p:#/`, the # represents the message index. If a message has 3 attachments:
-    ///     - 0 is the first image
-    ///     - 1 is the second image
-    ///     - 2 is the third image
-    ///     - 3 is the text of the message
-    /// 
-    /// In this example, a Like on `p:2/` is a like on the third image
+    /// See [Reaction](crate::message_types::variants::Reaction) for details on this data.
     fn clean_associated_guid(&self) -> Option<(usize, &str)> {
         // TODO: Test that the GUID length is correct!
         if let Some(guid) = &self.associated_message_guid {

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -2,7 +2,7 @@
  This module represents common (but not all) columns in the `message` table.
 */
 
-use std::{collections::HashMap, io::Read, vec};
+use std::{collections::HashMap, io::Read};
 
 use chrono::{naive::NaiveDateTime, offset::Local, DateTime, TimeZone};
 use plist::Value;
@@ -280,11 +280,19 @@ impl Message {
         }
     }
 
-    /// Get a vector of string slices of the message's components
+    /// Get a vector of a message's components
     ///
     /// If the message has attachments, there will be one [`U+FFFC`]((https://www.fileformat.info/info/unicode/char/fffc/index.htm)) character
     /// for each attachment and one [`U+FFFD`](https://www.fileformat.info/info/unicode/char/fffd/index.htm) for app messages that we need
     /// to format.
+    /// 
+    /// An iMessage that contains body text like:
+    /// 
+    /// `\u{FFFC}Check out this photo!`
+    /// 
+    /// Will have a `body()` of:
+    /// 
+    /// `[BubbleType::Attachment, BubbleType::Text("Check out this photo!")]`
     pub fn body(&self) -> Vec<BubbleType> {
         let mut out_v = vec![];
 

--- a/imessage-exporter/src/app/mod.rs
+++ b/imessage-exporter/src/app/mod.rs
@@ -2,3 +2,4 @@ pub mod converter;
 pub mod options;
 pub mod progress;
 pub mod runtime;
+pub mod sanitizers;

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -7,7 +7,7 @@ use std::{
 
 use rusqlite::Connection;
 
-use crate::{app::options::Options, Exporter, HTML, TXT};
+use crate::{app::{options::Options, sanitizers::sanitize_filename}, Exporter, HTML, TXT};
 use imessage_database::{
     error::table::TableError,
     tables::{
@@ -84,7 +84,7 @@ impl<'a> Config<'a> {
     ///
     /// If it does not, first try and make a flat list of its members. Failing that, use the unique `chat_identifier` field.
     pub fn filename(&self, chatroom: &Chat) -> String {
-        match &chatroom.display_name() {
+        let filename = match &chatroom.display_name() {
             // If there is a display name, use that
             Some(name) => {
                 format!(
@@ -106,7 +106,8 @@ impl<'a> Config<'a> {
                     chatroom.chat_identifier.to_owned()
                 }
             },
-        }
+        };
+        sanitize_filename(filename)
     }
 
     /// Generate a filename from a set of participants, truncating if the name is too long

--- a/imessage-exporter/src/app/sanitizers.rs
+++ b/imessage-exporter/src/app/sanitizers.rs
@@ -1,0 +1,41 @@
+/// The character to replace disallowed chars with
+const REPLACEMENT_CHAR: char = '_';
+/// Characters disallowed in a filename
+const DISALLOWED_CHARS: [char; 3] = ['/', '\\', ':'];
+
+/// Remove unsafe chars in [this list](app::sanitizers::DISALLOWED_CHARS).
+pub fn sanitize_filename(filename: String) -> String {
+    filename.chars().into_iter().map(|letter| match DISALLOWED_CHARS.contains(&letter){
+        true => REPLACEMENT_CHAR,
+        false => letter,
+    }).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::app::sanitizers::sanitize_filename;
+
+    #[test]
+    fn can_sanitize_all() {
+        let contaminated = String::from("a/b\\c:d");
+        let sanitized = String::from("a_b_c_d");
+
+        assert_eq!(sanitize_filename(contaminated), sanitized);
+    }
+
+    #[test]
+    fn doesnt_sanitize_none() {
+        let contaminated = String::from("a_b_c_d");
+        let sanitized = String::from("a_b_c_d");
+
+        assert_eq!(sanitize_filename(contaminated), sanitized);
+    }
+
+    #[test]
+    fn can_sanitize_one() {
+        let contaminated = String::from("ab/cd");
+        let sanitized = String::from("ab_cd");
+
+        assert_eq!(sanitize_filename(contaminated), sanitized);
+    }
+}

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -647,12 +647,13 @@ impl<'a> Writer<'a> for HTML<'a> {
     }
 
     fn write_to_file(file: &Path, text: &str) {
-        let mut file = File::options()
-            .append(true)
-            .create(true)
-            .open(file)
-            .unwrap();
-        file.write_all(text.as_bytes()).unwrap();
+        match File::options()
+        .append(true)
+        .create(true)
+        .open(file) {
+            Ok(file) => file.write_all(text.as_bytes()).unwrap(),
+            Err(why) => eprintln!("Unable to write to {file}: {why:?}"),
+        }
     }
 }
 

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -651,8 +651,8 @@ impl<'a> Writer<'a> for HTML<'a> {
         .append(true)
         .create(true)
         .open(file) {
-            Ok(file) => file.write_all(text.as_bytes()).unwrap(),
-            Err(why) => eprintln!("Unable to write to {file}: {why:?}"),
+            Ok(mut file) => file.write_all(text.as_bytes()).unwrap(),
+            Err(why) => eprintln!("Unable to write to {file:?}: {why:?}"),
         }
     }
 }

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -437,12 +437,13 @@ impl<'a> Writer<'a> for TXT<'a> {
     }
 
     fn write_to_file(file: &Path, text: &str) {
-        let mut file = File::options()
-            .append(true)
-            .create(true)
-            .open(file)
-            .unwrap();
-        file.write_all(text.as_bytes()).unwrap();
+        match File::options()
+        .append(true)
+        .create(true)
+        .open(file) {
+            Ok(file) => file.write_all(text.as_bytes()).unwrap(),
+            Err(why) => eprintln!("Unable to write to {file}: {why:?}"),
+        }
     }
 }
 

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -441,8 +441,8 @@ impl<'a> Writer<'a> for TXT<'a> {
         .append(true)
         .create(true)
         .open(file) {
-            Ok(file) => file.write_all(text.as_bytes()).unwrap(),
-            Err(why) => eprintln!("Unable to write to {file}: {why:?}"),
+            Ok(mut file) => file.write_all(text.as_bytes()).unwrap(),
+            Err(why) => eprintln!("Unable to write to {file:?}: {why:?}"),
         }
     }
 }


### PR DESCRIPTION
- Better warning when a file is not found
- Sanitize filenames of pesky characters for #47 
- Update formatting in docs