### PR TITLE
Feat/cs/clap 3 to 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,14 +29,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
+name = "anstream"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
 dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
 ]
 
 [[package]]
@@ -106,28 +143,30 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap 1.9.1",
- "once_cell",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "codespan-reporting"
@@ -138,6 +177,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
@@ -324,15 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,16 +412,6 @@ dependencies = [
  "indicatif",
  "rusqlite",
  "uuid",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -507,12 +533,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,7 +545,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
 dependencies = [
  "base64",
- "indexmap 2.1.0",
+ "indexmap",
  "line-wrap",
  "quick-xml",
  "serde",
@@ -742,12 +762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "time"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,6 +807,12 @@ name = "unicode-width"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -49,3 +49,18 @@ This software can recover some, but not all, deleted messages.
 Messages removed by deleting an entire conversation or by deleting a single message from a conversation are moved to a separate collection for up to 30 days. Messages present in this collection are restored to the conversations they belong to. Apple details this process [here](https://support.apple.com/en-us/HT202549#delete).
 
 Messages that have expired from this restoration process are permanently deleted and cannot be recovered.
+
+***
+
+#### How fast is `imessage-exporter`?
+
+This is a complicated question that depends on CPU, database size, chosen export type, and chosen attachment handling style.
+
+On my M1 Max MacBook Pro, performance is as follows:
+
+- With `--copy-method disabled`, exports run at about `18k` messages per second
+- With `--copy-method efficient`, exports run at about `13k` messages per second
+- With `--copy-method compatible`, exports run at about `300` messages per second
+- For more information on `--copy-method`, see [here](../imessage-exporter/README.md#how-to-use) and [here](./features.md#supported-message-features)
+
+However, if you recently deleted a large amount of data from Messages, the database will be slow for awhile, and will result in significantly reduced performance from `imessage-exporter`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -14,7 +14,9 @@ No, `imessage-exporter` only reads data present on the host system.
 
 #### How does the exporter handle previously exported messages?
 
-All messages are exported every time `imessage-exporter` runs. `imessage-exporter` appends to files when writing, so make sure to specify a different location!
+If files with the current output type exist in the output directory, `imessage-exporter` will alert the user that they will overwrite existing exported data and the export will be cancelled. If the export directory is clear, `imessage-exporter` will export all messages by default, or between the dates specified by the `--start-date` and `--end-date` arguments.
+
+See [here](../imessage-exporter/README.md#how-to-use) for details on `imessage-exporter` arguments.
 
 ***
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -61,6 +61,6 @@ On my M1 Max MacBook Pro, performance is as follows:
 - With `--copy-method disabled`, exports run at about `18k` messages per second
 - With `--copy-method efficient`, exports run at about `13k` messages per second
 - With `--copy-method compatible`, exports run at about `300` messages per second
-- For more information on `--copy-method`, see [here](../imessage-exporter/README.md#how-to-use) and [here](./features.md#supported-message-features)
+- For more information on `--copy-method`, see [here](../imessage-exporter/README.md#how-to-use) and [here](./features.md#supported-message-features).
 
 However, if you recently deleted a large amount of data from Messages, the database will be slow for awhile, and will result in significantly reduced performance from `imessage-exporter`.

--- a/imessage-database/src/message_types/sticker.rs
+++ b/imessage-database/src/message_types/sticker.rs
@@ -1,4 +1,4 @@
-/*
+/*!
 These are [sticker messages](https://support.apple.com/guide/iphone/send-stickers-iph37b0bfe7b/ios), either from the user's sticker library or sticker apps.
 */
 

--- a/imessage-database/src/tables/messages.rs
+++ b/imessage-database/src/tables/messages.rs
@@ -246,16 +246,30 @@ impl Diagnostic for Message {
             .query_row([], |r| r.get(0))
             .unwrap_or(0);
 
+        let mut messages_count = db
+            .prepare(&format!(
+                "
+            SELECT
+                COUNT(rowid)
+            FROM
+                {MESSAGE}
+            "
+            ))
+            .map_err(TableError::Messages)?;
+
+        let total_messages: i64 = messages_count.query_row([], |r| r.get(0)).unwrap_or(0);
+
         done_processing();
 
-        if num_dangling > 0 || messages_in_more_than_one_chat > 0 {
-            println!("Message diagnostic data:");
-            if num_dangling > 0 {
-                println!("    Messages not associated with a chat: {num_dangling}");
-            }
-            if messages_in_more_than_one_chat > 0 {
-                println!("    Messages belonging to more than one chat: {messages_in_more_than_one_chat}");
-            }
+        println!("Message diagnostic data:");
+        println!("    Total messages: {total_messages}");
+        if num_dangling > 0 {
+            println!("    Messages not associated with a chat: {num_dangling}");
+        }
+        if messages_in_more_than_one_chat > 0 {
+            println!(
+                "    Messages belonging to more than one chat: {messages_in_more_than_one_chat}"
+            );
         }
         Ok(())
     }

--- a/imessage-database/src/util/export_type.rs
+++ b/imessage-database/src/util/export_type.rs
@@ -1,0 +1,69 @@
+/*!
+ Contains data structures used to describe export types
+*/
+
+use std::fmt::Display;
+
+/// Represents the type of file to export iMessage data into
+#[derive(PartialEq, Eq)]
+pub enum ExportType {
+    /// Text file export
+    HTML,
+    /// HTML export
+    TXT,
+}
+
+impl ExportType {
+    /// Given user's input, return a variant if the input matches one
+    pub fn from_cli(platform: &str) -> Option<Self> {
+        match platform.to_lowercase().as_str() {
+            "txt" => Some(Self::TXT),
+            "html" => Some(Self::HTML),
+            _ => None,
+        }
+    }
+}
+
+impl Display for ExportType {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ExportType::TXT => write!(fmt, "txt"),
+            ExportType::HTML => write!(fmt, "html"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::util::export_type::ExportType;
+
+    #[test]
+    fn can_parse_html_any_case() {
+        assert!(matches!(
+            ExportType::from_cli("html"),
+            Some(ExportType::HTML)
+        ));
+        assert!(matches!(
+            ExportType::from_cli("HTML"),
+            Some(ExportType::HTML)
+        ));
+        assert!(matches!(
+            ExportType::from_cli("HtMl"),
+            Some(ExportType::HTML)
+        ));
+    }
+
+    #[test]
+    fn can_parse_txt_any_case() {
+        assert!(matches!(ExportType::from_cli("txt"), Some(ExportType::TXT)));
+        assert!(matches!(ExportType::from_cli("TXT"), Some(ExportType::TXT)));
+        assert!(matches!(ExportType::from_cli("tXt"), Some(ExportType::TXT)));
+    }
+
+    #[test]
+    fn cant_parse_invalid() {
+        assert!(ExportType::from_cli("pdf").is_none());
+        assert!(ExportType::from_cli("json").is_none());
+        assert!(ExportType::from_cli("").is_none());
+    }
+}

--- a/imessage-database/src/util/export_type.rs
+++ b/imessage-database/src/util/export_type.rs
@@ -5,7 +5,7 @@
 use std::fmt::Display;
 
 /// Represents the type of file to export iMessage data into
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum ExportType {
     /// HTML file export
     HTML,

--- a/imessage-database/src/util/export_type.rs
+++ b/imessage-database/src/util/export_type.rs
@@ -7,9 +7,9 @@ use std::fmt::Display;
 /// Represents the type of file to export iMessage data into
 #[derive(PartialEq, Eq)]
 pub enum ExportType {
-    /// Text file export
+    /// HTML file export
     HTML,
-    /// HTML export
+    /// Text file export
     TXT,
 }
 

--- a/imessage-database/src/util/mod.rs
+++ b/imessage-database/src/util/mod.rs
@@ -4,6 +4,7 @@
 
 pub mod dates;
 pub mod dirs;
+pub mod export_type;
 pub mod output;
 pub mod platform;
 pub mod plist;

--- a/imessage-database/src/util/platform.rs
+++ b/imessage-database/src/util/platform.rs
@@ -7,7 +7,7 @@ use std::{fmt::Display, path::Path};
 use crate::tables::table::DEFAULT_PATH_IOS;
 
 /// Represents the platform that created the database this library connects to
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum Platform {
     /// macOS-sourced data
     #[allow(non_camel_case_types)]

--- a/imessage-database/src/util/query_context.rs
+++ b/imessage-database/src/util/query_context.rs
@@ -8,7 +8,7 @@ use crate::{
     util::dates::{get_offset, TIMESTAMP_FACTOR},
 };
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, PartialEq, Eq)]
 /// Represents filter configurations for a SQL query.
 pub struct QueryContext {
     /// The start date filter. Only messages sent on or after this date will be included.

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ReagentX/imessage-exporter"
 version = "0.0.0"
 
 [dependencies]
-clap = {version = "3.2.23", features = ["cargo"]}
+clap = {version = "4.4.8", features = ["cargo"]}
 filetime = "0.2.22"
 imessage-database = {path = "../imessage-database"}
 indicatif = "0.17.7"

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -39,53 +39,52 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
 ```txt
 -d, --diagnostics
         Print diagnostic information and exit
-
+        
 -f, --format <txt, html>
         Specify a single file format to export messages into
-
+        
 -c, --copy-method <compatible, efficient, disabled>
         Specify a method to use when copying message attachments
         Compatible will convert HEIC files to JPEG
         Efficient will copy files without converting anything
         If omitted, the default is `disabled`
-
+        
 -p, --db-path <path/to/source>
         Specify a custom path for the iMessage database location
         For macOS, specify a path to a `chat.db` file
         For iOS, specify a path to the root of an unencrypted backup directory
-        If omitted, the default directory is ~/Library/Messages/chat.db
-
+        If omitted, the default directory is /Users/chris/Library/Messages/chat.db
+        
 -r, --attachment-root <path/to/attachments>
         Specify an optional custom path to look for attachments in (macOS only).
         Only use this if attachments are stored separately from the database's default location.
         The default location is ~/Library/Messages/Attachments
-
+        
 -a, --platform <macOS, iOS>
         Specify the platform the database was created on
         If omitted, the platform type is determined automatically
-
+        
 -o, --export-path <path/to/save/files>
         Specify a custom directory for outputting exported data
-        If omitted, the default directory is ~/imessage_export
-
+        If omitted, the default directory is /Users/chris/imessage_export
+        
 -s, --start-date <YYYY-MM-DD>
         The start date filter. Only messages sent on or after this date will be included
-
+        
 -e, --end-date <YYYY-MM-DD>
         The end date filter. Only messages sent before this date will be included
-
+        
 -l, --no-lazy
         Do not include `loading="lazy"` in HTML export `img` tags
         This will make pages load slower but PDF generation work
-
+        
 -m, --custom-name <custom-name>
         Specify an optional custom name for the database owner's messages in exports
-
+        
 -h, --help
-        Print help information
-
+        Print help
 -V, --version
-        Print version information
+        Print version
 ```
 
 ### Examples

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -53,7 +53,7 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         Specify a custom path for the iMessage database location
         For macOS, specify a path to a `chat.db` file
         For iOS, specify a path to the root of an unencrypted backup directory
-        If omitted, the default directory is /Users/chris/Library/Messages/chat.db
+        If omitted, the default directory is ~/Library/Messages/chat.db
         
 -r, --attachment-root <path/to/attachments>
         Specify an optional custom path to look for attachments in (macOS only).
@@ -66,7 +66,7 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         
 -o, --export-path <path/to/save/files>
         Specify a custom directory for outputting exported data
-        If omitted, the default directory is /Users/chris/imessage_export
+        If omitted, the default directory is ~/imessage_export
         
 -s, --start-date <YYYY-MM-DD>
         The start date filter. Only messages sent on or after this date will be included

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -14,6 +14,7 @@ use crate::app::{
 };
 
 /// Represents different ways the app can interact with attachment data
+#[derive(Debug, PartialEq, Eq)]
 pub enum AttachmentManager {
     /// Do not copy attachments
     Disabled,

--- a/imessage-exporter/src/app/attachment_manager.rs
+++ b/imessage-exporter/src/app/attachment_manager.rs
@@ -47,7 +47,7 @@ impl AttachmentManager {
         let attachment_path = attachment.resolved_attachment_path(
             &config.options.platform,
             &config.options.db_path,
-            config.options.attachment_root,
+            config.options.attachment_root.as_deref(),
         )?;
 
         if !matches!(self, AttachmentManager::Disabled) {

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -269,6 +269,7 @@ fn validate_path(
     Ok(resolved_path)
 }
 
+/// Build the command line argument parser
 fn get_command() -> Command {
     Command::new("iMessage Exporter")
         .version(crate_version!())
@@ -363,6 +364,7 @@ fn get_command() -> Command {
         )
 }
 
+/// Parse arguments from the command line
 pub fn from_command_line() -> ArgMatches {
     get_command().get_matches()
 }

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -1712,7 +1712,9 @@ mod tests {
     #[test]
     fn can_format_html_attachment_sticker() {
         // Create exporter
-        let options = fake_options();
+        let mut options = fake_options();
+        options.export_path = current_dir().unwrap().parent().unwrap().to_path_buf();
+
         let config = Config::new(options).unwrap();
         let exporter = HTML::new(&config);
 
@@ -1728,10 +1730,11 @@ mod tests {
             .unwrap()
             .join("imessage-database/test_data/stickers/outline.heic");
         attachment.filename = Some(sticker_path.to_string_lossy().to_string());
+        attachment.copied_path = Some(PathBuf::from(sticker_path.to_string_lossy().to_string()));
 
         let actual = exporter.format_sticker(&mut attachment, &message);
 
-        assert_eq!(actual, "<img src=\"/Users/chris/Documents/Code/Rust/imessage-exporter/imessage-database/test_data/stickers/outline.heic\" loading=\"lazy\">\n<div class=\"sticker_effect\">Sent with Outline effect</div>");
+        assert_eq!(actual, "<img src=\"imessage-database/test_data/stickers/outline.heic\" loading=\"lazy\">\n<div class=\"sticker_effect\">Sent with Outline effect</div>");
     }
 }
 

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -1,4 +1,3 @@
-use core::panic;
 use std::{
     collections::HashMap,
     fs::File,
@@ -40,7 +39,7 @@ const STYLE: &str = include_str!("resources/style.css");
 
 pub struct HTML<'a> {
     /// Data that is setup from the application's runtime
-    pub config: &'a Config<'a>,
+    pub config: &'a Config,
     /// Handles to files we want to write messages to
     /// Map of internal unique chatroom ID to a filename
     pub files: HashMap<i32, PathBuf>,
@@ -514,7 +513,7 @@ impl<'a> Writer<'a> for HTML<'a> {
                 let sticker_effect = sticker.get_sticker_effect(
                     &self.config.options.platform,
                     &self.config.options.db_path,
-                    self.config.options.attachment_root,
+                    self.config.options.attachment_root.as_deref(),
                 );
                 if let Ok(Some(sticker_effect)) = sticker_effect {
                     return format!("{sticker_embed}\n<div class=\"sticker_effect\">Sent with {sticker_effect} effect</div>");
@@ -659,7 +658,7 @@ impl<'a> Writer<'a> for HTML<'a> {
         let mut who = self.config.who(&msg.handle_id, msg.is_from_me);
         // Rename yourself so we render the proper grammar here
         if who == ME {
-            who = self.config.options.custom_name.unwrap_or("You")
+            who = self.config.options.custom_name.as_deref().unwrap_or("You")
         }
         let timestamp = format(&msg.date(&self.config.offset));
 
@@ -701,7 +700,7 @@ impl<'a> Writer<'a> for HTML<'a> {
 
             if edited_message.is_deleted() {
                 let who = if msg.is_from_me {
-                    self.config.options.custom_name.unwrap_or(YOU)
+                    self.config.options.custom_name.as_deref().unwrap_or(YOU)
                 } else {
                     "They"
                 };
@@ -1103,7 +1102,7 @@ impl<'a> HTML<'a> {
                 let who = if message.is_from_me {
                     "them"
                 } else {
-                    self.config.options.custom_name.unwrap_or("you")
+                    self.config.options.custom_name.as_deref().unwrap_or("you")
                 };
                 date.push_str(&format!(" (Read by {who} after {time})"));
             }
@@ -1284,7 +1283,7 @@ mod tests {
         }
     }
 
-    pub fn fake_options() -> Options<'static> {
+    pub fn fake_options() -> Options {
         Options {
             db_path: default_db_path(),
             attachment_root: None,
@@ -1518,7 +1517,7 @@ mod tests {
     fn can_format_html_from_them_custom_name_read() {
         // Create exporter
         let mut options = fake_options();
-        options.custom_name = Some("Name");
+        options.custom_name = Some("Name".to_string());
         let mut config = Config::new(options).unwrap();
         config
             .participants
@@ -1582,7 +1581,7 @@ mod tests {
     fn can_format_html_announcement_custom_name() {
         // Create exporter
         let mut options = fake_options();
-        options.custom_name = Some("Name");
+        options.custom_name = Some("Name".to_string());
         let config = Config::new(options).unwrap();
         let exporter = HTML::new(&config);
 

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -35,7 +35,7 @@ use imessage_database::{
 
 pub struct TXT<'a> {
     /// Data that is setup from the application's runtime
-    pub config: &'a Config<'a>,
+    pub config: &'a Config,
     /// Handles to files we want to write messages to
     /// Map of internal unique chatroom ID to a filename
     pub files: HashMap<i32, PathBuf>,
@@ -324,7 +324,7 @@ impl<'a> Writer<'a> for TXT<'a> {
                 let sticker_effect = sticker.get_sticker_effect(
                     &self.config.options.platform,
                     &self.config.options.db_path,
-                    self.config.options.attachment_root,
+                    self.config.options.attachment_root.as_deref(),
                 );
                 if let Ok(Some(sticker_effect)) = sticker_effect {
                     return format!("{sticker_effect} Sticker from {who}: {path_to_sticker}");
@@ -451,7 +451,7 @@ impl<'a> Writer<'a> for TXT<'a> {
         let mut who = self.config.who(&msg.handle_id, msg.is_from_me);
         // Rename yourself so we render the proper grammar here
         if who == ME {
-            who = self.config.options.custom_name.unwrap_or(YOU)
+            who = self.config.options.custom_name.as_deref().unwrap_or(YOU)
         }
 
         let timestamp = format(&msg.date(&self.config.offset));
@@ -487,7 +487,7 @@ impl<'a> Writer<'a> for TXT<'a> {
 
             if edited_message.is_deleted() {
                 let who = if msg.is_from_me {
-                    self.config.options.custom_name.unwrap_or(YOU)
+                    self.config.options.custom_name.as_deref().unwrap_or(YOU)
                 } else {
                     "They"
                 };
@@ -783,7 +783,7 @@ impl<'a> TXT<'a> {
                 let who = if message.is_from_me {
                     "them"
                 } else {
-                    self.config.options.custom_name.unwrap_or("you")
+                    self.config.options.custom_name.as_deref().unwrap_or("you")
                 };
                 date.push_str(&format!(" (Read by {who} after {time})"));
             }
@@ -843,7 +843,7 @@ mod tests {
         }
     }
 
-    pub fn fake_options() -> Options<'static> {
+    pub fn fake_options() -> Options {
         Options {
             db_path: default_db_path(),
             attachment_root: None,
@@ -1063,7 +1063,7 @@ mod tests {
     fn can_format_txt_from_them_custom_name_read() {
         // Create exporter
         let mut options = fake_options();
-        options.custom_name = Some("Name");
+        options.custom_name = Some("Name".to_string());
         let mut config = Config::new(options).unwrap();
         config
             .participants
@@ -1127,7 +1127,7 @@ mod tests {
     fn can_format_txt_announcement_custom_name() {
         // Create exporter
         let mut options = fake_options();
-        options.custom_name = Some("Name");
+        options.custom_name = Some("Name".to_string());
         let config = Config::new(options).unwrap();
         let exporter = TXT::new(&config);
 

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -1260,7 +1260,9 @@ mod tests {
     #[test]
     fn can_format_txt_attachment_sticker() {
         // Create exporter
-        let options = fake_options();
+        let mut options = fake_options();
+        options.export_path = current_dir().unwrap().parent().unwrap().to_path_buf();
+
         let config = Config::new(options).unwrap();
         let exporter = TXT::new(&config);
 
@@ -1276,10 +1278,11 @@ mod tests {
             .unwrap()
             .join("imessage-database/test_data/stickers/outline.heic");
         attachment.filename = Some(sticker_path.to_string_lossy().to_string());
+        attachment.copied_path = Some(PathBuf::from(sticker_path.to_string_lossy().to_string()));
 
         let actual = exporter.format_sticker(&mut attachment, &message);
 
-        assert_eq!(actual, "Outline Sticker from Me: /Users/chris/Documents/Code/Rust/imessage-exporter/imessage-database/test_data/stickers/outline.heic");
+        assert_eq!(actual, "Outline Sticker from Me: imessage-database/test_data/stickers/outline.heic");
     }
 }
 


### PR DESCRIPTION
- Upgrade Clap from 3.x to 4.x for #198
- Use new `ExportType` enum 
- Resolve https://github.com/ReagentX/imessage-exporter/security/dependabot/5
- Add total number of messages to diagnostic output 