### PR TITLE
Feat/cs/use cols in query

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -62,8 +62,8 @@ On my M1 Max MacBook Pro, approximate performance is as follows:
 
 | `--copy-method` | Messages exported per second |
 |---|---|
-| `disabled` | 21,395 |
-| `efficient` | 16,320 |
+| `disabled` | 32,845 |
+| `efficient` | 20,876 |
 | `compatible` | < 300 |
 
 For more information on `--copy-method`, see [here](../imessage-exporter/README.md#how-to-use) and [here](./features.md#supported-message-features).

--- a/imessage-database/src/error/table.rs
+++ b/imessage-database/src/error/table.rs
@@ -21,11 +21,11 @@ pub enum TableError {
 impl Display for TableError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {
-            TableError::Attachment(why) => write!(fmt, "Failed to parse row: {why}"),
-            TableError::ChatToHandle(why) => write!(fmt, "Failed to parse row: {why}"),
-            TableError::Chat(why) => write!(fmt, "Failed to parse row: {why}"),
-            TableError::Handle(why) => write!(fmt, "Failed to parse row: {why}"),
-            TableError::Messages(why) => write!(fmt, "Failed to parse row: {why}"),
+            TableError::Attachment(why) => write!(fmt, "Failed to parse attachment row: {why}"),
+            TableError::ChatToHandle(why) => write!(fmt, "Failed to parse chat handle row: {why}"),
+            TableError::Chat(why) => write!(fmt, "Failed to parse chat row: {why}"),
+            TableError::Handle(why) => write!(fmt, "Failed to parse handle row: {why}"),
+            TableError::Messages(why) => write!(fmt, "Failed to parse messages row: {why}"),
             TableError::CannotConnect(why) => write!(fmt, "{why}"),
             TableError::CannotRead(why) => write!(fmt, "{why}"),
         }


### PR DESCRIPTION
- Use column names for `messages` table queries against most recent table schema
- <details><summary> Improves performance by ≈50% (22k/s to 33k/s)</summary><p> <h5>Before:</h5> <img width="1686" alt="image" src="https://github.com/ReagentX/imessage-exporter/assets/1920666/057cdb07-77fb-499b-9232-f9f5a0ce9b34"> <h5>After:</h5> <img width="1688" alt="image" src="https://github.com/ReagentX/imessage-exporter/assets/1920666/f0479e4a-283a-4216-9d62-6ed3e9c96ec2"> </p></details>


