### PR TITLE
explicitly unwraps unhandled errors to address warnings

### DIFF
--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -98,7 +98,7 @@ impl<'a> Exporter<'a> for HTML<'a> {
             }
             // Message replies and reactions are rendered in context, so no need to render them separately
             else if !msg.is_reaction() {
-                msg.gen_text(&self.config.db);
+                msg.gen_text(&self.config.db).unwrap();
                 let message = self
                     .format_message(&msg, 0)
                     .map_err(RuntimeError::DatabaseError)?;
@@ -355,7 +355,7 @@ impl<'a> Writer<'a> for HTML<'a> {
                 replies
                     .iter_mut()
                     .try_for_each(|reply| -> Result<(), TableError> {
-                        reply.gen_text(&self.config.db);
+                        reply.gen_text(&self.config.db).unwrap();
                         if !reply.is_reaction() {
                             // Set indent to 1 so we know this is a recursive call
                             self.add_line(

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -84,7 +84,7 @@ impl<'a> Exporter<'a> for TXT<'a> {
             }
             // Message replies and reactions are rendered in context, so no need to render them separately
             else if !msg.is_reaction() {
-                msg.gen_text(&self.config.db);
+                msg.gen_text(&self.config.db).unwrap();
                 let message = self
                     .format_message(&msg, 0)
                     .map_err(RuntimeError::DatabaseError)?;
@@ -239,7 +239,7 @@ impl<'a> Writer<'a> for TXT<'a> {
                 replies
                     .iter_mut()
                     .try_for_each(|reply| -> Result<(), TableError> {
-                        reply.gen_text(&self.config.db);
+                        reply.gen_text(&self.config.db).unwrap();
                         if !reply.is_reaction() {
                             self.add_line(
                                 &mut formatted_message,


### PR DESCRIPTION
I realize this is a small change, but hopefully making the unhandled error more explicit is helpful. This quiets 4 compiler warnings.

If this is off base please feel free to disregard, ignore, or change.
Thanks again!