### PR TITLE
Feat/cs/custom attachment paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-edition = "2021"
 resolver = "2"
 members = [
   "imessage-database",

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -24,6 +24,7 @@ use crate::{
     },
 };
 
+pub const DEFAULT_ATTACHMENT_ROOT: &str = "~/Library/Messages/Attachments";
 const DIVISOR: f64 = 1024.;
 const UNITS: [&str; 5] = ["B", "KB", "MB", "GB", "TB"];
 
@@ -148,8 +149,11 @@ impl Attachment {
         &self,
         platform: &Platform,
         db_path: &Path,
+        custom_attachment_root: Option<&str>,
     ) -> Result<Option<Vec<u8>>, AttachmentError> {
-        if let Some(file_path) = self.resolved_attachment_path(platform, db_path) {
+        if let Some(file_path) =
+            self.resolved_attachment_path(platform, db_path, custom_attachment_root)
+        {
             let mut file = File::open(&file_path)
                 .map_err(|err| AttachmentError::Unreadable(file_path, err))?;
             let mut bytes = vec![];
@@ -164,6 +168,7 @@ impl Attachment {
         &self,
         platform: &Platform,
         db_path: &Path,
+        custom_attachment_root: Option<&str>,
     ) -> Result<Option<StickerEffect>, AttachmentError> {
         // Handle the non-sticker case
         if !self.is_sticker {
@@ -171,7 +176,7 @@ impl Attachment {
         }
 
         // Try to parse the HEIC data
-        if let Some(data) = self.as_bytes(platform, db_path)? {
+        if let Some(data) = self.as_bytes(platform, db_path, custom_attachment_root)? {
             return Ok(Some(get_sticker_effect(data)));
         }
 
@@ -231,11 +236,23 @@ impl Attachment {
     /// For macOS, `db_path` is unused. For iOS, `db_path` is the path to the root of the backup directory.
     ///
     /// iOS Parsing logic source is from [here](https://github.com/nprezant/iMessageBackup/blob/940d001fb7be557d5d57504eb26b3489e88de26e/imessage_backup_tools.py#L83-L85).
-    pub fn resolved_attachment_path(&self, platform: &Platform, db_path: &Path) -> Option<String> {
-        if let Some(path_str) = &self.filename {
+    ///
+    /// Use the optional `custom_attachment_root` parameter when the attachments are not stored in the same place as the database expects. The expected location is [`DEFAULT_ATTACHMENT_ROOT`](crate::tables::attachment::DEFAULT_ATTACHMENT_ROOT).
+    /// A custom attachment root like `/custom/path` will overwrite a path like `~/Library/Messages/Attachments/3d/...` to `/custom/path/3d...`
+    pub fn resolved_attachment_path(
+        &self,
+        platform: &Platform,
+        db_path: &Path,
+        custom_attachment_root: Option<&str>,
+    ) -> Option<String> {
+        if let Some(mut path_str) = self.filename.clone() {
+            // Apply custom attachment path
+            if let Some(custom_attachment_path) = custom_attachment_root {
+                path_str = path_str.replace(DEFAULT_ATTACHMENT_ROOT, custom_attachment_path);
+            }
             return match platform {
-                Platform::macOS => Some(Attachment::gen_macos_attachment(path_str)),
-                Platform::iOS => Attachment::gen_ios_attachment(path_str, db_path),
+                Platform::macOS => Some(Attachment::gen_macos_attachment(&path_str)),
+                Platform::iOS => Attachment::gen_ios_attachment(&path_str, db_path),
             };
         }
         None
@@ -243,7 +260,7 @@ impl Attachment {
 
     /// Emit diagnostic data for the Attachments table
     ///
-    /// This is defined outside of [crate::tables::table::Diagnostic] because it requires additional data.
+    /// This is defined outside of [`Diagnostic`](crate::tables::table::Diagnostic) because it requires additional data.
     ///
     /// Get the number of attachments that are missing from the filesystem
     /// or are missing one of the following columns:
@@ -359,7 +376,7 @@ impl Attachment {
 #[cfg(test)]
 mod tests {
     use crate::{
-        tables::attachment::{Attachment, MediaType},
+        tables::attachment::{Attachment, MediaType, DEFAULT_ATTACHMENT_ROOT},
         util::platform::Platform,
     };
 
@@ -459,8 +476,21 @@ mod tests {
         let attachment = sample_attachment();
 
         assert_eq!(
-            attachment.resolved_attachment_path(&Platform::macOS, &db_path),
+            attachment.resolved_attachment_path(&Platform::macOS, &db_path, None),
             Some("a/b/c.png".to_string())
+        );
+    }
+
+    #[test]
+    fn can_get_resolved_path_macos_custom() {
+        let db_path = PathBuf::from("fake_root");
+        let mut attachment = sample_attachment();
+        // Sample path like `~/Library/Messages/Attachments/0a/10/.../image.jpeg`
+        attachment.filename = Some(format!("{DEFAULT_ATTACHMENT_ROOT}/a/b/c.png"));
+
+        assert_eq!(
+            attachment.resolved_attachment_path(&Platform::macOS, &db_path, Some("custom/root")),
+            Some("custom/root/a/b/c.png".to_string())
         );
     }
 
@@ -472,7 +502,7 @@ mod tests {
 
         assert!(
             attachment
-                .resolved_attachment_path(&Platform::macOS, &db_path)
+                .resolved_attachment_path(&Platform::macOS, &db_path, None)
                 .unwrap()
                 .len()
                 > attachment.filename.unwrap().len()
@@ -486,7 +516,7 @@ mod tests {
         attachment.filename = Some("~/a/b/c~d.png".to_string());
 
         assert!(attachment
-            .resolved_attachment_path(&Platform::macOS, &db_path)
+            .resolved_attachment_path(&Platform::macOS, &db_path, None)
             .unwrap()
             .ends_with("c~d.png"));
     }
@@ -497,7 +527,20 @@ mod tests {
         let attachment = sample_attachment();
 
         assert_eq!(
-            attachment.resolved_attachment_path(&Platform::iOS, &db_path),
+            attachment.resolved_attachment_path(&Platform::iOS, &db_path, None),
+            Some("fake_root/41/41746ffc65924078eae42725c979305626f57cca".to_string())
+        );
+    }
+
+    #[test]
+    fn can_get_resolved_path_ios_custom() {
+        let db_path = PathBuf::from("fake_root");
+        let attachment = sample_attachment();
+
+        // iOS Backups store attachments at the same level as the database file, so if the backup
+        // is intact, the custom root is not relevant
+        assert_eq!(
+            attachment.resolved_attachment_path(&Platform::iOS, &db_path, Some("custom/root")),
             Some("fake_root/41/41746ffc65924078eae42725c979305626f57cca".to_string())
         );
     }
@@ -509,7 +552,7 @@ mod tests {
         attachment.filename = None;
 
         assert_eq!(
-            attachment.resolved_attachment_path(&Platform::macOS, &db_path),
+            attachment.resolved_attachment_path(&Platform::macOS, &db_path, None),
             None
         );
     }
@@ -521,7 +564,7 @@ mod tests {
         attachment.filename = None;
 
         assert_eq!(
-            attachment.resolved_attachment_path(&Platform::iOS, &db_path),
+            attachment.resolved_attachment_path(&Platform::iOS, &db_path, None),
             None
         );
     }

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -749,7 +749,7 @@ impl Message {
         }
     }
 
-    /// Get the variant of a message, see [crate::message_types::variants] for detail.
+    /// Get the variant of a message, see [`variants`](crate::message_types::variants) for detail.
     pub fn variant(&self) -> Variant {
         // Check if a message was edited first as those have special properties
         if self.is_edited() {

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, path::Path};
 
-use rusqlite::{Connection, Error, ErrorCode, OpenFlags, Result, Row, Statement};
+use rusqlite::{Connection, Error, OpenFlags, Result, Row, Statement};
 
 use crate::error::table::TableError;
 

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -4,7 +4,7 @@
 
 use std::{collections::HashMap, path::Path};
 
-use rusqlite::{Connection, Error, OpenFlags, Result, Row, Statement};
+use rusqlite::{Connection, Error, ErrorCode, OpenFlags, Result, Row, Statement};
 
 use crate::error::table::TableError;
 
@@ -44,16 +44,25 @@ pub trait Diagnostic {
 
 /// Get a connection to the iMessage SQLite database
 pub fn get_connection(path: &Path) -> Result<Connection, TableError> {
-    if path.exists() {
+    if path.exists() && path.is_file() {
         return match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
             Ok(res) => Ok(res),
             Err(why) => Err(
                 TableError::CannotConnect(
                     format!("Unable to read from chat database: {}\nEnsure full disk access is enabled for your terminal emulator in System Settings > Security and Privacy > Full Disk Access", why)
-                )
-            ),
-        };
+                )),
+            };
+    };
+
+    // Path does not point to a file
+    if path.exists() && !path.is_file() {
+        return Err(TableError::CannotConnect(format!(
+            "Specified path `{}` is not a database!",
+            &path.to_str().unwrap_or("Unknown")
+        )));
     }
+
+    // File is missing
     Err(TableError::CannotConnect(format!(
         "Database not found at {}",
         &path.to_str().unwrap_or("Unknown")

--- a/imessage-database/src/util/platform.rs
+++ b/imessage-database/src/util/platform.rs
@@ -7,6 +7,7 @@ use std::{fmt::Display, path::Path};
 use crate::tables::table::DEFAULT_PATH_IOS;
 
 /// Represents the platform that created the database this library connects to
+#[derive(PartialEq, Eq)]
 pub enum Platform {
     /// macOS-sourced data
     #[allow(non_camel_case_types)]

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -55,6 +55,11 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         For iOS, specify a path to the root of an unencrypted backup directory
         If omitted, the default directory is ~/Library/Messages/chat.db
 
+-r, --attachment-root <path/to/attachments>
+        Specify an optional custom path to look for attachments in.
+        Only use this if attachments are stored separately from the database's default location.
+        The default location is ~/Library/Messages/Attachments
+
 -a, --platform <macOS, iOS>
         Specify the platform the database was created on
         If omitted, the platform type is determined automatically
@@ -107,6 +112,12 @@ Export as `html` from `/Volumes/external/chat.db` to `/Volumes/external/export` 
 
 ```zsh
 % imessage-exporter -f html -c disabled -p /Volumes/external/chat.db -o /Volumes/external/export
+```
+
+Export as `html` from `/Volumes/external/chat.db` to `/Volumes/external/export` with attachments in `/Volumes/external/Attachments`:
+
+```zsh
+% imessage-exporter -f html -c efficient -p /Volumes/external/chat.db -r /Volumes/external/Attachments -o /Volumes/external/export 
 ```
 
 Export messages from `2020-01-01` to `2020-12-31` as `txt` from the default macOS iMessage Database location to `~/export-2020`:

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -56,7 +56,7 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         If omitted, the default directory is ~/Library/Messages/chat.db
 
 -r, --attachment-root <path/to/attachments>
-        Specify an optional custom path to look for attachments in.
+        Specify an optional custom path to look for attachments in (macOS only).
         Only use this if attachments are stored separately from the database's default location.
         The default location is ~/Library/Messages/Attachments
 

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -17,7 +17,7 @@ use crate::app::{
 pub enum AttachmentManager {
     /// Do not copy attachments
     Disabled,
-    /// Copy and convert attachments to more compatible formats using a [crate::app::converter::Converter]
+    /// Copy and convert attachments to more compatible formats using a [`Converter`](crate::app::converter::Converter)
     Compatible,
     /// Copy attachments without converting; preserves quality but may not display correctly in all browsers
     Efficient,
@@ -44,8 +44,11 @@ impl AttachmentManager {
         config: &Config,
     ) -> Option<()> {
         // Resolve the path to the attachment
-        let attachment_path = attachment
-            .resolved_attachment_path(&config.options.platform, &config.options.db_path)?;
+        let attachment_path = attachment.resolved_attachment_path(
+            &config.options.platform,
+            &config.options.db_path,
+            config.options.attachment_root,
+        )?;
 
         if !matches!(self, AttachmentManager::Disabled) {
             let from = Path::new(&attachment_path);

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -286,7 +286,7 @@ pub fn from_command_line() -> ArgMatches {
             Arg::new(OPTION_ATTACHMENT_ROOT)
                 .short('r')
                 .long(OPTION_ATTACHMENT_ROOT)
-                .help(&*format!("Specify an optional custom path to look for attachments in.\nOnly use this if attachments are stored separately from the database's default location.\nThe default location is {DEFAULT_ATTACHMENT_ROOT}"))
+                .help(&*format!("Specify an optional custom path to look for attachments in (macOS only).\nOnly use this if attachments are stored separately from the database's default location.\nThe default location is {DEFAULT_ATTACHMENT_ROOT}"))
                 .takes_value(true)
                 .display_order(4)
                 .value_name("path/to/attachments"),

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use clap::{crate_version, Arg, ArgMatches, Command};
 
 use imessage_database::{
-    tables::table::DEFAULT_PATH_IOS,
+    tables::{attachment::DEFAULT_ATTACHMENT_ROOT, table::DEFAULT_PATH_IOS},
     util::{
         dirs::{default_db_path, home},
         platform::Platform,
@@ -18,6 +18,7 @@ pub const DEFAULT_OUTPUT_DIR: &str = "imessage_export";
 
 // CLI Arg Names
 pub const OPTION_DB_PATH: &str = "db-path";
+pub const OPTION_ATTACHMENT_ROOT: &str = "attachment-root";
 pub const OPTION_ATTACHMENT_MANAGER: &str = "copy-method";
 pub const OPTION_DIAGNOSTIC: &str = "diagnostics";
 pub const OPTION_EXPORT_TYPE: &str = "format";
@@ -41,6 +42,8 @@ pub const ABOUT: &str = concat!(
 pub struct Options<'a> {
     /// Path to database file
     pub db_path: PathBuf,
+    /// Custom path to attachments
+    pub attachment_root: Option<&'a str>,
     /// The attachment manager type used to copy files
     pub attachment_manager: AttachmentManager,
     /// If true, emit diagnostic information to stdout
@@ -62,6 +65,7 @@ pub struct Options<'a> {
 impl<'a> Options<'a> {
     pub fn from_args(args: &'a ArgMatches) -> Result<Self, RuntimeError> {
         let user_path = args.value_of(OPTION_DB_PATH);
+        let attachment_root = args.value_of(OPTION_ATTACHMENT_ROOT);
         let attachment_manager_type = args.value_of(OPTION_ATTACHMENT_MANAGER);
         let diagnostic = args.is_present(OPTION_DIAGNOSTIC);
         let export_type = args.value_of(OPTION_EXPORT_TYPE);
@@ -137,6 +141,32 @@ impl<'a> Options<'a> {
             None => default_db_path(),
         };
 
+        // Build the Platform
+        let platform = match platform_type {
+            Some(platform_str) => Platform::from_cli(platform_str).ok_or(
+                RuntimeError::InvalidOptions(format!(
+                "{platform_str} is not a valid platform! Must be one of <{SUPPORTED_PLATFORMS}>")),
+            )?,
+            None => Platform::determine(&db_path),
+        };
+
+        // Validate that the custom attachment root exists, if provided
+        if let Some(path) = attachment_root {
+            let custom_attachment_path = PathBuf::from(path);
+            if !custom_attachment_path.exists() {
+                return Err(RuntimeError::InvalidOptions(format!(
+                    "Supplied {OPTION_ATTACHMENT_ROOT} `{path}` does not exist!"
+                )));
+            }
+        };
+
+        // Warn the user that custom attachment roots have no effect on iOS backups
+        if attachment_root.is_some() && platform == Platform::iOS {
+            eprintln!(
+                "Option {OPTION_ATTACHMENT_ROOT} is enabled, but the platform is {}, so the root will have no effect!", Platform::iOS
+            );
+        }
+
         // Determine the attachment manager mode
         let attachment_manager_mode = match attachment_manager_type {
             Some(manager) => {
@@ -147,17 +177,9 @@ impl<'a> Options<'a> {
             None => AttachmentManager::default(),
         };
 
-        // Build the Platform
-        let platform = match platform_type {
-            Some(platform_str) => Platform::from_cli(platform_str).ok_or(
-                RuntimeError::InvalidOptions(format!(
-                "{platform_str} is not a valid platform! Must be one of <{SUPPORTED_PLATFORMS}>")),
-            )?,
-            None => Platform::determine(&db_path),
-        };
-
         Ok(Options {
             db_path,
+            attachment_root,
             attachment_manager: attachment_manager_mode,
             diagnostic,
             export_type,
@@ -261,12 +283,21 @@ pub fn from_command_line() -> ArgMatches {
                 .value_name("path/to/source"),
         )
         .arg(
+            Arg::new(OPTION_ATTACHMENT_ROOT)
+                .short('r')
+                .long(OPTION_ATTACHMENT_ROOT)
+                .help(&*format!("Specify an optional custom path to look for attachments in.\nOnly use this if attachments are stored separately from the database's default location.\nThe default location is {DEFAULT_ATTACHMENT_ROOT}"))
+                .takes_value(true)
+                .display_order(4)
+                .value_name("path/to/attachments"),
+        )
+        .arg(
             Arg::new(OPTION_PLATFORM)
             .short('a')
             .long(OPTION_PLATFORM)
             .help("Specify the platform the database was created on\nIf omitted, the platform type is determined automatically")
             .takes_value(true)
-            .display_order(4)
+            .display_order(5)
             .value_name(SUPPORTED_PLATFORMS),
         )
         .arg(
@@ -275,7 +306,7 @@ pub fn from_command_line() -> ArgMatches {
                 .long(OPTION_EXPORT_PATH)
                 .help(&*format!("Specify a custom directory for outputting exported data\nIf omitted, the default directory is {}/{DEFAULT_OUTPUT_DIR}", home()))
                 .takes_value(true)
-                .display_order(5)
+                .display_order(6)
                 .value_name("path/to/save/files"),
         )
         .arg(
@@ -284,7 +315,7 @@ pub fn from_command_line() -> ArgMatches {
                 .long(OPTION_START_DATE)
                 .help("The start date filter. Only messages sent on or after this date will be included")
                 .takes_value(true)
-                .display_order(6)
+                .display_order(7)
                 .value_name("YYYY-MM-DD"),
         )
         .arg(
@@ -293,7 +324,7 @@ pub fn from_command_line() -> ArgMatches {
                 .long(OPTION_END_DATE)
                 .help("The end date filter. Only messages sent before this date will be included")
                 .takes_value(true)
-                .display_order(7)
+                .display_order(8)
                 .value_name("YYYY-MM-DD"),
         )
         .arg(
@@ -301,7 +332,7 @@ pub fn from_command_line() -> ArgMatches {
                 .short('l')
                 .long(OPTION_DISABLE_LAZY_LOADING)
                 .help("Do not include `loading=\"lazy\"` in HTML export `img` tags\nThis will make pages load slower but PDF generation work")
-                .display_order(8),
+                .display_order(9),
         )
         .arg(
             Arg::new(OPTION_CUSTOM_NAME)
@@ -309,7 +340,7 @@ pub fn from_command_line() -> ArgMatches {
                 .long(OPTION_CUSTOM_NAME)
                 .help("Specify an optional custom name for the database owner's messages in exports")
                 .takes_value(true)
-                .display_order(9)
+                .display_order(10)
         )
         .get_matches();
     matches

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -103,7 +103,11 @@ impl<'a> Config<'a> {
                 path.display().to_string()
             }
             None => attachment
-                .resolved_attachment_path(&self.options.platform, &self.options.db_path)
+                .resolved_attachment_path(
+                    &self.options.platform,
+                    &self.options.db_path,
+                    self.options.attachment_root,
+                )
                 .unwrap_or(attachment.filename().to_string()),
         }
     }
@@ -313,6 +317,7 @@ mod filename_tests {
     fn fake_options<'a>() -> Options<'a> {
         Options {
             db_path: default_db_path(),
+            attachment_root: None,
             attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
@@ -541,6 +546,7 @@ mod who_tests {
     fn fake_options<'a>() -> Options<'a> {
         Options {
             db_path: default_db_path(),
+            attachment_root: None,
             attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
@@ -762,6 +768,7 @@ mod directory_tests {
     fn fake_options<'a>() -> Options<'a> {
         Options {
             db_path: default_db_path(),
+            attachment_root: None,
             attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -512,6 +512,7 @@ impl<'a> Writer<'a> for HTML<'a> {
                 let sticker_effect = sticker.get_sticker_effect(
                     &self.config.options.platform,
                     &self.config.options.db_path,
+                    self.config.options.attachment_root,
                 );
                 if let Ok(Some(sticker_effect)) = sticker_effect {
                     return format!("{sticker_embed}\n<div class=\"sticker_effect\">Sent with {sticker_effect} effect</div>");
@@ -1222,6 +1223,7 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
+            attachment_root: None,
             attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -323,6 +323,7 @@ impl<'a> Writer<'a> for TXT<'a> {
                 let sticker_effect = sticker.get_sticker_effect(
                     &self.config.options.platform,
                     &self.config.options.db_path,
+                    self.config.options.attachment_root,
                 );
                 if let Ok(Some(sticker_effect)) = sticker_effect {
                     return format!("{sticker_effect} Sticker from {who}: {path_to_sticker}");
@@ -814,6 +815,7 @@ mod tests {
     pub fn fake_options() -> Options<'static> {
         Options {
             db_path: default_db_path(),
+            attachment_root: None,
             attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,


### PR DESCRIPTION
- Emit clearer error if specified database path exists but is not an iMessage database #177
- Support custom attachment root for #178 