### PR TITLE
add missing viewport tag

### DIFF
--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -38,7 +38,7 @@ use imessage_database::{
     },
 };
 
-const HEADER: &str = "<html>\n<head>\n<meta charset=\"UTF-8\">";
+const HEADER: &str = "<html>\n<head>\n<meta charset=\"UTF-8\">\n<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">";
 const FOOTER: &str = "</body></html>";
 const STYLE: &str = include_str!("resources/style.css");
 

--- a/imessage-exporter/src/exporters/resources/example.html
+++ b/imessage-exporter/src/exporters/resources/example.html
@@ -1,5 +1,6 @@
 <html>
 <meta charset="UTF-8">
+<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
 
 <link rel="stylesheet" type="text/css" href="style.css">
 


### PR DESCRIPTION
- Add missing viewport tag to improve mobile display:


![IMG_5797](https://github.com/ReagentX/imessage-exporter/assets/1920666/270632b6-9315-40a5-b67d-c486d6c1dcbc)
