### PR TITLE
Removed nested match statements 🪺

### DIFF
--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -61,13 +61,8 @@ impl Table for Attachment {
 
     fn extract(attachment: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match attachment {
-            Ok(attachment) => match attachment {
-                Ok(att) => Ok(att),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Attachment(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Attachment(why)),
+            Ok(Ok(attachment)) => Ok(attachment),
+            Err(why) | Ok(Err(why)) => Err(TableError::Attachment(why)),
         }
     }
 }

--- a/imessage-database/src/tables/chat.rs
+++ b/imessage-database/src/tables/chat.rs
@@ -37,13 +37,8 @@ impl Table for Chat {
 
     fn extract(chat: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match chat {
-            Ok(chat) => match chat {
-                Ok(ch) => Ok(ch),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Chat(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Chat(why)),
+            Ok(Ok(chat)) => Ok(chat),
+            Err(why) | Ok(Err(why)) => Err(TableError::Chat(why)),
         }
     }
 }

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -34,13 +34,8 @@ impl Table for ChatToHandle {
 
     fn extract(chat_to_handle: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match chat_to_handle {
-            Ok(chat_to_handle) => match chat_to_handle {
-                Ok(c2h) => Ok(c2h),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::ChatToHandle(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::ChatToHandle(why)),
+            Ok(Ok(chat_to_handle)) => Ok(chat_to_handle),
+            Err(why) | Ok(Err(why)) => Err(TableError::ChatToHandle(why)),
         }
     }
 }

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -35,13 +35,8 @@ impl Table for Handle {
 
     fn extract(handle: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match handle {
-            Ok(handle) => match handle {
-                Ok(hdl) => Ok(hdl),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Handle(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Handle(why)),
+            Ok(Ok(handle)) => Ok(handle),
+            Err(why) | Ok(Err(why)) => Err(TableError::Handle(why)),
         }
     }
 }

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -162,13 +162,8 @@ impl Table for Message {
 
     fn extract(message: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match message {
-            Ok(message) => match message {
-                Ok(msg) => Ok(msg),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Messages(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Messages(why)),
+            Ok(Ok(message)) => Ok(message),
+            Err(why) | Ok(Err(why)) => Err(TableError::Messages(why)),
         }
     }
 }


### PR DESCRIPTION
Wasn't sure if this was the intended fix for the `// TODO: When does this occur?` but it does avoid nested match statement. There is also [flatten](https://doc.rust-lang.org/std/result/enum.Result.html#method.flatten) but this is a nightly feature.