### PR TITLE
iOS cli option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,6 +58,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +156,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +219,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,6 +256,16 @@ dependencies = [
  "libc",
  "redox_syscall",
  "windows-sys",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -300,6 +348,7 @@ dependencies = [
  "imessage-database",
  "indicatif",
  "rusqlite",
+ "sha1",
  "uuid",
 ]
 
@@ -582,6 +631,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
 
 [[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -649,6 +709,12 @@ dependencies = [
  "libc",
  "num_threads",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -61,13 +61,8 @@ impl Table for Attachment {
 
     fn extract(attachment: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match attachment {
-            Ok(attachment) => match attachment {
-                Ok(att) => Ok(att),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Attachment(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Attachment(why)),
+            Ok(Ok(attachment)) => Ok(attachment),
+            Err(why) | Ok(Err(why)) => Err(TableError::Attachment(why)),
         }
     }
 }

--- a/imessage-database/src/tables/chat.rs
+++ b/imessage-database/src/tables/chat.rs
@@ -37,13 +37,8 @@ impl Table for Chat {
 
     fn extract(chat: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match chat {
-            Ok(chat) => match chat {
-                Ok(ch) => Ok(ch),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Chat(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Chat(why)),
+            Ok(Ok(chat)) => Ok(chat),
+            Err(why) | Ok(Err(why)) => Err(TableError::Chat(why)),
         }
     }
 }

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -34,13 +34,8 @@ impl Table for ChatToHandle {
 
     fn extract(chat_to_handle: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match chat_to_handle {
-            Ok(chat_to_handle) => match chat_to_handle {
-                Ok(c2h) => Ok(c2h),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::ChatToHandle(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::ChatToHandle(why)),
+            Ok(Ok(chat_to_handle)) => Ok(chat_to_handle),
+            Err(why) | Ok(Err(why)) => Err(TableError::ChatToHandle(why)),
         }
     }
 }

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -35,13 +35,8 @@ impl Table for Handle {
 
     fn extract(handle: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match handle {
-            Ok(handle) => match handle {
-                Ok(hdl) => Ok(hdl),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Handle(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Handle(why)),
+            Ok(Ok(handle)) => Ok(handle),
+            Err(why) | Ok(Err(why)) => Err(TableError::Handle(why)),
         }
     }
 }

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -162,13 +162,8 @@ impl Table for Message {
 
     fn extract(message: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
         match message {
-            Ok(message) => match message {
-                Ok(msg) => Ok(msg),
-                // TODO: When does this occur?
-                Err(why) => Err(TableError::Messages(why)),
-            },
-            // TODO: When does this occur?
-            Err(why) => Err(TableError::Messages(why)),
+            Ok(Ok(message)) => Ok(message),
+            Err(why) | Ok(Err(why)) => Err(TableError::Messages(why)),
         }
     }
 }

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -16,3 +16,4 @@ imessage-database = {path = "../imessage-database"}
 indicatif = "0.17.3"
 rusqlite = {version = "0.29.0", features = ["blob", "bundled"]}
 uuid = {version = "1.3.0", features = ["v4", "fast-rng"]}
+sha1 = "0.10.5"

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -287,7 +287,6 @@ pub fn from_command_line() -> ArgMatches {
             Arg::new(OPTION_IOS)
                 .long(OPTION_IOS)
                 .help("Specify that the database is from an iOS backup\nUsing this option requires a custom path to the iPhone backup directory")
-                .takes_value(true)
                 .display_order(9)
                 .requires(OPTION_DB_PATH)
         )

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -175,6 +175,13 @@ impl<'a> Options<'a> {
             import_platform,
         })
     }
+
+    pub fn get_db_path(&self) -> &PathBuf {
+        match self.import_platform {
+            ImportPlatform::IOS => &self.db_path.join(DEFAULT_IOS_CHATDB_PATH),
+            ImportPlatform::MacOS => &self.db_path,
+        }
+    }
 }
 
 /// Ensure export path is empty or does not contain files of the existing export type

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -34,6 +34,11 @@ pub const ABOUT: &str = concat!(
     "to find problems with the iMessage database."
 );
 
+pub enum ImportPlatform {
+    MacOS,
+    IOS,
+}
+
 pub struct Options<'a> {
     /// Path to database file
     pub db_path: PathBuf,
@@ -52,7 +57,7 @@ pub struct Options<'a> {
     /// Custom name for database owner in output
     pub custom_name: Option<&'a str>,
     /// If true, enable iOS-specific features, db_path is to a backup, uses hashed filepaths
-    pub ios: bool,
+    pub import_platform: ImportPlatform,
 }
 
 impl<'a> Options<'a> {
@@ -66,7 +71,11 @@ impl<'a> Options<'a> {
         let end_date = args.value_of(OPTION_END_DATE);
         let no_lazy = args.is_present(OPTION_DISABLE_LAZY_LOADING);
         let custom_name = args.value_of(OPTION_CUSTOM_NAME);
-        let ios = args.is_present(OPTION_IOS);
+        let import_platform = if args.is_present(OPTION_IOS) {
+                                                ImportPlatform::IOS
+                                            } else {
+                                                ImportPlatform::MacOS
+                                            };
 
         // Ensure export type is allowed
         if let Some(found_type) = export_type {

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -114,12 +114,13 @@ impl<'a> Options<'a> {
             )));
         }
 
-        // Ensure that if iOS is enabled, that the db_path is to a backup
+        // Ensure that if iOS is enabled, that the db_path contains the chat.db file
         if ios && user_path.is_some() {
-            let db_path = PathBuf::from(user_path.unwrap());
+            let path_string = user_path.unwrap();
+            let db_path = PathBuf::from(path_string);
             if !db_path.join(DEFAULT_IOS_CHATDB_PATH).exists() {
                 return Err(RuntimeError::InvalidOptions(format!(
-                    "Option {OPTION_IOS} is enabled, but the database path does not appear to be a valid iOS backup"
+                    "Option {OPTION_IOS} is enabled, but could not find {DEFAULT_IOS_CHATDB_PATH} in {path_string}"
                 )));
             }
         }

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -13,8 +13,6 @@ use crate::app::error::RuntimeError;
 pub const DEFAULT_OUTPUT_DIR: &str = "imessage_export";
 /// Default location in an iOS backup to find the iMessage database
 pub const DEFAULT_IOS_CHATDB_PATH: &str = "3d/3d0d7e5fb2ce288813306e4d4636395e047a3d28";
-/// Default location in an iOS backup to find the iMessage contacts database
-pub const DEFAULT_IOS_CONTACTSDB_PATH: &str = "31/31bb7ba8914766d4ba40d6dfb6113c8b614be442"; // unused
 
 // CLI Arg Names
 pub const OPTION_DB_PATH: &str = "db-path";

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -124,13 +124,20 @@ impl<'a> Options<'a> {
         }
 
         // Ensure that if iOS is enabled, that the db_path contains the chat.db file
-        if ios && user_path.is_some() {
-            let path_string = user_path.unwrap();
-            let db_path = PathBuf::from(path_string);
-            if !db_path.join(DEFAULT_IOS_CHATDB_PATH).exists() {
-                return Err(RuntimeError::InvalidOptions(format!(
-                    "Option {OPTION_IOS} is enabled, but could not find {DEFAULT_IOS_CHATDB_PATH} in {path_string}"
-                )));
+        if user_path.is_some() {
+            match import_platform {
+                ImportPlatform::IOS => {
+                    let path_string = user_path.unwrap();
+                    let db_path = PathBuf::from(path_string);
+                    if !db_path.join(DEFAULT_IOS_CHATDB_PATH).exists() {
+                        return Err(RuntimeError::InvalidOptions(format!(
+                            "Option {OPTION_IOS} is enabled, but could not find {DEFAULT_IOS_CHATDB_PATH} in {path_string}"
+                        )));
+                    }
+                }
+                // added space here to do MacOS path verification if wanted
+                // like validating the path given if the -p flag is used
+                _ => {}
             }
         }
 
@@ -165,7 +172,7 @@ impl<'a> Options<'a> {
             query_context,
             no_lazy,
             custom_name,
-            ios,
+            import_platform,
         })
     }
 }

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -289,6 +289,7 @@ pub fn from_command_line() -> ArgMatches {
                 .help("Specify that the database is from an iOS backup\nUsing this option requires a custom path to the iPhone backup directory")
                 .takes_value(true)
                 .display_order(9)
+                .requires(OPTION_DB_PATH)
         )
         .get_matches();
     matches

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -296,6 +296,7 @@ mod test {
             query_context: QueryContext::default(),
             no_lazy: false,
             custom_name: None,
+            ios: false,
         }
     }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -9,7 +9,7 @@ use rusqlite::Connection;
 
 use crate::{
     app::{
-        converter::Converter, error::RuntimeError, options::{Options, DEFAULT_IOS_CHATDB_PATH}, sanitizers::sanitize_filename,
+        converter::Converter, error::RuntimeError, options::Options, sanitizers::sanitize_filename,
     },
     Exporter, HTML, TXT,
 };
@@ -166,12 +166,7 @@ impl<'a> Config<'a> {
     /// let app = Config::new(options).unwrap();
     /// ```
     pub fn new(options: Options) -> Result<Config, RuntimeError> {
-        let conn = if options.ios {
-            let ios_db_path = options.db_path.join(DEFAULT_IOS_CHATDB_PATH);
-            get_connection(&ios_db_path).map_err(RuntimeError::DatabaseError)?
-        } else {
-            get_connection(&options.db_path).map_err(RuntimeError::DatabaseError)?
-        };
+        let conn = get_connection(&options.get_db_path()).map_err(RuntimeError::DatabaseError)?;
         eprintln!("Building cache...");
         eprintln!("[1/4] Caching chats...");
         let chatrooms = Chat::cache(&conn).map_err(RuntimeError::DatabaseError)?;
@@ -278,7 +273,7 @@ impl<'a> Config<'a> {
 
 #[cfg(test)]
 mod test {
-    use crate::{Config, Options};
+    use crate::{Config, Options, app::options::ImportPlatform};
     use imessage_database::{
         tables::{
             chat::Chat,
@@ -301,7 +296,7 @@ mod test {
             query_context: QueryContext::default(),
             no_lazy: false,
             custom_name: None,
-            ios: false,
+            import_platform: ImportPlatform::MacOS,
         }
     }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -9,7 +9,7 @@ use rusqlite::Connection;
 
 use crate::{
     app::{
-        converter::Converter, error::RuntimeError, options::Options, sanitizers::sanitize_filename,
+        converter::Converter, error::RuntimeError, options::{Options, DEFAULT_IOS_CHATDB_PATH}, sanitizers::sanitize_filename,
     },
     Exporter, HTML, TXT,
 };
@@ -166,7 +166,12 @@ impl<'a> Config<'a> {
     /// let app = Config::new(options).unwrap();
     /// ```
     pub fn new(options: Options) -> Result<Config, RuntimeError> {
-        let conn = get_connection(&options.db_path).map_err(RuntimeError::DatabaseError)?;
+        let conn = if options.ios {
+            let ios_db_path = options.db_path.join(DEFAULT_IOS_CHATDB_PATH);
+            get_connection(&ios_db_path).map_err(RuntimeError::DatabaseError)?
+        } else {
+            get_connection(&options.db_path).map_err(RuntimeError::DatabaseError)?
+        };
         eprintln!("Building cache...");
         eprintln!("[1/4] Caching chats...");
         let chatrooms = Chat::cache(&conn).map_err(RuntimeError::DatabaseError)?;

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -399,7 +399,7 @@ impl<'a> Writer<'a> for HTML<'a> {
             Some(path) => {
                 if let Some(path_str) = path.as_os_str().to_str() {
                     let resolved_attachment_path = match self.config.options.import_platform.resolved_attachment_path(
-                        path_str, self.config.options.get_db_path()
+                        path_str, self.config.options.db_path.clone()
                     ) {
                         Ok(path) => path,
                         // not sure how to handle this error

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -278,7 +278,7 @@ impl<'a> Writer<'a> for TXT<'a> {
     ) -> Result<String, &'a str> {
         match &attachment.filename {
             Some(filename) => match self.config.options.import_platform.get_attachment_path_txt(
-                    self.config.options.db_path, filename) 
+                    self.config.options.get_db_path(), filename) 
                 {
                     Ok(path) => Ok(path),
                     Err(_) => Err(attachment.filename()),

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -285,9 +285,13 @@ impl<'a> Writer<'a> for TXT<'a> {
                     let hash = format!("{:x}", Sha1::digest(
                         format!("{}{}", salt, &filename[2..]).as_bytes()
                     ));
+                    // attempting to escape spaces in the path for easier copy-paste
+                    let db_path_os_string = self.config.options.db_path.to_str()
+                        .map(|s| s.replace(" ", r#"\ "#))
+                        .unwrap_or_else(|| self.config.options.db_path.display().to_string());
                     // <db_path>/<hash[0..2]>/<hash>/<filename> > <filename> allows for copy-paste conversion
-                    format!("{}/{}/{} > {}", self.config.options.db_path.display(), 
-                                            &hash[0..2], &hash, filename.rsplit_once("/").unwrap().1)
+                    format!("{}/{}/{} > {}", db_path_os_string, &hash[0..2], hash,
+                                             filename.rsplit_once("/").unwrap().1)
                 } else {
                     // macOS uses the filename as the path
                     filename.to_string()

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -278,7 +278,7 @@ impl<'a> Writer<'a> for TXT<'a> {
     ) -> Result<String, &'a str> {
         match &attachment.filename {
             Some(filename) => match self.config.options.import_platform.get_attachment_path_txt(
-                    self.config.options.get_db_path(), filename) 
+                    self.config.options.db_path.clone(), filename) 
                 {
                     Ok(path) => Ok(path),
                     Err(_) => Err(attachment.filename()),


### PR DESCRIPTION
# Adding full support for iOS backups
## The Problem
So I noticed in multiple reddit threads people were asking you if this tool could be used on iOS backups.[[1]](https://old.reddit.com/r/DataHoarder/comments/108gnnh/i_wanted_to_be_able_to_exportbackup_imessage/j3tu4ss/) [[2]](https://old.reddit.com/r/DataHoarder/comments/108gnnh/i_wanted_to_be_able_to_exportbackup_imessage/)
I also wanted to do this, but the first issue is "where is the `chat.db` file?" How does one extract the chat info, attachments, etc when the backup has nonsense hashed file names? Building off of this, how can we retain most of the core code while still allowing backups from iOS? It shouldn't be tedious either and should work from any backup location as people might use Finder, iMazing, or an external drive which all store the backup in different locations.

## Finding `chat.db`
From my limited testing and thanks to @nprezant's work 5 years ago, it seems that iOS backups keep their chat.db file in the same location: `$PATH_TO_BACKUP/3d/3d0d7e5fb2ce288813306e4d4636395e047a3d28`. After finding this I did a test run and found that the messages backed up no problem **but there were no attachments**
<p align="center">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/47309906/234127303-26f3b2b6-0244-44e6-a9d0-31fe1b067d9d.png" >
</p>

Notice that all the file paths are paths from the iOS system, meaning that all the attachments are stored somewhere in the backup, they are just hidden by the hash.

##### If all you want is texts from your iPhone run the following
```sh
imessage-exporter -n -f html -p $PATH_TO_BACKUP/3d/3d0d7e5fb2ce288813306e4d4636395e047a3d28 -o $EXPORT_DIR
```

### Finding 'contacts.db'
One thing I also found that might prove helpful for issues like #61 is a `contacts.db` stored at: `$PATH_TO_BACKUP/31/31bb7ba8914766d4ba40d6dfb6113c8b614be442`

Since the hash is a consistent pattern, these two file locations _shouldn't change_, but there is no guarantee.

## The Hash
How the files are hashed from "original path" -> "hashed path" is as follows:
```python
def get_hashed_path(raw_path):
    domainpath = 'MediaDomain-' + raw_path[2:] # create the domain path that will be hashed
    filename = sha1(domainpath.encode('utf-8')).hexdigest() # create the SHA1 hash (which is the file name)
    dir = filename[:2] # the first two digets of the filename are the directory name
    return Path(dir, filename) # create an file path to the attachment
```
so for example,
```console
$ python3 get_hashed_path('~/Library/SMS/Attachments/40/00/9D1D2F2B-FFF9-4791-85A3-AC609E584FF4/IMG_4567.jpeg')
PosixPath('c7/c7c61670bfead910aa7c066be22b14e17ef793c7')
```
<sup>Thanks again to [nprazent](https://github.com/nprezant/iMessageBackup/blob/940d001fb7be557d5d57504eb26b3489e88de26e/imessage_backup_tools.py#L82)</sup>

The `SHA1` hash requires the crate [sha1 v0.10.5](https://crates.io/crates/sha1) to be added to the `Cargo.toml' 
3aa16204acdbe8d7659cbef4a4680f7b2f56572c

https://github.com/ReagentX/imessage-exporter/blob/3aa16204acdbe8d7659cbef4a4680f7b2f56572c/imessage-exporter/Cargo.toml#L19

## `--ios` CLI Argument
Since the backup exists in its own little world, and I didn't want to rewrite a lot of the reader and exporter, I thought the best option was to add a `--ios` flag which requires the `-p, --db-path` to point to the folder holding the iOS backup. So this would be `Library/Application\ Support/MobileSync/Backup/<backup-version>`

This is what the help dialogue says for the option
```
        --ios
            Specify that the database is from an iOS backup
            Using this option requires a custom path to the iPhone backup directory
```
https://github.com/ReagentX/imessage-exporter/blob/592973c31c7f443a6e7ece917ad0d6f8e2e0addf/imessage-exporter/src/app/options.rs#L39-L58
https://github.com/ReagentX/imessage-exporter/blob/592973c31c7f443a6e7ece917ad0d6f8e2e0addf/imessage-exporter/src/app/options.rs#L71
https://github.com/ReagentX/imessage-exporter/blob/8b25dc288dc68e5a3da44233324c041f6f0abbfe/imessage-exporter/src/app/options.rs#L286-L292

### Validating the path
I found that the best way to validate the path was to check for the aforementioned [chat.db](#####If-all-you-want-is-texts-from-your-iPhone-run-the-following).
https://github.com/ReagentX/imessage-exporter/blob/592973c31c7f443a6e7ece917ad0d6f8e2e0addf/imessage-exporter/src/app/options.rs#L119-L127
The value for the path is a public constant, and while I was at it I added the contact.db file location as well in case it's used later, even though it is unused code
https://github.com/ReagentX/imessage-exporter/blob/592973c31c7f443a6e7ece917ad0d6f8e2e0addf/imessage-exporter/src/app/options.rs#L14-L17

### Establishing the database connection
Since the iOS Backup lives in its own directory, the path of the `chat.db` needs to be appended to the path to the iOS backup. However, if the iOS option is not enabled, then the path should remain the same.
https://github.com/ReagentX/imessage-exporter/blob/ae0b29b1f29eae5c51f627d85af698a530950870/imessage-exporter/src/app/runtime.rs#L168-L174

## HTML Exporter
Since the HTML Exporter already has `resolved_attachment_path` to resolve the relative path, simply adding a control flow statement to determine which path is used was all that was necessary. If the `ios` flag is true, then the path to the attachment from the database will be rehashed to find its location in the backup. This seemed to work perfectly and attachments were appearing in the html files no problems.
https://github.com/ReagentX/imessage-exporter/blob/034c90878a22b6c6fd8ba62110556b8f9d9ed120/imessage-exporter/src/exporters/html.rs#L404-L415
> **Note**
> Using `.display()` might yield some issues since it ["may perform lossy conversion"](https://doc.rust-lang.org/std/path/struct.Path.html#method.display) meaning it won't display non-UTF-8 characters. Not sure how much of a problem this really is.

The exporter properly creates the `Attachments` folder, where each subdirectory uses the `chat_id` and each file name is the "original" file name and not the "hashed" one.
<img width="580" alt="image" src="https://user-images.githubusercontent.com/47309906/234141735-8932d544-e40d-426d-b340-e207e9b6ddb8.png">

## TXT Exporter
I thought it fitting I should still update the TXT Exporter using these file paths, as the ones it would display were files that did not exist on the machine.
<p align=center>
<img width="400" alt="image" src="https://user-images.githubusercontent.com/47309906/234140242-91d92a8d-6c03-4437-a751-b63be3a88304.png">
</p>
I made it so the file path actually points to the file's location in the iOS backup, and whats more I formatted it such that it could be easily pasted into the terminal using `cat` or `bat` allowing someone to have the file in its correct format.
<p align=center>
<img width="400" alt="image" src="https://user-images.githubusercontent.com/47309906/234142761-0d3a4765-aeb8-437d-b259-a3ea2c978791.png">
<img width="400" alt="image" src="https://user-images.githubusercontent.com/47309906/234143044-cc891703-edf9-44c8-aa4b-92a17a2d3715.png">
</p?>

## Possible improvements

- Path concatenation and creation done in a more "rusty" way, I am not that experienced and I'm not sure if what I did was proper
- `--ios` arugment location, I put it at the end, but probably having it appear closer to the front would be better
   - making the help section more clear that the `-p` argument should be used with it
 - removing escape slashes on paths when adding directories. macOS has the feature to drag and drop directories into the terminal however doing so includes the escape slash in front of any whitespace `\ `. I made sure to **add**  that back in for the TXT export, but having the option to shave it off would be nice as I am sure many people will "drop" their iOS backup directory into the terminal and not know they have to remove the escape character for the path to read properly

Thanks again to @nprezant and their repo [iMessageBackup](https://github.com/nprezant/iMessageBackup)
and yes the emojis are non negotiable 😜