### PR TITLE
Use imagemagick to convert HEIC images if sips is not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +301,7 @@ dependencies = [
  "indicatif",
  "rusqlite",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -722,6 +729,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -15,4 +15,5 @@ filetime = "0.2.19"
 imessage-database = {path = "../imessage-database"}
 indicatif = "0.17.3"
 rusqlite = {version = "0.28.0", features = ["blob", "bundled"]}
+which = "4.4.0"
 uuid = {version = "1.2.2", features = ["v4", "fast-rng"]}

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -79,7 +79,7 @@ Export as `html` from `/Volumes/external/chat.db` to `/Volumes/external/export` 
 % imessage-exporter -f html --no-copy -p /Volumes/external/chat.db -o /Volumes/external/export
 ```
 
-Export messages from `2020-01-01` to `2020-12-31` as `txt` the default iMessage Database location to `~/export-2020`:
+Export messages from `2020-01-01` to `2020-12-31` as `txt` from the default iMessage Database location to `~/export-2020`:
 
 ```zsh
 % imessage-exporter -f txt -o ~/export-2020 -s 2020-01-01 -e 2021-01-01


### PR DESCRIPTION
Hi, I used imessage-exporter for the first time yesterday and it worked perfect, except that it didn't copy any HEIC images. This fixes #89.

The changes check to see if `sips` is present in the path, and if it isn't it then checks for `convert` from imagemagick. If neither is found then it errors saying there's no tool for conversion.

I did add a crate to check if binaries are in the path, but this can be rewritten by hand if you would prefer that. I have tested these changes under linux and they do work, including the more helpful error message when neither tool is found.