### PR TITLE
Added homebrew (package manager) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,19 @@ This crate provides both a library to interact with iMessage data as well as a b
 
 The `imessage-exporter` binary exports iMessage data to `txt` or `html` formats. It can also run diagnostics to find problems with the iMessage database.
 
+### Installation
+
+#### From source
 Installation instructions for the binary are located [here](imessage-exporter/README.md).
 
+
+#### Using Homebrew (macOS)
+If you are a homebrew user on macOS, you can install using `brew tap`:
+
+```shell
+brew tap ReagentX/imessage-exporter https://github.com/ReagentX/imessage-exporter
+brew install ReagentX/imessage-exporter/imessage-exporter
+```
 ## Library
 
 The `imessage_database` library provides models that allow us to access iMessage information as native data structures.

--- a/imessage-exporter.rb
+++ b/imessage-exporter.rb
@@ -1,0 +1,34 @@
+class ImessageExporter < Formula
+  # change these var when a new version is released
+  soft_version = "1.0.0"
+  sha256sum_intel = "4d7f790d1da616e08cbd71a390362b1cf311b17a77386ee0ea9fe147944ab914"
+  sha256sum_arm64 = "c0a20681d6c90a5d22314d585364de8d62def9579c8014acbe4bcaa13d6d23b6"
+
+  # formula infos
+  desc "CLI to export MacOS iMessage data + run diagnostics"
+  repo_url = "https://github.com/ReagentX/imessage-exporter"
+  homepage repo_url
+  version soft_version
+
+  binary_name = "imessage-exporter-" + (Hardware::CPU.type == :intel ? "x86_64" : "aarch64") + "-apple-darwin.tar.gz"
+  binary_url = "#{repo_url}/releases/latest/download/#{binary_name}"
+  url binary_url
+  sha256 Hardware::CPU.type == :intel ? sha256sum_intel : sha256sum_arm64
+
+  def install
+    bin.install "imessage-exporter"
+  end
+
+  test do
+    assert_equal "imessage is not a valid export type! Must be one of <txt, html>\n",
+    shell_output("imessage-exporter -f imessage")
+    assert_equal "Diagnostics are enabled; format is disallowed\n",
+    shell_output("imessage-exporter -f txt -d")
+    assert_equal "No export type selected, required by no-copy\n",
+    shell_output("imessage-exporter -n")
+    assert_equal "No export type selected, required by export-path\n",
+    shell_output("imessage-exporter -o imessage")
+    assert_equal "",
+    shell_output("imessage-exporter -p imessage")
+  end
+end


### PR DESCRIPTION
I added a formula file that allow to install and manage the CLI from macOS most popular package manager: Homebrew. I also updated README.md with install instructions.

To allow the users to upgrade via the package manager when a new version is released, the version number and sha256sum variables should be updated. I highlighted these variables in the file.
  I might do a pull request later with a GitHub workflow to automate this task.  

Feel free to ask me any questions about this. 😃