### PR TITLE
Made images in html exports use relative paths

### DIFF
--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -97,7 +97,10 @@ impl AttachmentManager {
                     eprintln!("Unable to update {to:?} metadata: {why}")
                 }
             }
-            attachment.copied_path = Some(to);
+            
+            if let Ok(relative_path) = to.stripe_prefix(&config.options.export_path) {
+                attachment.copied_path = Some(relative_path.to_path_buf());
+            }
         }
         Some(())
     }

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -98,8 +98,10 @@ impl AttachmentManager {
                 }
             }
             
-            if let Ok(relative_path) = to.stripe_prefix(&config.options.export_path) {
+            if let Ok(relative_path) = to.strip_prefix(&config.options.export_path) {
                 attachment.copied_path = Some(relative_path.to_path_buf());
+            } else {
+                attachment.copied_path = Some(to);
             }
         }
         Some(())


### PR DESCRIPTION
The image src tags were using filesystem absolute paths. I have changed it to use relative paths, so if you move the output directory to another place on the filesystem the html files still reference the same images.

I've only tested this exactly once.