### PR TITLE
Feat/cs/use buf write

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -62,9 +62,9 @@ On my M1 Max MacBook Pro, approximate performance is as follows:
 
 | `--copy-method` | Messages exported per second |
 |---|---|
-| `disabled` | 18,000 |
-| `efficient` | 13,000 |
-| `compatible` | 300 |
+| `disabled` | 21,395 |
+| `efficient` | 16,320 |
+| `compatible` | < 300 |
 
 For more information on `--copy-method`, see [here](../imessage-exporter/README.md#how-to-use) and [here](./features.md#supported-message-features).
 

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -811,7 +811,7 @@ mod path_tests {
         let _ = fs::remove_file("/tmp/orphaned.txt");
 
         let tmp = String::from("/tmp");
-        let export_path: Option<&String> = Some(&tmp);
+        let export_path = Some(&tmp);
         let export_type = Some(ExportType::Txt);
 
         let result = validate_path(export_path, &export_type.as_ref());

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -419,6 +419,8 @@ pub fn from_command_line() -> ArgMatches {
 
 #[cfg(test)]
 mod arg_tests {
+    use std::fs;
+
     use imessage_database::util::{
         dirs::default_db_path, platform::Platform, query_context::QueryContext,
     };
@@ -538,6 +540,9 @@ mod arg_tests {
 
     #[test]
     fn can_build_option_export_html() {
+        // Cleanup existing temp data
+        let _ =fs::remove_file("/tmp/orphaned.html");
+
         // Get matches from sample args
         let cli_args: Vec<&str> = vec!["imessage-exporter", "-f", "html", "-o", "/tmp"];
         let command = get_command();
@@ -568,6 +573,9 @@ mod arg_tests {
 
     #[test]
     fn can_build_option_export_txt_no_lazy() {
+        // Cleanup existing temp data
+        let _ =fs::remove_file("/tmp/orphaned.txt");
+
         // Get matches from sample args
         let cli_args: Vec<&str> = vec!["imessage-exporter", "-f", "txt", "-l"];
         let command = get_command();
@@ -785,6 +793,9 @@ mod path_tests {
 
     #[test]
     fn can_validate_empty() {
+        // Cleanup existing temp data
+        let _ =fs::remove_file("/tmp/orphaned.txt");
+
         let tmp = String::from("/tmp");
         let export_path = Some(&tmp);
         let export_type = Some(ExportType::Txt);
@@ -796,8 +807,11 @@ mod path_tests {
 
     #[test]
     fn can_validate_different_type() {
+        // Cleanup existing temp data
+        let _ =fs::remove_file("/tmp/orphaned.txt");
+
         let tmp = String::from("/tmp");
-        let export_path = Some(&tmp);
+        let export_path: Option<&String> = Some(&tmp);
         let export_type = Some(ExportType::Txt);
 
         let result = validate_path(export_path, &export_type.as_ref());
@@ -813,6 +827,9 @@ mod path_tests {
 
     #[test]
     fn can_validate_same_type() {
+        // Cleanup existing temp data
+        let _ =fs::remove_file("/tmp/orphaned.txt");
+
         let tmp = String::from("/tmp");
         let export_path = Some(&tmp);
         let export_type = Some(ExportType::Txt);

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -541,7 +541,7 @@ mod arg_tests {
     #[test]
     fn can_build_option_export_html() {
         // Cleanup existing temp data
-        let _ =fs::remove_file("/tmp/orphaned.html");
+        let _ = fs::remove_file("/tmp/orphaned.html");
 
         // Get matches from sample args
         let cli_args: Vec<&str> = vec!["imessage-exporter", "-f", "html", "-o", "/tmp"];
@@ -574,7 +574,7 @@ mod arg_tests {
     #[test]
     fn can_build_option_export_txt_no_lazy() {
         // Cleanup existing temp data
-        let _ =fs::remove_file("/tmp/orphaned.txt");
+        let _ = fs::remove_file("/tmp/orphaned.txt");
 
         // Get matches from sample args
         let cli_args: Vec<&str> = vec!["imessage-exporter", "-f", "txt", "-l"];
@@ -794,7 +794,7 @@ mod path_tests {
     #[test]
     fn can_validate_empty() {
         // Cleanup existing temp data
-        let _ =fs::remove_file("/tmp/orphaned.txt");
+        let _ = fs::remove_file("/tmp/orphaned.txt");
 
         let tmp = String::from("/tmp");
         let export_path = Some(&tmp);
@@ -808,7 +808,7 @@ mod path_tests {
     #[test]
     fn can_validate_different_type() {
         // Cleanup existing temp data
-        let _ =fs::remove_file("/tmp/orphaned.txt");
+        let _ = fs::remove_file("/tmp/orphaned.txt");
 
         let tmp = String::from("/tmp");
         let export_path: Option<&String> = Some(&tmp);
@@ -828,7 +828,7 @@ mod path_tests {
     #[test]
     fn can_validate_same_type() {
         // Cleanup existing temp data
-        let _ =fs::remove_file("/tmp/orphaned.txt");
+        let _ = fs::remove_file("/tmp/orphaned.txt");
 
         let tmp = String::from("/tmp");
         let export_path = Some(&tmp);

--- a/imessage-exporter/src/exporters/exporter.rs
+++ b/imessage-exporter/src/exporters/exporter.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::BufWriter, path::Path};
+use std::{fs::File, io::BufWriter};
 
 use imessage_database::{
     error::{message::MessageError, plist::PlistParseError, table::TableError},

--- a/imessage-exporter/src/exporters/exporter.rs
+++ b/imessage-exporter/src/exporters/exporter.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fs::File, io::BufWriter, path::Path};
 
 use imessage_database::{
     error::{message::MessageError, plist::PlistParseError, table::TableError},
@@ -19,7 +19,7 @@ pub trait Exporter<'a> {
     /// Begin iterating over the messages table
     fn iter_messages(&mut self) -> Result<(), RuntimeError>;
     /// Get the file handle to write to, otherwise create a new one
-    fn get_or_create_file(&mut self, message: &Message) -> &Path;
+    fn get_or_create_file(&mut self, message: &Message) -> &mut BufWriter<File>;
 }
 
 /// Defines behavior for formatting message instances to the desired output format
@@ -53,7 +53,7 @@ pub(super) trait Writer<'a> {
     fn format_shared_location(&self, msg: &'a Message) -> &str;
     /// Format an edited message
     fn format_edited(&self, msg: &'a Message, indent: &str) -> Result<String, MessageError>;
-    fn write_to_file(file: &Path, text: &str);
+    fn write_to_file(file: &mut BufWriter<File>, text: &str) -> Result<(), RuntimeError>;
 }
 
 /// Defines behavior for formatting custom balloons to the desired output format

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -141,9 +141,9 @@ impl<'a> Exporter<'a> for HTML<'a> {
         match self.config.conversation(message) {
             Some((chatroom, _)) => {
                 let filename = self.config.filename(chatroom);
-                self.files.entry(filename.clone()).or_insert_with(|| {
+                self.files.entry(filename).or_insert_with(|| {
                     let mut path = self.config.options.export_path.clone();
-                    path.push(filename);
+                    path.push(self.config.filename(chatroom));
                     path.set_extension("html");
 
                     // If the file already exists, don't write the headers again

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -45,9 +45,9 @@ pub struct HTML<'a> {
     /// Data that is setup from the application's runtime
     pub config: &'a Config,
     /// Handles to files we want to write messages to
-    /// Map of internal unique chatroom ID to a filename
+    /// Map of internal unique chatroom ID to a buffered writer
     pub files: HashMap<i32, BufWriter<File>>,
-    /// Path to file for orphaned messages
+    /// Writer instance for orphaned messages
     pub orphaned: BufWriter<File>,
 }
 
@@ -1466,7 +1466,7 @@ mod tests {
             attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
-            export_path: PathBuf::new(),
+            export_path: PathBuf::from("/tmp"),
             query_context: QueryContext::default(),
             no_lazy: false,
             custom_name: None,
@@ -2069,6 +2069,14 @@ mod tests {
         let actual = exporter.format_sticker(&mut attachment, &message);
 
         assert_eq!(actual, "<img src=\"imessage-database/test_data/stickers/outline.heic\" loading=\"lazy\">\n<div class=\"sticker_effect\">Sent with Outline effect</div>");
+
+        // Remove the file created by the constructor for this test
+        let orphaned_path = current_dir()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("orphaned.html");
+        std::fs::remove_file(orphaned_path).unwrap();
     }
 }
 

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -38,9 +38,9 @@ pub struct TXT<'a> {
     /// Data that is setup from the application's runtime
     pub config: &'a Config,
     /// Handles to files we want to write messages to
-    /// Map of internal unique chatroom ID to a filename
+    /// Map of internal unique chatroom ID to a buffered writer
     pub files: HashMap<i32, BufWriter<File>>,
-    /// Path to file for orphaned messages
+    /// Writer instance for orphaned messages
     pub orphaned: BufWriter<File>,
 }
 
@@ -135,9 +135,7 @@ impl<'a> Exporter<'a> for TXT<'a> {
                     .open(path.clone())
                     .unwrap();
 
-                let buf = BufWriter::new(file);
-
-                buf
+                BufWriter::new(file)
             }),
             None => &mut self.orphaned,
         }
@@ -975,7 +973,7 @@ mod tests {
             attachment_manager: AttachmentManager::Disabled,
             diagnostic: false,
             export_type: None,
-            export_path: PathBuf::new(),
+            export_path: PathBuf::from("/tmp"),
             query_context: QueryContext::default(),
             no_lazy: false,
             custom_name: None,
@@ -1546,6 +1544,14 @@ mod tests {
             actual,
             "Outline Sticker from Me: imessage-database/test_data/stickers/outline.heic"
         );
+
+        // Remove the file created by the constructor for this test
+        let orphaned_path = current_dir()
+            .unwrap()
+            .parent()
+            .unwrap()
+            .join("orphaned.txt");
+        std::fs::remove_file(orphaned_path).unwrap();
     }
 }
 

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -126,9 +126,9 @@ impl<'a> Exporter<'a> for TXT<'a> {
         match self.config.conversation(message) {
             Some((chatroom, _)) => {
                 let filename = self.config.filename(chatroom);
-                self.files.entry(filename.clone()).or_insert_with(|| {
+                self.files.entry(filename).or_insert_with(|| {
                     let mut path = self.config.options.export_path.clone();
-                    path.push(filename);
+                    path.push(self.config.filename(chatroom));
                     path.set_extension("txt");
 
                     let file = File::options()

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -2,7 +2,6 @@ use std::{
     collections::HashMap,
     fs::File,
     io::{BufWriter, Write},
-    path::{Path, PathBuf},
 };
 
 use crate::{


### PR DESCRIPTION
- Use `BufWriter<File>` instead of `PathBuf` in `Exporter` structs
- <details><summary> Improves performance by ≈25% (16k/s to 22k/s)</summary><p> <h5>Before:</h5> <img width="1690" alt="image" src="https://github.com/ReagentX/imessage-exporter/assets/1920666/2d01bde4-e564-466c-a380-e530c9f215fd"> <h5>After:</h5> <img width="1683" alt="image" src="https://github.com/ReagentX/imessage-exporter/assets/1920666/fe8e5cbb-694d-4042-93f3-fe9cdd20e529"> </p></details>
