### PR TITLE
Feat/cs/make chats handles deterministic

### DIFF
--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -86,7 +86,7 @@ impl Deduplicate for ChatToHandle {
     ///
     /// This returns a new hashmap that maps the real chat ID to a new deduplicated unique chat ID
     /// that represents a single chat for all of the same participants, even if they have multiple handles.
-    /// 
+    ///
     /// Assuming no new chat-handle relationships have been written to the database, deduplicated data is deterministic across runs.
     fn dedupe(duplicated_data: &HashMap<i32, Self::T>) -> HashMap<i32, i32> {
         let mut deduplicated_chats: HashMap<i32, i32> = HashMap::new();
@@ -191,7 +191,6 @@ mod tests {
         input.insert(6, BTreeSet::from([3])); // 2
 
         let output = ChatToHandle::dedupe(&input);
-        println!("{output:?}");
         let expected_deduped_ids: HashSet<i32> = output.values().copied().collect();
         assert_eq!(expected_deduped_ids.len(), 3);
     }
@@ -207,7 +206,6 @@ mod tests {
         input.insert(6, BTreeSet::from([3])); // 3
 
         let output = ChatToHandle::dedupe(&input);
-        println!("{output:?}");
         let expected_deduped_ids: HashSet<i32> = output.values().copied().collect();
         assert_eq!(expected_deduped_ids.len(), 4);
     }

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -85,7 +85,9 @@ impl Deduplicate for ChatToHandle {
     /// Given the initial set of duplicated chats, deduplicate them based on the participants
     ///
     /// This returns a new hashmap that maps the real chat ID to a new deduplicated unique chat ID
-    /// that represents a single chat for all of the same participants, even if they have multiple handles
+    /// that represents a single chat for all of the same participants, even if they have multiple handles.
+    /// 
+    /// Assuming no new chat-handle relationships have been written to the database, deduplicated data is deterministic across runs.
     fn dedupe(duplicated_data: &HashMap<i32, Self::T>) -> HashMap<i32, i32> {
         let mut deduplicated_chats: HashMap<i32, i32> = HashMap::new();
         let mut participants_to_unique_chat_id: HashMap<Self::T, i32> = HashMap::new();

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -96,7 +96,9 @@ impl Deduplicate for Handle {
     /// Given the initial set of duplicated handles, deduplicate them
     ///
     /// This returns a new hashmap that maps the real handle ID to a new deduplicated unique handle ID
-    /// that represents a single handle for all of the deduplicate handles
+    /// that represents a single handle for all of the deduplicate handles.
+    /// 
+    /// Assuming no new handles have been written to the database, deduplicated data is deterministic across runs.
     fn dedupe(duplicated_data: &HashMap<i32, Self::T>) -> HashMap<i32, i32> {
         let mut deduplicated_participants: HashMap<i32, i32> = HashMap::new();
         let mut participant_to_unique_participant_id: HashMap<Self::T, i32> = HashMap::new();

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -103,7 +103,12 @@ impl Deduplicate for Handle {
 
         // Build cache of each unique set of participants to a new identifier:
         let mut unique_participant_identifier = 0;
-        for (participant_id, participant) in duplicated_data {
+
+        // Iterate over the values in a deterministic order
+        let mut sorted_dupes: Vec<(&i32, &Self::T)> = duplicated_data.iter().collect();
+        sorted_dupes.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        for (participant_id, participant) in sorted_dupes {
             if let Some(id) = participant_to_unique_participant_id.get(participant) {
                 deduplicated_participants.insert(participant_id.to_owned(), id.to_owned());
             } else {
@@ -244,15 +249,61 @@ mod tests {
     #[test]
     fn test_can_dedupe() {
         let mut input: HashMap<i32, String> = HashMap::new();
-        input.insert(1, String::from("A"));
-        input.insert(2, String::from("A"));
-        input.insert(3, String::from("A"));
-        input.insert(4, String::from("B"));
-        input.insert(5, String::from("B"));
-        input.insert(6, String::from("C"));
+        input.insert(1, String::from("A")); // 0
+        input.insert(2, String::from("A")); // 0
+        input.insert(3, String::from("A")); // 0
+        input.insert(4, String::from("B")); // 1
+        input.insert(5, String::from("B")); // 1
+        input.insert(6, String::from("C")); // 2
 
         let output = Handle::dedupe(&input);
         let expected_deduped_ids: HashSet<i32> = output.values().copied().collect();
         assert_eq!(expected_deduped_ids.len(), 3);
+    }
+
+    #[test]
+    // Simulate 3 runs of the program and ensure that the order of the deduplicated contacts is stable
+    fn test_same_values() {
+        let mut input_1: HashMap<i32, String> = HashMap::new();
+        input_1.insert(1, String::from("A"));
+        input_1.insert(2, String::from("A"));
+        input_1.insert(3, String::from("A"));
+        input_1.insert(4, String::from("B"));
+        input_1.insert(5, String::from("B"));
+        input_1.insert(6, String::from("C"));
+
+        let mut input_2: HashMap<i32, String> = HashMap::new();
+        input_2.insert(1, String::from("A"));
+        input_2.insert(2, String::from("A"));
+        input_2.insert(3, String::from("A"));
+        input_2.insert(4, String::from("B"));
+        input_2.insert(5, String::from("B"));
+        input_2.insert(6, String::from("C"));
+
+        let mut input_3: HashMap<i32, String> = HashMap::new();
+        input_3.insert(1, String::from("A"));
+        input_3.insert(2, String::from("A"));
+        input_3.insert(3, String::from("A"));
+        input_3.insert(4, String::from("B"));
+        input_3.insert(5, String::from("B"));
+        input_3.insert(6, String::from("C"));
+
+        let mut output_1 = Handle::dedupe(&input_1)
+            .into_iter()
+            .collect::<Vec<(i32, i32)>>();
+        let mut output_2 = Handle::dedupe(&input_2)
+            .into_iter()
+            .collect::<Vec<(i32, i32)>>();
+        let mut output_3 = Handle::dedupe(&input_3)
+            .into_iter()
+            .collect::<Vec<(i32, i32)>>();
+
+        output_1.sort();
+        output_2.sort();
+        output_3.sort();
+
+        assert_eq!(output_1, output_2);
+        assert_eq!(output_1, output_3);
+        assert_eq!(output_2, output_3);
     }
 }


### PR DESCRIPTION
- Make deduplication deterministic for chats and handles
  - As a side effect, this also makes exported filenames deterministic
- More efficient HTML entity translation