### PR TITLE
Feat/cs/alert for used output dir

### DIFF
--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -43,8 +43,7 @@ pub trait Diagnostic {
 }
 
 /// Get a connection to the iMessage SQLite database
-pub fn get_connection(path_str: &str) -> Result<Connection, TableError> {
-    let path = Path::new(path_str);
+pub fn get_connection(path: &Path) -> Result<Connection, TableError> {
     if path.exists() {
         return match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
             Ok(res) => Ok(res),

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -93,8 +93,6 @@ pub const UNKNOWN: &str = "Unknown";
 pub const DEFAULT_PATH: &str = "Library/Messages/chat.db";
 /// Chat name reserved for messages that do not belong to a chat in the table
 pub const ORPHANED: &str = "orphaned";
-/// Default export directory name
-pub const DEFAULT_OUTPUT_DIR: &str = "imessage_export";
 /// Maximum length a filename can be
 pub const MAX_LENGTH: usize = 240;
 /// Replacement text sent in Fitness.app messages

--- a/imessage-database/src/util/dirs.rs
+++ b/imessage-database/src/util/dirs.rs
@@ -2,7 +2,7 @@
  Contains functions that generate the correct path to the default iMessage database location.
 */
 
-use std::env::var;
+use std::{env::var, path::PathBuf};
 
 use crate::tables::table::DEFAULT_PATH;
 
@@ -31,8 +31,8 @@ pub fn home() -> String {
 /// use imessage_database::util::dirs::default_db_path;
 ///
 /// let path = default_db_path();
-/// println!("{path}");
+/// println!("{path:?}");
 /// ```
-pub fn default_db_path() -> String {
-    format!("{}/{DEFAULT_PATH}", home())
+pub fn default_db_path() -> PathBuf {
+    PathBuf::from(format!("{}/{DEFAULT_PATH}", home()))
 }

--- a/imessage-exporter/src/app/error.rs
+++ b/imessage-exporter/src/app/error.rs
@@ -2,7 +2,10 @@
 Errors that can happen during the application's runtime
 */
 
-use std::fmt::{Display, Formatter, Result};
+use std::{
+    fmt::{Display, Formatter, Result},
+    io::Error as IoError,
+};
 
 use imessage_database::error::table::TableError;
 
@@ -10,6 +13,7 @@ use imessage_database::error::table::TableError;
 #[derive(Debug)]
 pub enum RuntimeError {
     InvalidOptions(String),
+    DiskError(IoError),
     DatabaseError(TableError),
 }
 
@@ -17,6 +21,7 @@ impl Display for RuntimeError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {
             RuntimeError::InvalidOptions(why) => write!(fmt, "Invalid options!\n{why}"),
+            RuntimeError::DiskError(why) => write!(fmt, "{why}"),
             RuntimeError::DatabaseError(why) => write!(fmt, "{why}"),
         }
     }

--- a/imessage-exporter/src/app/error.rs
+++ b/imessage-exporter/src/app/error.rs
@@ -9,14 +9,14 @@ use imessage_database::error::table::TableError;
 /// Errors that can happen during the application's runtime
 #[derive(Debug)]
 pub enum RuntimeError {
-    InvalidOptions,
+    InvalidOptions(String),
     DatabaseError(TableError),
 }
 
 impl Display for RuntimeError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {
-            RuntimeError::InvalidOptions => write!(fmt, "Invalid options!"),
+            RuntimeError::InvalidOptions(why) => write!(fmt, "Invalid options!\n{why}"),
             RuntimeError::DatabaseError(why) => write!(fmt, "{why}"),
         }
     }

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -73,12 +73,17 @@ impl<'a> Options<'a> {
         // Ensure an export type is specified if other export options are selected
         if no_copy && export_type.is_none() {
             return Err(RuntimeError::InvalidOptions(format!(
-                "No export type selected, required by {OPTION_COPY}"
+                "Option {OPTION_COPY} is enabled, which requires `--{OPTION_EXPORT_TYPE}`"
             )));
         }
         if export_path.is_some() && export_type.is_none() {
             return Err(RuntimeError::InvalidOptions(format!(
-                "No export type selected, required by {OPTION_EXPORT_PATH}"
+                "Option {OPTION_EXPORT_PATH} is enabled, which requires `--{OPTION_EXPORT_TYPE}`"
+            )));
+        }
+        if no_lazy && export_type != Some("html") {
+            return Err(RuntimeError::InvalidOptions(format!(
+                "Option {OPTION_DISABLE_LAZY_LOADING} is enabled, which requires `--{OPTION_EXPORT_TYPE}`"
             )));
         }
 
@@ -96,12 +101,6 @@ impl<'a> Options<'a> {
         if diagnostic && export_type.is_some() {
             return Err(RuntimeError::InvalidOptions(format!(
                 "Diagnostics are enabled; {OPTION_EXPORT_TYPE} is disallowed"
-            )));
-        }
-
-        if no_lazy && export_type != Some("html") {
-            return Err(RuntimeError::InvalidOptions(format!(
-                "Option {OPTION_DISABLE_LAZY_LOADING} is enabled, which requires `--{OPTION_EXPORT_TYPE}`"
             )));
         }
 

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -64,7 +64,9 @@ impl<'a> Options<'a> {
                 .split(',')
                 .any(|allowed_type| allowed_type.trim() == found_type)
             {
-                return Err(RuntimeError::InvalidOptions(format!("{found_type} is not a valid export type! Must be one of <{SUPPORTED_FILE_TYPES}>")));
+                return Err(RuntimeError::InvalidOptions(format!(
+                    "{found_type} is not a valid export type! Must be one of <{SUPPORTED_FILE_TYPES}>"
+                )));
             }
         }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -233,8 +233,7 @@ impl<'a> Config<'a> {
             self.run_diagnostic();
         } else if self.options.export_type.is_some() {
             // Ensure the path we want to export to exists
-            create_dir_all(&self.options.export_path)
-                .map_err(RuntimeError::DiskError)?;
+            create_dir_all(&self.options.export_path).map_err(RuntimeError::DiskError)?;
 
             match self.options.export_type.unwrap_or_default() {
                 "txt" => {

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -172,11 +172,6 @@ impl<'a> Config<'a> {
     /// let app = State::new(options).unwrap();
     /// ```
     pub fn new(options: Options) -> Result<Config, RuntimeError> {
-        // Escape early if options are invalid
-        if !options.valid {
-            return Err(RuntimeError::InvalidOptions);
-        }
-
         let conn = get_connection(&options.db_path).map_err(RuntimeError::DatabaseError)?;
         eprintln!("Building cache...");
         eprintln!("[1/4] Caching chats...");
@@ -302,7 +297,6 @@ mod test {
             export_path: None,
             query_context: QueryContext::default(),
             no_lazy: false,
-            valid: true,
         }
     }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -156,12 +156,12 @@ impl<'a> Config<'a> {
     /// ```
     /// use crate::app::{
     ///    options::{from_command_line, Options},
-    ///    runtime::State,
+    ///    runtime::Config,
     /// };
     ///
     /// let args = from_command_line();
     /// let options = Options::from_args(&args);
-    /// let app = State::new(options).unwrap();
+    /// let app = Config::new(options).unwrap();
     /// ```
     pub fn new(options: Options) -> Result<Config, RuntimeError> {
         let conn = get_connection(&options.db_path).map_err(RuntimeError::DatabaseError)?;
@@ -220,12 +220,12 @@ impl<'a> Config<'a> {
     /// ```
     /// use crate::app::{
     ///    options::{from_command_line, Options},
-    ///    runtime::State,
+    ///    runtime::Config,
     /// };
     ///
     /// let args = from_command_line();
     /// let options = Options::from_args(&args);
-    /// let app = State::new(options).unwrap();
+    /// let app = Config::new(options).unwrap();
     /// app.start();
     /// ```
     pub fn start(&self) -> Result<(), RuntimeError> {

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -55,7 +55,7 @@ pub struct HTML<'a> {
 
 impl<'a> Exporter<'a> for HTML<'a> {
     fn new(config: &'a Config) -> Self {
-        let mut orphaned = config.export_path();
+        let mut orphaned = config.options.export_path.clone();
         orphaned.push(ORPHANED);
         orphaned.set_extension("html");
         HTML {
@@ -69,7 +69,7 @@ impl<'a> Exporter<'a> for HTML<'a> {
         // Tell the user what we are doing
         eprintln!(
             "Exporting to {} as html...",
-            self.config.export_path().display()
+            self.config.options.export_path.display()
         );
 
         // Write orphaned file headers
@@ -124,7 +124,7 @@ impl<'a> Exporter<'a> for HTML<'a> {
     fn get_or_create_file(&mut self, message: &Message) -> &Path {
         match self.config.conversation(message.chat_id) {
             Some((chatroom, id)) => self.files.entry(*id).or_insert_with(|| {
-                let mut path = self.config.export_path();
+                let mut path = self.config.options.export_path.clone();
                 path.push(self.config.filename(chatroom));
                 path.set_extension("html");
 
@@ -1106,6 +1106,8 @@ impl<'a> HTML<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use crate::{exporters::exporter::Writer, Config, Exporter, Options, HTML};
     use imessage_database::{
         tables::messages::Message,
@@ -1143,10 +1145,10 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
-            no_copy: true,
+            no_copy: false,
             diagnostic: false,
-            export_type: Some("html"),
-            export_path: None,
+            export_type: None,
+            export_path: PathBuf::new(),
             query_context: QueryContext::default(),
             no_lazy: false,
         }

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -1149,7 +1149,6 @@ mod tests {
             export_path: None,
             query_context: QueryContext::default(),
             no_lazy: false,
-            valid: true,
         }
     }
 

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -44,7 +44,7 @@ pub struct TXT<'a> {
 
 impl<'a> Exporter<'a> for TXT<'a> {
     fn new(config: &'a Config) -> Self {
-        let mut orphaned = config.export_path();
+        let mut orphaned = config.options.export_path.clone();
         orphaned.push(ORPHANED);
         orphaned.set_extension("txt");
         TXT {
@@ -58,7 +58,7 @@ impl<'a> Exporter<'a> for TXT<'a> {
         // Tell the user what we are doing
         eprintln!(
             "Exporting to {} as txt...",
-            self.config.export_path().display()
+            self.config.options.export_path.display()
         );
 
         // Set up progress bar
@@ -103,7 +103,7 @@ impl<'a> Exporter<'a> for TXT<'a> {
     fn get_or_create_file(&mut self, message: &Message) -> &Path {
         match self.config.conversation(message.chat_id) {
             Some((chatroom, id)) => self.files.entry(*id).or_insert_with(|| {
-                let mut path = self.config.export_path();
+                let mut path = self.config.options.export_path.clone();
                 path.push(self.config.filename(chatroom));
                 path.set_extension("txt");
                 path
@@ -662,6 +662,8 @@ impl<'a> TXT<'a> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use crate::{exporters::exporter::Writer, Config, Exporter, Options, TXT};
     use imessage_database::{
         tables::messages::Message,
@@ -699,10 +701,10 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
-            no_copy: true,
+            no_copy: false,
             diagnostic: false,
-            export_type: Some("txt"),
-            export_path: None,
+            export_type: None,
+            export_path: PathBuf::new(),
             query_context: QueryContext::default(),
             no_lazy: false,
         }

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -705,7 +705,6 @@ mod tests {
             export_path: None,
             query_context: QueryContext::default(),
             no_lazy: false,
-            valid: true,
         }
     }
 

--- a/imessage-exporter/src/main.rs
+++ b/imessage-exporter/src/main.rs
@@ -17,13 +17,17 @@ fn main() {
     let options = Options::from_args(&args);
 
     // Create app state and start
-    match Config::new(options) {
-        Ok(app) => match app.start() {
-            Ok(()) => (),
-            Err(why) => eprintln!("Unable to launch: {why}"),
-        },
-        Err(why) => {
-            eprintln!("Unable to launch: {why}")
+    if let Err(why) = &options {
+        eprintln!("{why}");
+    } else {
+        match Config::new(options.unwrap()) {
+            Ok(app) => match app.start() {
+                Ok(()) => (),
+                Err(why) => eprintln!("Unable to launch: {why}"),
+            },
+            Err(why) => {
+                eprintln!("Unable to launch: {why}")
+            }
         }
     }
 }

--- a/imessage-exporter/src/main.rs
+++ b/imessage-exporter/src/main.rs
@@ -21,10 +21,11 @@ fn main() {
         eprintln!("{why}");
     } else {
         match Config::new(options.unwrap()) {
-            Ok(app) => match app.start() {
-                Ok(()) => (),
-                Err(why) => eprintln!("Unable to launch: {why}"),
-            },
+            Ok(app) => {
+                if let Err(why) = app.start() {
+                    eprintln!("Unable to start: {why}")
+                }
+            }
             Err(why) => {
                 eprintln!("Unable to launch: {why}")
             }


### PR DESCRIPTION
- Disallow multiple exports to same directory (exports are append-only, multiple appends will break files)
- Use `Result<>` for CLI Arg parser logic