### PR TITLE
Making HTML slightly more proper and CSS fixup

### DIFF
--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -32,8 +32,8 @@ use imessage_database::{
     },
 };
 
-const HEADER: &str = "<html>\n<meta charset=\"UTF-8\">";
-const FOOTER: &str = "</html>";
+const HEADER: &str = "<html>\n<head>\n<meta charset=\"UTF-8\">";
+const FOOTER: &str = "</body></html>";
 const STYLE: &str = include_str!("resources/style.css");
 
 pub struct HTML<'a> {
@@ -961,6 +961,7 @@ impl<'a> HTML<'a> {
         HTML::write_to_file(path, "<style>\n");
         HTML::write_to_file(path, STYLE);
         HTML::write_to_file(path, "\n</style>");
+        HTML::write_to_file(path, "\n</head>\n<body>\n");
     }
 
     fn edited_to_html(&self, timestamp: &str, text: &str, last: bool) -> String {

--- a/imessage-exporter/src/exporters/resources/style.css
+++ b/imessage-exporter/src/exporters/resources/style.css
@@ -22,7 +22,7 @@ a[href^="#"] {
 	overflow-wrap: break-word;
 }
 
-.message .sent.imessage {
+.message .sent.iMessage {
 	background-color: #1982FC;
 }
 


### PR DESCRIPTION
Small changes which make the HTML slightly more proper (adding a <head> and <body> tag where appropriate)

Also, changing the CSS to make it case-sensitive which is useful for some HTML-to-PDF renderers (like weasyprint) which require case-sensitive CSS selectors