### PR TITLE
Feat/cs/use local paths

### DIFF
--- a/imessage-database/src/util/platform.rs
+++ b/imessage-database/src/util/platform.rs
@@ -73,8 +73,8 @@ mod tests {
 
     #[test]
     fn cant_parse_invalid() {
-        assert!(matches!(Platform::from_cli("mac"), None));
-        assert!(matches!(Platform::from_cli("iphone"), None));
-        assert!(matches!(Platform::from_cli(""), None));
+        assert!(Platform::from_cli("mac").is_none());
+        assert!(Platform::from_cli("iphone").is_none());
+        assert!(Platform::from_cli("").is_none());
     }
 }

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -97,7 +97,10 @@ impl AttachmentManager {
                     eprintln!("Unable to update {to:?} metadata: {why}")
                 }
             }
-            attachment.copied_path = Some(to);
+            
+            if let Ok(relative_path) = to.stripe_prefix(&config.options.export_path) {
+                attachment.copied_path = Some(relative_path.to_path_buf());
+            }
         }
         Some(())
     }

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -98,8 +98,10 @@ impl AttachmentManager {
                 }
             }
             
-            if let Ok(relative_path) = to.stripe_prefix(&config.options.export_path) {
+            if let Ok(relative_path) = to.strip_prefix(&config.options.export_path) {
                 attachment.copied_path = Some(relative_path.to_path_buf());
+            } else {
+                attachment.copied_path = Some(to);
             }
         }
         Some(())

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -95,12 +95,7 @@ impl AttachmentManager {
                     eprintln!("Unable to update {to:?} metadata: {why}")
                 }
             }
-            
-            if let Ok(relative_path) = to.strip_prefix(&config.options.export_path) {
-                attachment.copied_path = Some(relative_path.to_path_buf());
-            } else {
-                attachment.copied_path = Some(to);
-            }
+            attachment.copied_path = Some(to);
         }
         Some(())
     }

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Display,
     fs::{copy, create_dir_all, metadata},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use filetime::{set_file_times, FileTime};
