### PR TITLE
fix build.rs

### DIFF
--- a/imessage-database/build.rs
+++ b/imessage-database/build.rs
@@ -1,11 +1,11 @@
 use std::{
     env,
-    fs::{copy, exists},
-    path::PathBuf,
+    fs::copy,
+    path::{Path, PathBuf},
 };
 
 fn main() {
-    if !exists("src/message_types/handwriting/handwriting_proto.rs").unwrap() {
+    if !Path::new("src/message_types/handwriting/handwriting_proto.rs").exists() {
         protobuf_codegen::Codegen::new()
             .pure()
             .input("src/message_types/handwriting/handwriting.proto")


### PR DESCRIPTION
build.rs was causing the a crash during the installation with cargo : 

error[E0432]: unresolved import std::fs::exists
 --> imessage-database/build.rs:3:16
  |
3 |     fs::{copy, exists},
  |                ^^^^^^ no exists i