### PR TITLE
Arroyo Lupine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,13 +92,13 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.24"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3c5919066adf22df73762e50cffcde3a758f2a848b113b586d1f86728b673b"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
  "time 0.1.43",
  "wasm-bindgen",
@@ -248,9 +254,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "filetime"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3de6e8d11b22ff9edc6d916f890800597d60f8b2da1caf2955c274638d6412"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
 dependencies = [
  "cfg-if",
  "libc",
@@ -364,14 +370,24 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.3"
+version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cef509aa9bc73864d6756f0d34d35504af3cf0844373afe9b8669a5b8005a729"
+checksum = "8ff8cc23a7393a397ed1d7f56e6365cba772aba9f9912ab968b03043c395d057"
 dependencies = [
  "console",
+ "instant",
  "number_prefix",
  "portable-atomic",
  "unicode-width",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -440,16 +456,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "0.3.19"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f6a7b87c2e435a3241addceeeff740ff8b7e76b74c13bf9acb17fa454ea00b"
+checksum = "767eb9f07d4a5ebcb39bbf2d452058a93c011373abf6832e24194a1c3f004794"
 
 [[package]]
 name = "ppv-lite86"
@@ -730,9 +736,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "uuid"
-version = "1.3.0"
+version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1674845326ee10d37ca60470760d4288a6f80f304007d92e5c53bab78c9cfd79"
+checksum = "0fa2982af2eec27de306107c027578ff7f423d65f7250e40ce0fea8f45248b81"
 dependencies = [
  "getrandom",
  "rand",
@@ -843,18 +849,18 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -867,42 +873,42 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.2"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation for the library is located [here](imessage-database/README.md).
 
 ### Supported Features
 
-This crate supports every iMessage feature as of MacOS 13.4 (22F66) and iOS 16.5 (20F66):
+This crate supports every iMessage feature as of MacOS 13.4.1 (22F82) and iOS 16.5.1 (20F75):
 
 - Multi-part messages
 - Replies/Threads

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation for the library is located [here](imessage-database/README.md).
 
 ### Supported Features
 
-This crate supports every iMessage feature as of MacOS 13.4.1 (22F82) and iOS 16.5.1 (20F75):
+This crate supports every iMessage feature as of MacOS 13.5 (22G74) and iOS 16.6 (20G75):
 
 - Multi-part messages
 - Replies/Threads

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Documentation for the library is located [here](imessage-database/README.md).
 
 ### Supported Features
 
-This crate supports every iMessage feature as of MacOS 13.3.1 (22E261) and iOS 16.4.1 (20E252):
+This crate supports every iMessage feature as of MacOS 13.4 (22F66) and iOS 16.5 (20F66):
 
 - Multi-part messages
 - Replies/Threads

--- a/docs/features.md
+++ b/docs/features.md
@@ -37,7 +37,7 @@ This tool targets the current latest public release for MacOS and iMessage. It m
 - Attachments
   - Any type of attachment that can be displayed on the web is embedded in the HTML exports
   - Attachments can be copied to the export directory or referenced in-place
-  - Less-compatible HEIC/HEIF images are converted to PNG for portable exports
+  - Less-compatible HEIC images are converted to PNG for portable exports
   - Attachments are displayed as
     - File paths in TXT exports
     - Embeds in HTML exports (including `<img>`, `<video>`, and `<audio>`)

--- a/imessage-database/Cargo.toml
+++ b/imessage-database/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ReagentX/imessage-exporter"
 version = "0.0.0"
 
 [dependencies]
-chrono = "0.4.24"
+chrono = "0.4.26"
 plist = "1.4.3"
 rusqlite = {version = "0.29.0", features = ["blob", "bundled"]}
 sha1 = "0.10.5"

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -176,13 +176,13 @@ impl Attachment {
     /// # Example:
     ///
     /// ```
-    /// use imessage_database::util::dirs::default_db_path;
+    /// use imessage_database::util::{dirs::default_db_path, platform::Platform};
     /// use imessage_database::tables::table::{Diagnostic, get_connection};
     /// use imessage_database::tables::attachment::Attachment;
     ///
     /// let db_path = default_db_path();
     /// let conn = get_connection(&db_path).unwrap();
-    /// Attachment::run_diagnostic(&conn);
+    /// Attachment::run_diagnostic(&conn, &db_path, &Platform::MacOS);
     /// ```
     pub fn run_diagnostic(db: &Connection, db_path: &Path, platform: &Platform) {
         processing();

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -244,7 +244,7 @@ impl Attachment {
         }
     }
 
-    /// Generate a MacOS Path for an attachment
+    /// Generate a MacOS path for an attachment
     fn gen_macos_attachment(path: &str) -> String {
         if path.starts_with('~') {
             return path.replace('~', &home());

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -83,7 +83,7 @@ impl Attachment {
                     ",
                     msg.rowid
                 ))
-                .unwrap();
+                .map_err(TableError::Attachment)?;
 
             let iter = statement
                 .query_map([], |row| Ok(Attachment::from_row(row)))

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -186,13 +186,6 @@ impl Attachment {
     /// ```
     pub fn run_diagnostic(db: &Connection, db_path: &Path, platform: &Platform) {
         processing();
-        let mut statement_ck = db
-            .prepare(&format!(
-                "SELECT count(rowid) FROM {ATTACHMENT} WHERE typeof(ck_server_change_token_blob) == 'text'"
-            ))
-            .unwrap();
-        let num_blank_ck: i32 = statement_ck.query_row([], |r| r.get(0)).unwrap_or(0);
-
         let mut total_attachments = 0;
         let mut null_attachments = 0;
         let mut statement_paths = db
@@ -229,25 +222,22 @@ impl Attachment {
             .count();
 
         done_processing();
-        if num_blank_ck > 0 || missing_files > 0 {
-            println!("\rMissing attachment data:");
-        }
 
-        if missing_files > 0 && total_attachments > 0 {
-            println!("    Total attachments: {total_attachments}");
-            println!(
-                "    Missing files: {missing_files:?} ({:.0}%)",
-                (missing_files as f64 / total_attachments as f64) * 100f64
-            );
-            println!("        No path provided: {null_attachments}");
-            println!(
-                "        No file located: {}",
-                missing_files.saturating_sub(null_attachments)
-            );
-        }
+        if missing_files > 0 {
+            println!("\rAttachment diagnostic data:");
 
-        if num_blank_ck > 0 {
-            println!("    ck_server_change_token_blob: {num_blank_ck:?}");
+            if missing_files > 0 && total_attachments > 0 {
+                println!("    Total attachments: {total_attachments}");
+                println!(
+                    "    Missing files: {missing_files:?} ({:.0}%)",
+                    (missing_files as f64 / total_attachments as f64) * 100f64
+                );
+                println!("        No path provided: {null_attachments}");
+                println!(
+                    "        No file located: {}",
+                    missing_files.saturating_sub(null_attachments)
+                );
+            }
         }
     }
 

--- a/imessage-database/src/tables/chat.rs
+++ b/imessage-database/src/tables/chat.rs
@@ -69,7 +69,7 @@ impl Cacheable for Chat {
 
         let chats = statement
             .query_map([], |row| Ok(Chat::from_row(row)))
-            .unwrap();
+            .map_err(TableError::Chat)?;
 
         for chat in chats {
             let result = Chat::extract(chat)?;

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -128,16 +128,16 @@ impl Diagnostic for ChatToHandle {
     /// let conn = get_connection(&db_path).unwrap();
     /// ChatToHandle::run_diagnostic(&conn);
     /// ```
-    fn run_diagnostic(db: &Connection) {
+    fn run_diagnostic(db: &Connection) -> Result<(), TableError> {
         processing();
 
         // Get the Chat IDs that are associated with messages
         let mut statement_message_chats = db
             .prepare(&format!("SELECT DISTINCT chat_id from {CHAT_MESSAGE_JOIN}"))
-            .unwrap();
+            .map_err(TableError::ChatToHandle)?;
         let statement_message_chat_rows = statement_message_chats
             .query_map([], |row: &Row| -> Result<i32> { row.get(0) })
-            .unwrap();
+            .map_err(TableError::ChatToHandle)?;
         let mut unique_chats_from_messages: HashSet<i32> = HashSet::new();
         statement_message_chat_rows.into_iter().for_each(|row| {
             unique_chats_from_messages.insert(row.unwrap());
@@ -146,10 +146,10 @@ impl Diagnostic for ChatToHandle {
         // Get the Chat IDs that are associated with handles
         let mut statement_handle_chats = db
             .prepare(&format!("SELECT DISTINCT chat_id from {CHAT_HANDLE_JOIN}"))
-            .unwrap();
+            .map_err(TableError::ChatToHandle)?;
         let statement_handle_chat_rows = statement_handle_chats
             .query_map([], |row: &Row| -> Result<i32> { row.get(0) })
-            .unwrap();
+            .map_err(TableError::ChatToHandle)?;
         let mut unique_chats_from_handles: HashSet<i32> = HashSet::new();
         statement_handle_chat_rows.into_iter().for_each(|row| {
             unique_chats_from_handles.insert(row.unwrap());
@@ -164,5 +164,7 @@ impl Diagnostic for ChatToHandle {
         if chats_with_no_handles > 0 {
             println!("\rChats with no handles: {chats_with_no_handles:?}");
         }
+
+        Ok(())
     }
 }

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -62,7 +62,7 @@ impl Cacheable for ChatToHandle {
         let mut rows = ChatToHandle::get(db)?;
         let mappings = rows
             .query_map([], |row| Ok(ChatToHandle::from_row(row)))
-            .unwrap();
+            .map_err(TableError::ChatToHandle)?;
 
         for mapping in mappings {
             let joiner = ChatToHandle::extract(mapping)?;

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -140,15 +140,17 @@ impl Diagnostic for Handle {
     /// let conn = get_connection(&db_path).unwrap();
     /// Handle::run_diagnostic(&conn);
     /// ```
-    fn run_diagnostic(db: &Connection) {
+    fn run_diagnostic(db: &Connection) -> Result<(), TableError> {
         processing();
         let query = concat!(
             "SELECT COUNT(DISTINCT person_centric_id) ",
             "FROM handle ",
             "WHERE person_centric_id NOT NULL"
         );
-        let mut rows = db.prepare(query).unwrap();
-        let count_dupes: Option<i32> = rows.query_row([], |r| r.get(0)).unwrap_or(None);
+        let mut rows = db.prepare(query).map_err(TableError::Messages)?;
+        let count_dupes: Option<i32> = rows
+            .query_row([], |r| r.get(0))
+            .map_err(TableError::Handle)?;
 
         done_processing();
 
@@ -157,6 +159,7 @@ impl Diagnostic for Handle {
                 println!("\rContacts with more than one ID: {dupes}");
             }
         }
+        Ok(())
     }
 }
 

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -70,7 +70,7 @@ impl Cacheable for Handle {
         // Execute query to build the Handles
         let handles = statement
             .query_map([], |row| Ok(Handle::from_row(row)))
-            .unwrap();
+            .map_err(TableError::Handle)?;
 
         // Iterate over the handles and update the map
         for handle in handles {

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -79,7 +79,7 @@ impl Cacheable for Handle {
         }
 
         // Condense contacts that share person_centric_id so their IDs map to the same strings
-        let dupe_contacts = Handle::get_person_id_map(db);
+        let dupe_contacts = Handle::get_person_id_map(db)?;
         for contact in dupe_contacts {
             let (id, new) = contact;
             map.insert(id, new);
@@ -169,7 +169,7 @@ impl Handle {
     /// This method generates a hashmap of each separate item in this table to a combined string
     /// that represents all of the copies, so any handle ID will always map to the same string
     /// for a given chat participant
-    fn get_person_id_map(db: &Connection) -> HashMap<i32, String> {
+    fn get_person_id_map(db: &Connection) -> Result<HashMap<i32, String>, TableError> {
         let mut person_to_id: HashMap<String, HashSet<String>> = HashMap::new();
         let mut row_to_id: HashMap<i32, String> = HashMap::new();
         let mut row_data: Vec<(String, i32, String)> = vec![];
@@ -188,12 +188,12 @@ impl Handle {
             // Cache the results of the query in memory
             let contacts = statement
                 .query_map([], |row| {
-                    let person_centric_id: String = row.get(0).unwrap();
-                    let rowid: i32 = row.get(1).unwrap();
-                    let id: String = row.get(2).unwrap();
+                    let person_centric_id: String = row.get(0)?;
+                    let rowid: i32 = row.get(1)?;
+                    let id: String = row.get(2)?;
                     Ok((person_centric_id, rowid, id))
                 })
-                .unwrap();
+                .map_err(TableError::Handle)?;
 
             for contact in contacts {
                 match contact {
@@ -232,7 +232,7 @@ impl Handle {
             }
         }
 
-        row_to_id
+        Ok(row_to_id)
     }
 }
 

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -187,7 +187,7 @@ impl Diagnostic for Message {
     /// let conn = get_connection(&db_path).unwrap();
     /// Message::run_diagnostic(&conn);
     /// ```
-    fn run_diagnostic(db: &Connection) {
+    fn run_diagnostic(db: &Connection) -> Result<(), TableError> {
         processing();
         let mut messages_without_chat = db
             .prepare(&format!(
@@ -203,7 +203,7 @@ impl Diagnostic for Message {
                 m.date
             "
             ))
-            .unwrap();
+            .map_err(TableError::Messages)?;
 
         let num_dangling: i32 = messages_without_chat
             .query_row([], |r| r.get(0))
@@ -224,7 +224,7 @@ impl Diagnostic for Message {
             HAVING c > 1);
             "
             ))
-            .unwrap();
+            .map_err(TableError::Messages)?;
 
         let messages_in_more_than_one_chat: i32 = messages_in_more_than_one_chat_q
             .query_row([], |r| r.get(0))
@@ -241,6 +241,7 @@ impl Diagnostic for Message {
                 println!("    Messages belonging to more than one chat: {messages_in_more_than_one_chat}");
             }
         }
+        Ok(())
     }
 }
 

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -658,7 +658,7 @@ impl Message {
                         m.date;
                     ",
                 filter.join(",")
-            )).unwrap();
+            )).map_err(TableError::Messages)?;
 
             // Execute query to build the Handles
             let messages = statement
@@ -700,7 +700,7 @@ impl Message {
                      m.date;
                 ", self.guid
             ))
-            .unwrap();
+            .map_err(TableError::Messages)?;
 
             let iter = statement
                 .query_map([], |row| Ok(Message::from_row(row)))

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -282,7 +282,7 @@ impl Cacheable for Message {
             // Execute query to build the Handles
             let messages = statement
                 .query_map([], |row| Ok(Message::from_row(row)))
-                .unwrap();
+                .map_err(TableError::Messages)?;
 
             // Iterate over the messages and update the map
             for reaction in messages {
@@ -661,7 +661,7 @@ impl Message {
             // Execute query to build the Handles
             let messages = statement
                 .query_map([], |row| Ok(Message::from_row(row)))
-                .unwrap();
+                .map_err(TableError::Messages)?;
 
             for message in messages {
                 let msg = Message::extract(message)?;
@@ -702,7 +702,7 @@ impl Message {
 
             let iter = statement
                 .query_map([], |row| Ok(Message::from_row(row)))
-                .unwrap();
+                .map_err(TableError::Messages)?;
 
             for message in iter {
                 let m = Message::extract(message)?;

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -580,6 +580,7 @@ impl Message {
                      *,
                      c.chat_id,
                      (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
+                     (SELECT b.chat_id FROM {RECENTLY_DELETED} b WHERE m.ROWID = b.message_id) as deleted_from,
                      (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
                  FROM
                      message as m
@@ -594,6 +595,7 @@ impl Message {
                      *,
                      c.chat_id,
                      (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
+                     (SELECT NULL) as deleted_from,
                      (SELECT 0) as num_replies
                  FROM
                      message as m

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -205,15 +205,40 @@ impl Diagnostic for Message {
             ))
             .unwrap();
 
-        let num_dangling: Option<i32> = messages_without_chat
+        let num_dangling: i32 = messages_without_chat
             .query_row([], |r| r.get(0))
-            .unwrap_or(None);
+            .unwrap_or(0);
+
+        let mut messages_in_more_than_one_chat_q = db
+            .prepare(&format!(
+                "
+            SELECT
+                COUNT(*)
+            FROM (
+            SELECT DISTINCT
+                message_id
+              , COUNT(chat_id) AS c
+            FROM {CHAT_MESSAGE_JOIN}
+            GROUP BY
+                message_id
+            HAVING c > 1);
+            "
+            ))
+            .unwrap();
+
+        let messages_in_more_than_one_chat: i32 = messages_in_more_than_one_chat_q
+            .query_row([], |r| r.get(0))
+            .unwrap_or(0);
 
         done_processing();
 
-        if let Some(dangling) = num_dangling {
-            if dangling > 0 {
-                println!("\rMessages not associated with a chat: {dangling}");
+        if num_dangling > 0 || messages_in_more_than_one_chat > 0 {
+            println!("Message diagnostic data:");
+            if num_dangling > 0 {
+                println!("    Messages not associated with a chat: {num_dangling}");
+            }
+            if messages_in_more_than_one_chat > 0 {
+                println!("    Messages belonging to more than one chat: {messages_in_more_than_one_chat}");
             }
         }
     }

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -39,7 +39,7 @@ pub trait Deduplicate {
 /// Defines behavior for printing diagnostic information for a table
 pub trait Diagnostic {
     /// Emit diagnostic data about the table to `stdout`
-    fn run_diagnostic(db: &Connection);
+    fn run_diagnostic(db: &Connection) -> Result<(), TableError>;
 }
 
 /// Get a connection to the iMessage SQLite database

--- a/imessage-database/src/util/platform.rs
+++ b/imessage-database/src/util/platform.rs
@@ -23,6 +23,7 @@ impl Platform {
         } else if db_path.is_file() {
             return Self::MacOS;
         }
+        // If we get here, the database is missing; that error is handled in the connection lifecycle
         Self::default()
     }
 

--- a/imessage-database/src/util/platform.rs
+++ b/imessage-database/src/util/platform.rs
@@ -2,7 +2,9 @@
  Contains data structures used to describe database platforms
 */
 
-use std::fmt::Display;
+use std::{fmt::Display, path::Path};
+
+use crate::tables::table::DEFAULT_PATH_IOS;
 
 /// Represents the platform that created the database this library connects to
 pub enum Platform {
@@ -14,6 +16,14 @@ pub enum Platform {
 }
 
 impl Platform {
+    /// Try to determine the current platform, defaulting to MacOS.
+    pub fn determine(db_path: &Path) -> Self {
+        if db_path.join(DEFAULT_PATH_IOS).exists() {
+            return Self::iOS;
+        }
+        Self::MacOS
+    }
+
     /// Given user's input, return a variant if the input matches one
     pub fn from_cli(platform: &str) -> Option<Self> {
         match platform.to_lowercase().as_str() {

--- a/imessage-database/src/util/platform.rs
+++ b/imessage-database/src/util/platform.rs
@@ -20,8 +20,10 @@ impl Platform {
     pub fn determine(db_path: &Path) -> Self {
         if db_path.join(DEFAULT_PATH_IOS).exists() {
             return Self::iOS;
+        } else if db_path.is_file() {
+            return Self::MacOS;
         }
-        Self::MacOS
+        Self::default()
     }
 
     /// Given user's input, return a variant if the input matches one

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -11,8 +11,8 @@ version = "0.0.0"
 
 [dependencies]
 clap = {version = "3.2.23", features = ["cargo"]}
-filetime = "0.2.20"
+filetime = "0.2.21"
 imessage-database = {path = "../imessage-database"}
-indicatif = "0.17.3"
+indicatif = "0.17.5"
 rusqlite = {version = "0.29.0", features = ["blob", "bundled"]}
-uuid = {version = "1.3.0", features = ["v4", "fast-rng"]}
+uuid = {version = "1.3.4", features = ["v4", "fast-rng"]}

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -43,11 +43,11 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
 -f, --format <txt, html>
         Specify a single file format to export messages into
 
--c, --copy-type <compatible, efficient, disabled>
+-c, --copy-method <compatible, efficient, disabled>
         Specify a method to use when copying message attachments
         Compatible will convert HEIC files to JPEG
         Efficient will copy files without converting anything
-        If omitted, the default is `Compatible`
+        If omitted, the default is `disabled`
 
 -p, --db-path <path/to/source>
         Specify a custom path for the iMessage database location

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -54,7 +54,7 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
 
 -a, --platform <MacOS, iOS>
         Specify the platform the database was created on
-        If omitted, the default is MacOS
+        If omitted, the platform type is determined automatically
 
 -o, --export-path <path/to/save/files>
         Specify a custom directory for outputting exported data

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -43,8 +43,11 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
 -f, --format <txt, html>
         Specify a single file format to export messages into
 
--n, --no-copy
-        Do not copy attachments, instead reference them in-place
+-c, --copy-type <compatible, efficient, disabled>
+        Specify a method to use when copying message attachments
+        Compatible will convert HEIC files to JPEG
+        Efficient will copy files without converting anything
+        If omitted, the default is `Compatible`
 
 -p, --db-path <path/to/source>
         Specify a custom path for the iMessage database location
@@ -82,16 +85,16 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
 
 ### Examples
 
-Export as `html` and copy attachments from the default iMessage Database location to your home directory:
+Export as `html` and copy attachments in web-compatible formats from the default iMessage Database location to your home directory:
 
 ```zsh
-% imessage-exporter -f html
+% imessage-exporter -f html -c compatible
 ```
 
-Export as `txt` from the default iMessage Database location to a new folder in the current working directory called `output`:
+Export as `txt` and copy attachments in their original formats from the default iMessage Database location to a new folder in the current working directory called `output`:
 
 ```zsh
-% imessage-exporter -f txt -o output
+% imessage-exporter -f txt -o output -c efficient
 ```
 
 Export as `txt` from the an unencrypted iPhone backup located at `~/iphone_backup_latest` to a new folder in the current working directory called `backup_export`:
@@ -103,7 +106,7 @@ Export as `txt` from the an unencrypted iPhone backup located at `~/iphone_backu
 Export as `html` from `/Volumes/external/chat.db` to `/Volumes/external/export` without copying attachments:
 
 ```zsh
-% imessage-exporter -f html --no-copy -p /Volumes/external/chat.db -o /Volumes/external/export
+% imessage-exporter -f html -c disabled -p /Volumes/external/chat.db -o /Volumes/external/export
 ```
 
 Export messages from `2020-01-01` to `2020-12-31` as `txt` from the default MacOS iMessage Database location to `~/export-2020`:

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -12,15 +12,21 @@ This binary is available on [crates.io](https://crates.io/crates/imessage-export
 
 `cargo install imessage-exporter` is the best way to install the app for normal use.
 
+<details><summary>Uninstall steps</code></summary><p><pre>% cargo uninstall message-exporter</pre></p></details>
+
 ### Homebrew
 
 This binary is available via [`brew`](https://formulae.brew.sh/formula/imessage-exporter).
 
 `brew install imessage-exporter` will install the app, but it may not be up to date with the latest release.
 
+<details><summary>Uninstall steps</code></summary><p><pre>% brew uninstall message-exporter</pre></p></details>
+
 ### Prebuilt Binaries
 
 The [releases page](https://github.com/ReagentX/imessage-exporter/releases) provides prebuilt binaries for both Apple Silicon and Intel-based Macs.
+
+<details><summary>Uninstall steps</code></summary><p><pre>% rm path/to/message-exporter-binary</pre></p></details>
 
 ### Installing manually
 

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -13,6 +13,7 @@ use crate::app::{
     runtime::Config,
 };
 
+/// Represents different ways the app can interact with attachment data
 pub enum AttachmentManager {
     /// Do not copy attachments
     Disabled,

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use filetime::{set_file_times, FileTime};
-use imessage_database::tables::{attachment::Attachment, messages::Message};
+use imessage_database::{
+    tables::{attachment::Attachment, messages::Message},
+    util::platform::Platform,
+};
 use uuid::Uuid;
 
 use crate::app::{
@@ -56,8 +59,6 @@ impl AttachmentManager {
                 return None;
             }
 
-            let ext = from.extension()?;
-
             // Create a path to copy the file to
             let mut to = config.attachment_path();
 
@@ -68,7 +69,8 @@ impl AttachmentManager {
             // Add a random filename
             to.push(Uuid::new_v4().to_string());
 
-            to.set_extension(ext);
+            // Set the new file's extension to the original one
+            to.set_extension(attachment.extension()?);
 
             match self {
                 AttachmentManager::Compatible => match &config.converter {

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -35,7 +35,7 @@ impl AttachmentManager {
     }
 
     /// Handle an attachment, copying and converting if requested
-    /// 
+    ///
     /// If copied, update attachment's `copied_path`
     pub fn handle_attachment<'a>(
         &'a self,
@@ -43,10 +43,11 @@ impl AttachmentManager {
         attachment: &'a mut Attachment,
         config: &Config,
     ) -> Option<()> {
+        // Resolve the path to the attachment
+        let attachment_path = attachment
+            .resolved_attachment_path(&config.options.platform, &config.options.db_path)?;
+
         if !matches!(self, AttachmentManager::Disabled) {
-            // Resolve the path to the attachment
-            let attachment_path = attachment
-                .resolved_attachment_path(&config.options.platform, &config.options.db_path)?;
             let from = Path::new(&attachment_path);
 
             // Ensure the file exists at the specified location

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -42,20 +42,19 @@ impl AttachmentManager {
         message: &Message,
         attachment: &'a mut Attachment,
         config: &Config,
-    ) -> Result<PathBuf, &'a str> {
+    ) -> Option<PathBuf> {
         let attachment_path = attachment
-            .resolved_attachment_path(&config.options.platform, &config.options.db_path)
-            .ok_or(attachment.filename())?;
+            .resolved_attachment_path(&config.options.platform, &config.options.db_path)?;
 
         let from = Path::new(&attachment_path);
 
         if !matches!(self, AttachmentManager::Disabled) {
             if !from.exists() {
                 eprintln!("Attachment not found at specified path: {from:?}");
-                return Err(attachment.filename());
+                return None;
             }
 
-            let ext = from.extension().ok_or(attachment.filename())?;
+            let ext = from.extension()?;
 
             // Create a path to copy the file to
             let mut to = config.attachment_path();
@@ -97,9 +96,9 @@ impl AttachmentManager {
                     eprintln!("Unable to update {to:?} metadata: {why}")
                 }
             }
-            return Ok(to);
+            return Some(to);
         }
-        Ok(from.to_path_buf())
+        Some(from.to_path_buf())
     }
 
     /// Copy a file without altering it

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -1,0 +1,140 @@
+use std::{
+    fmt::Display,
+    fs::{copy, create_dir_all, metadata},
+    path::{Path, PathBuf},
+};
+
+use filetime::{set_file_times, FileTime};
+use imessage_database::tables::{attachment::Attachment, messages::Message};
+use uuid::Uuid;
+
+use crate::app::{
+    converter::{heic_to_jpeg, Converter},
+    runtime::Config,
+};
+
+pub enum FileManager {
+    /// Do not copy attachments
+    Disabled,
+    /// Copy and convert attachments to more compatible formats using a [crate::app::converter::Converter]
+    Compatible,
+    /// Copy attachments without converting; preserves quality but may not display correctly in all browsers
+    Efficient,
+}
+
+impl FileManager {
+    pub fn from_cli(copy_state: &str) -> Option<Self> {
+        match copy_state.to_lowercase().as_str() {
+            "compatible" => Some(Self::Compatible),
+            "efficient" => Some(Self::Efficient),
+            "disabled" => Some(Self::Disabled),
+            _ => None,
+        }
+    }
+
+    pub fn copy<'a>(
+        &'a self,
+        message: &Message,
+        attachment: &'a mut Attachment,
+        config: &Config,
+    ) -> Result<PathBuf, &'a str> {
+        let attachment_path = attachment
+            .resolved_attachment_path(&config.options.platform, &config.options.db_path)
+            .ok_or(attachment.filename())?;
+
+        let from = Path::new(&attachment_path);
+
+        if !matches!(self, FileManager::Disabled) {
+            if !from.exists() {
+                eprintln!("Attachment not found at specified path: {from:?}");
+                return Err(attachment.filename());
+            }
+
+            let ext = from.extension().ok_or(attachment.filename())?;
+
+            // Create a path to copy the file to
+            let mut to = config.attachment_path();
+
+            // Add the subdirectory
+            let sub_dir = config.conversation_attachment_path(message.chat_id);
+            to.push(sub_dir);
+
+            // Add a random filename
+            to.push(Uuid::new_v4().to_string());
+
+            to.set_extension(ext);
+
+            match self {
+                FileManager::Compatible => match &config.converter {
+                    Some(converter) => {
+                        // Update extension for conversion
+                        to.set_extension("jpg");
+                        Self::copy_convert(from, &to, converter);
+                    }
+                    None => Self::copy_raw(from, &to),
+                },
+                FileManager::Efficient => Self::copy_raw(from, &to),
+                FileManager::Disabled => unreachable!(),
+            };
+
+            // Update file metadata
+            if let Ok(metadata) = metadata(from) {
+                let mtime = match &message.date(&config.offset) {
+                    Ok(date) => {
+                        FileTime::from_unix_time(date.timestamp(), date.timestamp_subsec_nanos())
+                    }
+                    Err(_) => FileTime::from_last_modification_time(&metadata),
+                };
+
+                let atime = FileTime::from_last_access_time(&metadata);
+
+                if let Err(why) = set_file_times(&to, atime, mtime) {
+                    eprintln!("Unable to update {to:?} metadata: {why}")
+                }
+            }
+            return Ok(to);
+        }
+        Ok(from.to_path_buf())
+    }
+
+    fn copy_raw(from: &Path, to: &Path) {
+        // Ensure the directory tree exists
+        if let Some(folder) = to.parent() {
+            if !folder.exists() {
+                if let Err(why) = create_dir_all(folder) {
+                    eprintln!("Unable to create {folder:?}: {why}");
+                }
+            }
+        }
+        if let Err(why) = copy(from, to) {
+            eprintln!("Unable to copy {from:?} to {to:?}: {why}")
+        };
+    }
+
+    fn copy_convert(from: &Path, to: &Path, converter: &Converter) {
+        let ext = from.extension().unwrap_or_default();
+        if ext == "heic" || ext == "HEIC" {
+            if heic_to_jpeg(from, to, converter).is_none() {
+                eprintln!("Unable to convert {from:?}")
+            }
+        } else {
+            Self::copy_raw(from, to);
+        }
+    }
+}
+
+impl Default for FileManager {
+    fn default() -> Self {
+        Self::Compatible
+    }
+}
+
+impl Display for FileManager {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileManager::Disabled => write!(fmt, "Disabled"),
+            FileManager::Compatible => write!(fmt, "Compatible"),
+            FileManager::Efficient => write!(fmt, "Efficient"),
+        }
+    }
+}

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -35,7 +35,7 @@ impl AttachmentManager {
     }
 
     /// Handle an attachment, copying and converting if requested
-    /// 
+    ///
     /// If this method fails at any point, it returns an `Err(&str)` that represents the attachment's filename
     pub fn run<'a>(
         &'a self,
@@ -132,16 +132,16 @@ impl AttachmentManager {
 
 impl Default for AttachmentManager {
     fn default() -> Self {
-        Self::Compatible
+        Self::Disabled
     }
 }
 
 impl Display for AttachmentManager {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            AttachmentManager::Disabled => write!(fmt, "Disabled"),
-            AttachmentManager::Compatible => write!(fmt, "Compatible"),
-            AttachmentManager::Efficient => write!(fmt, "Efficient"),
+            AttachmentManager::Disabled => write!(fmt, "disabled"),
+            AttachmentManager::Compatible => write!(fmt, "compatible"),
+            AttachmentManager::Efficient => write!(fmt, "efficient"),
         }
     }
 }

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -5,10 +5,7 @@ use std::{
 };
 
 use filetime::{set_file_times, FileTime};
-use imessage_database::{
-    tables::{attachment::Attachment, messages::Message},
-    util::platform::Platform,
-};
+use imessage_database::tables::{attachment::Attachment, messages::Message};
 use uuid::Uuid;
 
 use crate::app::{

--- a/imessage-exporter/src/app/mod.rs
+++ b/imessage-exporter/src/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod converter;
+pub mod attachment_manager;
 pub mod error;
 pub mod options;
 pub mod progress;

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -42,7 +42,7 @@ pub struct Options<'a> {
     /// Path to database file
     pub db_path: PathBuf,
     /// The method used to copy files
-    pub copy_format: AttachmentManager,
+    pub attachment_manager: AttachmentManager,
     /// If true, emit diagnostic information to stdout
     pub diagnostic: bool,
     /// The type of file we are exporting data to
@@ -157,7 +157,7 @@ impl<'a> Options<'a> {
 
         Ok(Options {
             db_path,
-            copy_format: copy_state,
+            attachment_manager: copy_state,
             diagnostic,
             export_type,
             export_path: validate_path(export_path, export_type)?,

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -11,7 +11,7 @@ use imessage_database::{
     },
 };
 
-use crate::app::{error::RuntimeError, attachment_manager::FileManager};
+use crate::app::{error::RuntimeError, attachment_manager::AttachmentManager};
 
 /// Default export directory name
 pub const DEFAULT_OUTPUT_DIR: &str = "imessage_export";
@@ -42,7 +42,7 @@ pub struct Options<'a> {
     /// Path to database file
     pub db_path: PathBuf,
     /// The method used to copy files
-    pub copy_format: FileManager,
+    pub copy_format: AttachmentManager,
     /// If true, emit diagnostic information to stdout
     pub diagnostic: bool,
     /// The type of file we are exporting data to
@@ -139,11 +139,11 @@ impl<'a> Options<'a> {
 
         // Determine the copy state
         let copy_state = match copy_type {
-            Some(copy) => FileManager::from_cli(copy).ok_or(
+            Some(copy) => AttachmentManager::from_cli(copy).ok_or(
                 RuntimeError::InvalidOptions(format!(
                 "{copy} is not a valid copy type! Must be one of <{SUPPORTED_COPY_FORMATS}>")),
             )?,
-            None => FileManager::default(),
+            None => AttachmentManager::default(),
         };
 
         // Build the Platform
@@ -245,7 +245,7 @@ pub fn from_command_line() -> ArgMatches {
             Arg::new(OPTION_COPY)
             .short('c')
             .long(OPTION_COPY)
-            .help(&*format!("Specify a method to use when copying message attachments\nCompatible will convert HEIC files to JPEG\nEfficient will copy files without converting anything\nIf omitted, default is {}", FileManager::default()))
+            .help(&*format!("Specify a method to use when copying message attachments\nCompatible will convert HEIC files to JPEG\nEfficient will copy files without converting anything\nIf omitted, the default is `{}`", AttachmentManager::default()))
             .takes_value(true)
             .display_order(2)
             .value_name(SUPPORTED_COPY_FORMATS),

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -9,8 +9,8 @@ use rusqlite::Connection;
 
 use crate::{
     app::{
-        converter::Converter, attachment_manager::AttachmentManager, error::RuntimeError, options::Options,
-        sanitizers::sanitize_filename,
+        attachment_manager::AttachmentManager, converter::Converter, error::RuntimeError,
+        options::Options, sanitizers::sanitize_filename,
     },
     Exporter, HTML, TXT,
 };

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -13,6 +13,7 @@ use crate::{
     },
     Exporter, HTML, TXT,
 };
+
 use imessage_database::{
     tables::{
         attachment::Attachment,
@@ -197,7 +198,7 @@ impl<'a> Config<'a> {
         println!("\niMessage Database Diagnostics\n");
         Handle::run_diagnostic(&self.db);
         Message::run_diagnostic(&self.db);
-        Attachment::run_diagnostic(&self.db);
+        Attachment::run_diagnostic(&self.db, &self.options.db_path, &self.options.platform);
         ChatToHandle::run_diagnostic(&self.db);
 
         // Global Diagnostics

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -88,6 +88,20 @@ impl<'a> Config<'a> {
         String::from(ORPHANED)
     }
 
+    /// Generate a file path for an attachment
+    ///
+    /// If the attachment was copied, use that path
+    /// if not, default to the filename
+    pub fn message_attachment_path(&self, attachment: &Attachment) -> String {
+        // Build a relative filepath from the fully qualified one on the `Attachment`
+        match &attachment.copied_path {
+            Some(path) => path.display().to_string(),
+            None => attachment
+                .resolved_attachment_path(&self.options.platform, &self.options.db_path)
+                .unwrap_or(attachment.filename().to_string()),
+        }
+    }
+
     /// Get a filename for a chat, possibly using cached data.
     ///
     /// If the chat has an assigned name, use that, truncating if necessary.

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -9,7 +9,7 @@ use rusqlite::Connection;
 
 use crate::{
     app::{
-        converter::Converter, attachment_manager::FileManager, error::RuntimeError, options::Options,
+        converter::Converter, attachment_manager::AttachmentManager, error::RuntimeError, options::Options,
         sanitizers::sanitize_filename,
     },
     Exporter, HTML, TXT,
@@ -246,7 +246,7 @@ impl<'a> Config<'a> {
                     TXT::new(self).iter_messages()?;
                 }
                 "html" => {
-                    if !matches!(self.options.copy_format, FileManager::Disabled) {
+                    if !matches!(self.options.copy_format, AttachmentManager::Disabled) {
                         create_dir_all(self.attachment_path()).map_err(RuntimeError::DiskError)?;
                     }
                     HTML::new(self).iter_messages()?;
@@ -275,7 +275,7 @@ impl<'a> Config<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{app::attachment_manager::FileManager, Config, Options};
+    use crate::{app::attachment_manager::AttachmentManager, Config, Options};
     use imessage_database::{
         tables::{
             chat::Chat,
@@ -292,7 +292,7 @@ mod tests {
     fn fake_options<'a>() -> Options<'a> {
         Options {
             db_path: default_db_path(),
-            copy_format: FileManager::Disabled,
+            copy_format: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
             export_path: PathBuf::new(),

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -246,7 +246,7 @@ impl<'a> Config<'a> {
                     TXT::new(self).iter_messages()?;
                 }
                 "html" => {
-                    if !matches!(self.options.copy_format, AttachmentManager::Disabled) {
+                    if !matches!(self.options.attachment_manager, AttachmentManager::Disabled) {
                         create_dir_all(self.attachment_path()).map_err(RuntimeError::DiskError)?;
                     }
                     HTML::new(self).iter_messages()?;
@@ -292,7 +292,7 @@ mod tests {
     fn fake_options<'a>() -> Options<'a> {
         Options {
             db_path: default_db_path(),
-            copy_format: AttachmentManager::Disabled,
+            attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
             export_path: PathBuf::new(),

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -407,12 +407,12 @@ impl<'a> Writer<'a> for HTML<'a> {
         match self
             .config
             .options
-            .copy_format
+            .attachment_manager
             .run(message, attachment, self.config)
         {
             Ok(success) => {
                 // Reference attachments in-place if copying is disabled
-                if !matches!(self.config.options.copy_format, AttachmentManager::Disabled) {
+                if !matches!(self.config.options.attachment_manager, AttachmentManager::Disabled) {
                     attachment.copied_path = Some(success);
                 }
             }
@@ -1105,7 +1105,7 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
-            copy_format: AttachmentManager::Disabled,
+            attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
             export_path: PathBuf::new(),

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -68,6 +68,9 @@ impl<'a> Exporter<'a> for HTML<'a> {
         // Write orphaned file headers
         HTML::write_headers(&self.orphaned);
 
+        // Keep track of current message ROWID
+        let mut current_message_row = -1;
+
         // Set up progress bar
         let mut current_message = 0;
         let total_messages =
@@ -85,6 +88,14 @@ impl<'a> Exporter<'a> for HTML<'a> {
 
         for message in messages {
             let mut msg = Message::extract(message).map_err(RuntimeError::DatabaseError)?;
+
+            // Early escape if we try and render the same message GUID twice
+            // See https://github.com/ReagentX/imessage-exporter/issues/135 for rationale
+            if msg.rowid == current_message_row {
+                current_message += 1;
+                continue;
+            }
+            current_message_row = msg.rowid;
 
             // Render the announcement in-line
             if msg.is_announcement() {

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -422,25 +422,7 @@ impl<'a> Writer<'a> for HTML<'a> {
         }
 
         // Build a relative filepath from the fully qualified one on the `Attachment`
-        let embed_path = match &attachment.copied_path {
-            Some(path) => {
-                let sub_dir = &self.config.conversation_attachment_path(message.chat_id);
-                format!(
-                    "{ATTACHMENTS_DIR}/{}/{}",
-                    sub_dir,
-                    path.file_name()
-                        .ok_or(attachment.filename())?
-                        .to_str()
-                        .ok_or(attachment.filename())?
-                )
-            }
-            None => attachment
-                .resolved_attachment_path(
-                    &self.config.options.platform,
-                    &self.config.options.db_path,
-                )
-                .ok_or(attachment.filename())?,
-        };
+        let embed_path = self.config.message_attachment_path(attachment);
 
         return Ok(match attachment.mime_type() {
             MediaType::Image(_) => {

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     app::{
-        attachment_manager::FileManager, error::RuntimeError, progress::build_progress_bar_export,
+        attachment_manager::AttachmentManager, error::RuntimeError, progress::build_progress_bar_export,
         runtime::Config,
     },
     exporters::exporter::{BalloonFormatter, Exporter, Writer},
@@ -408,11 +408,11 @@ impl<'a> Writer<'a> for HTML<'a> {
             .config
             .options
             .copy_format
-            .copy(message, attachment, self.config)
+            .run(message, attachment, self.config)
         {
             Ok(success) => {
                 // Reference attachments in-place if copying is disabled
-                if !matches!(self.config.options.copy_format, FileManager::Disabled) {
+                if !matches!(self.config.options.copy_format, AttachmentManager::Disabled) {
                     attachment.copied_path = Some(success);
                 }
             }
@@ -1065,7 +1065,7 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::{
-        app::attachment_manager::FileManager, exporters::exporter::Writer, Config, Exporter, Options, HTML,
+        app::attachment_manager::AttachmentManager, exporters::exporter::Writer, Config, Exporter, Options, HTML,
     };
     use imessage_database::{
         tables::{attachment::Attachment, messages::Message},
@@ -1105,7 +1105,7 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
-            copy_format: FileManager::Disabled,
+            copy_format: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
             export_path: PathBuf::new(),

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -409,7 +409,7 @@ impl<'a> Writer<'a> for HTML<'a> {
             .attachment_manager
             .run(message, attachment, self.config)
         {
-            Ok(success) => {
+            Some(success) => {
                 // Reference attachments in-place if copying is disabled
                 if !matches!(
                     self.config.options.attachment_manager,
@@ -418,7 +418,7 @@ impl<'a> Writer<'a> for HTML<'a> {
                     attachment.copied_path = Some(success);
                 }
             }
-            Err(_) => return Err(attachment.filename()),
+            None => return Err(attachment.filename()),
         }
 
         // Build a relative filepath from the fully qualified one on the `Attachment`

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -7,8 +7,8 @@ use std::{
 
 use crate::{
     app::{
-        attachment_manager::AttachmentManager, error::RuntimeError, progress::build_progress_bar_export,
-        runtime::Config,
+        attachment_manager::AttachmentManager, error::RuntimeError,
+        progress::build_progress_bar_export, runtime::Config,
     },
     exporters::exporter::{BalloonFormatter, Exporter, Writer},
 };
@@ -34,8 +34,6 @@ use imessage_database::{
         plist::parse_plist,
     },
 };
-
-use uuid::Uuid;
 
 const HEADER: &str = "<html>\n<meta charset=\"UTF-8\">";
 const FOOTER: &str = "</html>";
@@ -90,6 +88,7 @@ impl<'a> Exporter<'a> for HTML<'a> {
 
         for message in messages {
             let mut msg = Message::extract(message).map_err(RuntimeError::DatabaseError)?;
+
             // Render the announcement in-line
             if msg.is_announcement() {
                 let announcement = self.format_announcement(&msg);
@@ -412,7 +411,10 @@ impl<'a> Writer<'a> for HTML<'a> {
         {
             Ok(success) => {
                 // Reference attachments in-place if copying is disabled
-                if !matches!(self.config.options.attachment_manager, AttachmentManager::Disabled) {
+                if !matches!(
+                    self.config.options.attachment_manager,
+                    AttachmentManager::Disabled
+                ) {
                     attachment.copied_path = Some(success);
                 }
             }
@@ -1065,7 +1067,8 @@ mod tests {
     use std::path::PathBuf;
 
     use crate::{
-        app::attachment_manager::AttachmentManager, exporters::exporter::Writer, Config, Exporter, Options, HTML,
+        app::attachment_manager::AttachmentManager, exporters::exporter::Writer, Config, Exporter,
+        Options, HTML,
     };
     use imessage_database::{
         tables::{attachment::Attachment, messages::Message},

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -6,10 +6,7 @@ use std::{
 };
 
 use crate::{
-    app::{
-        attachment_manager::AttachmentManager, error::RuntimeError,
-        progress::build_progress_bar_export, runtime::Config,
-    },
+    app::{error::RuntimeError, progress::build_progress_bar_export, runtime::Config},
     exporters::exporter::{BalloonFormatter, Exporter, Writer},
 };
 
@@ -287,23 +284,12 @@ impl<'a> Writer<'a> for TXT<'a> {
         attachment: &'a mut Attachment,
         message: &Message,
     ) -> Result<String, &'a str> {
-        match self
-            .config
+        // Copy the file, if requested
+        self.config
             .options
             .attachment_manager
-            .run(message, attachment, self.config)
-        {
-            Some(success) => {
-                // Reference attachments in-place if copying is disabled
-                if !matches!(
-                    self.config.options.attachment_manager,
-                    AttachmentManager::Disabled
-                ) {
-                    attachment.copied_path = Some(success);
-                }
-            }
-            None => return Err(attachment.filename()),
-        }
+            .handle_attachment(message, attachment, self.config)
+            .ok_or(attachment.filename())?;
 
         // Build a relative filepath from the fully qualified one on the `Attachment`
         Ok(self.config.message_attachment_path(attachment))

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -733,7 +733,7 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
-            copy_format: AttachmentManager::Disabled,
+            attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
             export_path: PathBuf::new(),

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -694,7 +694,7 @@ impl<'a> TXT<'a> {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{exporters::exporter::Writer, Config, Exporter, Options, TXT, app::attachment_manager::FileManager};
+    use crate::{exporters::exporter::Writer, Config, Exporter, Options, TXT, app::attachment_manager::AttachmentManager};
     use imessage_database::{
         tables::{attachment::Attachment, messages::Message},
         util::{dirs::default_db_path, platform::Platform, query_context::QueryContext},
@@ -733,7 +733,7 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
-            copy_format: FileManager::Disabled,
+            copy_format: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
             export_path: PathBuf::new(),

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -694,7 +694,7 @@ impl<'a> TXT<'a> {
 mod tests {
     use std::path::PathBuf;
 
-    use crate::{exporters::exporter::Writer, Config, Exporter, Options, TXT};
+    use crate::{exporters::exporter::Writer, Config, Exporter, Options, TXT, app::attachment_manager::FileManager};
     use imessage_database::{
         tables::{attachment::Attachment, messages::Message},
         util::{dirs::default_db_path, platform::Platform, query_context::QueryContext},
@@ -733,7 +733,7 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
-            no_copy: false,
+            copy_format: FileManager::Disabled,
             diagnostic: false,
             export_type: None,
             export_path: PathBuf::new(),


### PR DESCRIPTION
- Rework attachment management logic
- Improve attachment and message table diagnostics
- Allow attachment backup for `txt` exports
- Implement #125
- Implement #121
- Fix #118
- Fix #122 
- Fix #135