@@ -72,9 +72,7 @@ impl AttachmentManager {
             match self {
                 AttachmentManager::Compatible => match &config.converter {
                     Some(converter) => {
-                        // Update extension for conversion
-                        to.set_extension("jpg");
-                        Self::copy_convert(from, &to, converter);
+                        Self::copy_convert(from, &mut to, converter);
                     }
                     None => Self::copy_raw(from, &to),
                 },
@@ -118,9 +116,11 @@ impl AttachmentManager {
     }
 
     /// Copy a file, converting if possible
-    fn copy_convert(from: &Path, to: &Path, converter: &Converter) {
+    fn copy_convert(from: &Path, to: &mut PathBuf, converter: &Converter) {
         let ext = from.extension().unwrap_or_default();
         if ext == "heic" || ext == "HEIC" {
+            // Update extension for conversion
+            to.set_extension("jpg");
             if heic_to_jpeg(from, to, converter).is_none() {
                 eprintln!("Unable to convert {from:?}")
             }

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -926,4 +926,21 @@ mod directory_tests {
         let expected = String::from("attachments/d.jpg");
         assert_eq!(result, expected);
     }
+
+    #[test]
+    fn can_get_path_copied_bad() {
+        let mut options = fake_options();
+        // Set an export path
+        options.export_path = PathBuf::from("/Users/ReagentX/exports");
+
+        let app = fake_app(options);
+
+        // Create attachment
+        let mut attachment = fake_attachment();
+        attachment.copied_path = Some(PathBuf::from(attachment.filename.as_ref().unwrap()));
+
+        let result = app.message_attachment_path(&attachment);
+        let expected = String::from("a/b/c/d.jpg");
+        assert_eq!(result, expected);
+    }
 }

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -300,9 +300,7 @@ mod filename_tests {
     use crate::{app::attachment_manager::AttachmentManager, Config, Options};
     use imessage_database::{
         tables::{
-            attachment::Attachment,
             chat::Chat,
-            messages::Message,
             table::{get_connection, MAX_LENGTH},
         },
         util::{dirs::default_db_path, platform::Platform, query_context::QueryContext},
@@ -535,7 +533,7 @@ mod filename_tests {
 mod who_tests {
     use crate::{app::attachment_manager::AttachmentManager, Config, Options};
     use imessage_database::{
-        tables::{attachment::Attachment, chat::Chat, messages::Message, table::get_connection},
+        tables::{chat::Chat, messages::Message, table::get_connection},
         util::{dirs::default_db_path, platform::Platform, query_context::QueryContext},
     };
     use std::{collections::HashMap, path::PathBuf};
@@ -606,19 +604,6 @@ mod who_tests {
             num_attachments: 0,
             deleted_from: None,
             num_replies: 0,
-        }
-    }
-
-    pub fn fake_attachment() -> Attachment {
-        Attachment {
-            rowid: 0,
-            filename: Some("a/b/c/d.jpg".to_string()),
-            uti: Some("public.png".to_string()),
-            mime_type: Some("image/png".to_string()),
-            transfer_name: Some("d.jpg".to_string()),
-            total_bytes: 100,
-            hide_attachment: 0,
-            copied_path: None,
         }
     }
 
@@ -769,7 +754,7 @@ mod who_tests {
 mod directory_tests {
     use crate::{app::attachment_manager::AttachmentManager, Config, Options};
     use imessage_database::{
-        tables::{attachment::Attachment, chat::Chat, messages::Message, table::get_connection},
+        tables::{attachment::Attachment, table::get_connection},
         util::{dirs::default_db_path, platform::Platform, query_context::QueryContext},
     };
     use std::{collections::HashMap, path::PathBuf};
@@ -788,15 +773,6 @@ mod directory_tests {
         }
     }
 
-    fn fake_chat() -> Chat {
-        Chat {
-            rowid: 0,
-            chat_identifier: "Default".to_string(),
-            service_name: "".to_string(),
-            display_name: None,
-        }
-    }
-
     fn fake_app(options: Options) -> Config {
         let connection = get_connection(&options.db_path).unwrap();
         Config {
@@ -810,36 +786,6 @@ mod directory_tests {
             offset: 0,
             db: connection,
             converter: Some(crate::app::converter::Converter::Sips),
-        }
-    }
-
-    fn blank() -> Message {
-        Message {
-            rowid: i32::default(),
-            guid: String::default(),
-            text: None,
-            service: Some("iMessage".to_string()),
-            handle_id: Some(i32::default()),
-            subject: None,
-            date: i64::default(),
-            date_read: i64::default(),
-            date_delivered: i64::default(),
-            is_from_me: false,
-            is_read: false,
-            item_type: 0,
-            group_title: None,
-            group_action_type: 0,
-            associated_message_guid: None,
-            associated_message_type: Some(i32::default()),
-            balloon_bundle_id: None,
-            expressive_send_style_id: None,
-            thread_originator_guid: None,
-            thread_originator_part: None,
-            date_edited: 0,
-            chat_id: None,
-            num_attachments: 0,
-            deleted_from: None,
-            num_replies: 0,
         }
     }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -96,7 +96,10 @@ impl<'a> Config<'a> {
     pub fn message_attachment_path(&self, attachment: &Attachment) -> String {
         // Build a relative filepath from the fully qualified one on the `Attachment`
         match &attachment.copied_path {
-            Some(path) => path.display().to_string(),
+            Some(path) => {
+                // TODO: Strip the fully qualified path here, make it relative to the Attachments directory
+                path.display().to_string()
+            }
             None => attachment
                 .resolved_attachment_path(&self.options.platform, &self.options.db_path)
                 .unwrap_or(attachment.filename().to_string()),
@@ -284,17 +287,18 @@ impl<'a> Config<'a> {
             return match self.participants.get(handle_id) {
                 Some(contact) => contact,
                 None => UNKNOWN,
-            }
+            };
         }
         UNKNOWN
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod filename_tests {
     use crate::{app::attachment_manager::AttachmentManager, Config, Options};
     use imessage_database::{
         tables::{
+            attachment::Attachment,
             chat::Chat,
             messages::Message,
             table::{get_connection, MAX_LENGTH},
@@ -342,36 +346,6 @@ mod tests {
             offset: 0,
             db: connection,
             converter: Some(crate::app::converter::Converter::Sips),
-        }
-    }
-
-    fn blank() -> Message {
-        Message {
-            rowid: i32::default(),
-            guid: String::default(),
-            text: None,
-            service: Some("iMessage".to_string()),
-            handle_id: Some(i32::default()),
-            subject: None,
-            date: i64::default(),
-            date_read: i64::default(),
-            date_delivered: i64::default(),
-            is_from_me: false,
-            is_read: false,
-            item_type: 0,
-            group_title: None,
-            group_action_type: 0,
-            associated_message_guid: None,
-            associated_message_type: Some(i32::default()),
-            balloon_bundle_id: None,
-            expressive_send_style_id: None,
-            thread_originator_guid: None,
-            thread_originator_part: None,
-            date_edited: 0,
-            chat_id: None,
-            num_attachments: 0,
-            deleted_from: None,
-            num_replies: 0,
         }
     }
 
@@ -553,6 +527,98 @@ mod tests {
         let filename = app.filename(&chat);
         assert_eq!(filename, "Default");
     }
+}
+
+#[cfg(test)]
+mod who_tests {
+    use crate::{app::attachment_manager::AttachmentManager, Config, Options};
+    use imessage_database::{
+        tables::{attachment::Attachment, chat::Chat, messages::Message, table::get_connection},
+        util::{dirs::default_db_path, platform::Platform, query_context::QueryContext},
+    };
+    use std::{collections::HashMap, path::PathBuf};
+
+    fn fake_options<'a>() -> Options<'a> {
+        Options {
+            db_path: default_db_path(),
+            attachment_manager: AttachmentManager::Disabled,
+            diagnostic: false,
+            export_type: None,
+            export_path: PathBuf::new(),
+            query_context: QueryContext::default(),
+            no_lazy: false,
+            custom_name: None,
+            platform: Platform::MacOS,
+        }
+    }
+
+    fn fake_chat() -> Chat {
+        Chat {
+            rowid: 0,
+            chat_identifier: "Default".to_string(),
+            service_name: "".to_string(),
+            display_name: None,
+        }
+    }
+
+    fn fake_app(options: Options) -> Config {
+        let connection = get_connection(&options.db_path).unwrap();
+        Config {
+            chatrooms: HashMap::new(),
+            real_chatrooms: HashMap::new(),
+            chatroom_participants: HashMap::new(),
+            participants: HashMap::new(),
+            real_participants: HashMap::new(),
+            reactions: HashMap::new(),
+            options,
+            offset: 0,
+            db: connection,
+            converter: Some(crate::app::converter::Converter::Sips),
+        }
+    }
+
+    fn blank() -> Message {
+        Message {
+            rowid: i32::default(),
+            guid: String::default(),
+            text: None,
+            service: Some("iMessage".to_string()),
+            handle_id: Some(i32::default()),
+            subject: None,
+            date: i64::default(),
+            date_read: i64::default(),
+            date_delivered: i64::default(),
+            is_from_me: false,
+            is_read: false,
+            item_type: 0,
+            group_title: None,
+            group_action_type: 0,
+            associated_message_guid: None,
+            associated_message_type: Some(i32::default()),
+            balloon_bundle_id: None,
+            expressive_send_style_id: None,
+            thread_originator_guid: None,
+            thread_originator_part: None,
+            date_edited: 0,
+            chat_id: None,
+            num_attachments: 0,
+            deleted_from: None,
+            num_replies: 0,
+        }
+    }
+
+    pub fn fake_attachment() -> Attachment {
+        Attachment {
+            rowid: 0,
+            filename: Some("a/b/c/d.jpg".to_string()),
+            uti: Some("public.png".to_string()),
+            mime_type: Some("image/png".to_string()),
+            transfer_name: Some("d.jpg".to_string()),
+            total_bytes: 100,
+            hide_attachment: 0,
+            copied_path: None,
+        }
+    }
 
     #[test]
     fn can_get_who_them() {
@@ -695,6 +761,98 @@ mod tests {
         let room = app.conversation(&message);
         assert!(room.is_none());
     }
+}
+
+#[cfg(test)]
+mod directory_tests {
+    use crate::{app::attachment_manager::AttachmentManager, Config, Options};
+    use imessage_database::{
+        tables::{attachment::Attachment, chat::Chat, messages::Message, table::get_connection},
+        util::{dirs::default_db_path, platform::Platform, query_context::QueryContext},
+    };
+    use std::{collections::HashMap, path::PathBuf};
+
+    fn fake_options<'a>() -> Options<'a> {
+        Options {
+            db_path: default_db_path(),
+            attachment_manager: AttachmentManager::Disabled,
+            diagnostic: false,
+            export_type: None,
+            export_path: PathBuf::new(),
+            query_context: QueryContext::default(),
+            no_lazy: false,
+            custom_name: None,
+            platform: Platform::MacOS,
+        }
+    }
+
+    fn fake_chat() -> Chat {
+        Chat {
+            rowid: 0,
+            chat_identifier: "Default".to_string(),
+            service_name: "".to_string(),
+            display_name: None,
+        }
+    }
+
+    fn fake_app(options: Options) -> Config {
+        let connection = get_connection(&options.db_path).unwrap();
+        Config {
+            chatrooms: HashMap::new(),
+            real_chatrooms: HashMap::new(),
+            chatroom_participants: HashMap::new(),
+            participants: HashMap::new(),
+            real_participants: HashMap::new(),
+            reactions: HashMap::new(),
+            options,
+            offset: 0,
+            db: connection,
+            converter: Some(crate::app::converter::Converter::Sips),
+        }
+    }
+
+    fn blank() -> Message {
+        Message {
+            rowid: i32::default(),
+            guid: String::default(),
+            text: None,
+            service: Some("iMessage".to_string()),
+            handle_id: Some(i32::default()),
+            subject: None,
+            date: i64::default(),
+            date_read: i64::default(),
+            date_delivered: i64::default(),
+            is_from_me: false,
+            is_read: false,
+            item_type: 0,
+            group_title: None,
+            group_action_type: 0,
+            associated_message_guid: None,
+            associated_message_type: Some(i32::default()),
+            balloon_bundle_id: None,
+            expressive_send_style_id: None,
+            thread_originator_guid: None,
+            thread_originator_part: None,
+            date_edited: 0,
+            chat_id: None,
+            num_attachments: 0,
+            deleted_from: None,
+            num_replies: 0,
+        }
+    }
+
+    pub fn fake_attachment() -> Attachment {
+        Attachment {
+            rowid: 0,
+            filename: Some("a/b/c/d.jpg".to_string()),
+            uti: Some("public.png".to_string()),
+            mime_type: Some("image/png".to_string()),
+            transfer_name: Some("d.jpg".to_string()),
+            total_bytes: 100,
+            hide_attachment: 0,
+            copied_path: None,
+        }
+    }
 
     #[test]
     fn can_get_valid_attachment_sub_dir() {
@@ -733,5 +891,18 @@ mod tests {
         // Get subdirectory
         let sub_dir = app.conversation_attachment_path(None);
         assert_eq!(String::from("orphaned"), sub_dir)
+    }
+
+    #[test]
+    fn can_get_path_not_copied() {
+        let options = fake_options();
+        let app = fake_app(options);
+
+        // Create attachment
+        let attachment = fake_attachment();
+
+        let result = app.message_attachment_path(&attachment);
+        let expected = String::from("a/b/c/d.jpg");
+        assert_eq!(result, expected);
     }
 }

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -470,18 +470,18 @@ impl<'a> Writer<'a> for HTML<'a> {
             }
             MediaType::Text(_) => {
                 format!(
-                    "<a href=\"file://{embed_path}\">Click to download {} ({})</a>",
+                    "<a href=\"{embed_path}\">Click to download {} ({})</a>",
                     attachment.filename(),
                     attachment.file_size()
                 )
             }
             MediaType::Application(_) => format!(
-                "<a href=\"file://{embed_path}\">Click to download {} ({})</a>",
+                "<a href=\"{embed_path}\">Click to download {} ({})</a>",
                 attachment.filename(),
                 attachment.file_size()
             ),
             MediaType::Unknown => {
-                format!("<p>Unknown attachment type: {embed_path}</p> <a href=\"file://{embed_path}\">Download ({})</a>", attachment.file_size())
+                format!("<p>Unknown attachment type: {embed_path}</p> <a href=\"{embed_path}\">Download ({})</a>", attachment.file_size())
             }
             MediaType::Other(media_type) => {
                 format!("<p>Unable to embed {media_type} attachments: {embed_path}</p>")


### PR DESCRIPTION
- Remove unnecessary `file://` from some exported file URLs
- Fix #164 
- Use relative paths to attachments directory for #158:
  - <img width="674" alt="image" src="https://github.com/ReagentX/imessage-exporter/assets/1920666/cce24631-81fa-4a06-a04e-c5fc3e5e27aa">
