### PR TITLE
Select conversations by number

### DIFF
--- a/imessage-database/src/error/query_context.rs
+++ b/imessage-database/src/error/query_context.rs
@@ -8,6 +8,7 @@ use std::fmt::{Display, Formatter, Result};
 #[derive(Debug)]
 pub enum QueryContextError {
     InvalidDate(String),
+    InvalidTelephone(String),
 }
 
 impl Display for QueryContextError {
@@ -16,6 +17,10 @@ impl Display for QueryContextError {
             QueryContextError::InvalidDate(date) => write!(
                 fmt,
                 "Invalid date provided: {date}! Must be in format YYYY-MM-DD."
+            ),
+            QueryContextError::InvalidTelephone(telephone) => write!(
+                fmt,
+                "Invalid telephone provided: {telephone}! Must be in format XXXXXXXXXXX, e.g., 16468885555"
             ),
         }
     }

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -179,7 +179,7 @@ impl Diagnostic for ChatToHandle {
 
 #[cfg(test)]
 mod tests {
-    use crate::tables::{chat_handle::ChatToHandle, table::Deduplicate};
+    use crate::tables::{chat_handle::{ChatToHandle, MapChatHandle}, table::Deduplicate};
     use std::collections::{BTreeSet, HashMap, HashSet};
 
     #[test]

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -13,6 +13,8 @@ use crate::{
 };
 use rusqlite::{Connection, Error, Result, Row, Statement};
 
+type MapChatHandle = HashMap<i32, BTreeSet<i32>>;
+
 /// Represents a single row in the `chat_handle_join` table.
 pub struct ChatToHandle {
     chat_id: i32,
@@ -57,7 +59,7 @@ impl Cacheable for ChatToHandle {
     /// let chatrooms = ChatToHandle::cache(&conn);
     /// ```
     fn cache(db: &Connection) -> Result<HashMap<Self::K, Self::V>, TableError> {
-        let mut cache: HashMap<i32, BTreeSet<i32>> = HashMap::new();
+        let mut cache: MapChatHandle = HashMap::new();
 
         let mut rows = ChatToHandle::get(db)?;
         let mappings = rows
@@ -88,7 +90,7 @@ impl Deduplicate for ChatToHandle {
     /// that represents a single chat for all of the same participants, even if they have multiple handles.
     ///
     /// Assuming no new chat-handle relationships have been written to the database, deduplicated data is deterministic across runs.
-    fn dedupe(duplicated_data: &HashMap<i32, Self::T>) -> HashMap<i32, i32> {
+    fn dedupe(duplicated_data: &MapChatHandle) -> HashMap<i32, i32> {
         let mut deduplicated_chats: HashMap<i32, i32> = HashMap::new();
         let mut participants_to_unique_chat_id: HashMap<Self::T, i32> = HashMap::new();
 
@@ -182,7 +184,7 @@ mod tests {
 
     #[test]
     fn can_dedupe() {
-        let mut input: HashMap<i32, BTreeSet<i32>> = HashMap::new();
+        let mut input: MapChatHandle = HashMap::new();
         input.insert(1, BTreeSet::from([1])); // 0
         input.insert(2, BTreeSet::from([1])); // 0
         input.insert(3, BTreeSet::from([1])); // 0
@@ -197,7 +199,7 @@ mod tests {
 
     #[test]
     fn can_dedupe_multi() {
-        let mut input: HashMap<i32, BTreeSet<i32>> = HashMap::new();
+        let mut input: MapChatHandle = HashMap::new();
         input.insert(1, BTreeSet::from([1, 2])); // 0
         input.insert(2, BTreeSet::from([1])); // 1
         input.insert(3, BTreeSet::from([1])); // 1
@@ -213,7 +215,7 @@ mod tests {
     #[test]
     // Simulate 3 runs of the program and ensure that the order of the deduplicated contacts is stable
     fn test_same_values() {
-        let mut input_1: HashMap<i32, BTreeSet<i32>> = HashMap::new();
+        let mut input_1: MapChatHandle = HashMap::new();
         input_1.insert(1, BTreeSet::from([1]));
         input_1.insert(2, BTreeSet::from([1]));
         input_1.insert(3, BTreeSet::from([1]));
@@ -221,7 +223,7 @@ mod tests {
         input_1.insert(5, BTreeSet::from([2]));
         input_1.insert(6, BTreeSet::from([3]));
 
-        let mut input_2: HashMap<i32, BTreeSet<i32>> = HashMap::new();
+        let mut input_2: MapChatHandle = HashMap::new();
         input_2.insert(1, BTreeSet::from([1]));
         input_2.insert(2, BTreeSet::from([1]));
         input_2.insert(3, BTreeSet::from([1]));
@@ -229,7 +231,7 @@ mod tests {
         input_2.insert(5, BTreeSet::from([2]));
         input_2.insert(6, BTreeSet::from([3]));
 
-        let mut input_3: HashMap<i32, BTreeSet<i32>> = HashMap::new();
+        let mut input_3: MapChatHandle = HashMap::new();
         input_3.insert(1, BTreeSet::from([1]));
         input_3.insert(2, BTreeSet::from([1]));
         input_3.insert(3, BTreeSet::from([1]));

--- a/imessage-database/src/util/query_context.rs
+++ b/imessage-database/src/util/query_context.rs
@@ -15,6 +15,8 @@ pub struct QueryContext {
     pub start: Option<i64>,
     /// The end date filter. Only messages sent before this date will be included.
     pub end: Option<i64>,
+    /// Telephone filter. Only messages including this number will be included.
+    pub telephone: Option<String>,
 }
 
 impl QueryContext {
@@ -50,6 +52,25 @@ impl QueryContext {
         Ok(())
     }
 
+    /// Generate a `QueryContext` with a telephone number.
+    /// # Example:
+    ///
+    /// ```
+    /// use imessage_database::util::query_context::QueryContext;
+    ///
+    /// let mut context = QueryContext::default();
+    /// context.set_telephone("16468885555");
+    /// ```
+    pub fn set_telephone(&mut self, telephone: &str) -> Result<(), QueryContextError> {
+        let tele = QueryContext::sanitize_telephone(telephone)
+            .ok_or(QueryContextError::InvalidTelephone(telephone.to_string()))?;
+
+        let mut number = String::from(tele);
+        number.insert_str(0, "+");
+        self.telephone = Some(number);
+        Ok(())
+    }
+
     /// Ensure a date string is valid
     fn sanitize_date(date: &str) -> Option<i64> {
         if date.len() < 9 {
@@ -80,6 +101,14 @@ impl QueryContext {
         let stamp = local.timestamp_nanos_opt().unwrap_or(0);
 
         Some(stamp - (get_offset() * TIMESTAMP_FACTOR))
+    }
+
+    /// Ensure a telephone string is valid
+    fn sanitize_telephone(telephone: &str) -> Option<&str> {
+        if telephone.len() < 11 {
+            return None;
+        }
+        Some(telephone)
     }
 
     /// Determine if the current `QueryContext` has any filters present
@@ -293,6 +322,24 @@ mod sanitize_tests {
     #[test]
     fn can_reject_wrong_hyphen() {
         let res = QueryContext::sanitize_date("2020–01–01");
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn can_sanitize_good_telephone() {
+        let res = QueryContext::sanitize_telephone("16468885555");
+        assert!(res.is_some());
+    }
+
+    #[test]
+    fn can_reject_bad_short_telephone() {
+        let res = QueryContext::sanitize_telephone("1646888555");
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn can_reject_typo_telephone() {
+        let res = QueryContext::sanitize_telephone("1646-8885555");
         assert!(res.is_none());
     }
 }

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -76,6 +76,10 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
 -e, --end-date <YYYY-MM-DD>
         The end date filter
         Only messages sent before this date will be included
+
+-t, --telephone <XXXXXXXXXXX>
+        The telephone filter
+        Only messages associated with this number will be included
         
 -l, --no-lazy
         Do not include `loading="lazy"` in HTML export `img` tags
@@ -135,6 +139,10 @@ Export messages from `2020-01-01` to `2020-12-31` as `txt` from the default macO
 
 ```zsh
 imessage-exporter -f txt -o ~/export-2020 -s 2020-01-01 -e 2021-01-01 -a macOS
+```
+
+```zsh
+imessage-exporter -f html -s 2024-10-15 -t 16468885555
 ```
 
 ## Features

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -433,7 +433,7 @@ fn get_command() -> Command {
                 .long(OPTION_TELEPHONE)
                 .help("The telephone filter\nOnly messages including this telephone number will be included\n")
                 .display_order(13)
-                .value_name("+16468885555"),
+                .value_name("16468885555"),
         )
 }
 
@@ -566,7 +566,7 @@ mod arg_tests {
     #[test]
     fn cant_build_option_diagnostic_flag_with_telephone() {
         // Get matches from sample args
-        let cli_args: Vec<&str> = vec!["imessage-exporter", "-d", "-t", "+16468885555"];
+        let cli_args: Vec<&str> = vec!["imessage-exporter", "-d", "-t", "16468885555"];
         let command = get_command();
         let args = command.get_matches_from(cli_args);
 
@@ -819,7 +819,7 @@ mod arg_tests {
     #[test]
     fn cant_build_option_telephone_path_no_export_type() {
         // Get matches from sample args
-        let cli_args: Vec<&str> = vec!["imessage-exporter", "-t", "+16468885555"];
+        let cli_args: Vec<&str> = vec!["imessage-exporter", "-t", "16468885555"];
         let command = get_command();
         let args = command.get_matches_from(cli_args);
 

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -32,6 +32,7 @@ pub const OPTION_CUSTOM_NAME: &str = "custom-name";
 pub const OPTION_PLATFORM: &str = "platform";
 pub const OPTION_BYPASS_FREE_SPACE_CHECK: &str = "ignore-disk-warning";
 pub const OPTION_USE_CALLER_ID: &str = "use-caller-id";
+pub const OPTION_TELEPHONE: &str = "telephone";
 
 // Other CLI Text
 pub const SUPPORTED_FILE_TYPES: &str = "txt, html";
@@ -86,6 +87,7 @@ impl Options {
         let use_caller_id = args.get_flag(OPTION_USE_CALLER_ID);
         let platform_type: Option<&String> = args.get_one(OPTION_PLATFORM);
         let ignore_disk_space = args.get_flag(OPTION_BYPASS_FREE_SPACE_CHECK);
+        let telephone: Option<&String> = args.get_one(OPTION_TELEPHONE);
 
         // Build the export type
         let export_type: Option<ExportType> = match export_file_type {
@@ -121,6 +123,11 @@ impl Options {
         if use_caller_id && export_file_type.is_none() {
             return Err(RuntimeError::InvalidOptions(format!(
                 "Option {OPTION_USE_CALLER_ID} is enabled, which requires `--{OPTION_EXPORT_TYPE}`"
+            )));
+        }
+        if telephone.is_some() && export_file_type.is_none() {
+            return Err(RuntimeError::InvalidOptions(format!(
+                "Option {OPTION_TELEPHONE} is enabled, which requires `--{OPTION_EXPORT_TYPE}`"
             )));
         }
 
@@ -162,6 +169,11 @@ impl Options {
                 "Diagnostics are enabled; {OPTION_USE_CALLER_ID} is disallowed"
             )));
         }
+        if diagnostic && telephone.is_some() {
+            return Err(RuntimeError::InvalidOptions(format!(
+                "Diagnostics are enabled; {OPTION_TELEPHONE} is disallowed"
+            )));
+        }
 
         // Ensure that there are no custom name conflicts
         if custom_name.is_some() && use_caller_id {
@@ -179,6 +191,11 @@ impl Options {
         }
         if let Some(end) = end_date {
             if let Err(why) = query_context.set_end(end) {
+                return Err(RuntimeError::InvalidOptions(format!("{why}")));
+            }
+        }
+        if let Some(telephone) = telephone {
+            if let Err(why) = query_context.set_telephone(telephone) {
                 return Err(RuntimeError::InvalidOptions(format!("{why}")));
             }
         }
@@ -410,6 +427,14 @@ fn get_command() -> Command {
                 .action(ArgAction::SetTrue)
                 .display_order(12)
         )
+        .arg(
+            Arg::new(OPTION_TELEPHONE)
+                .short('t')
+                .long(OPTION_TELEPHONE)
+                .help("The telephone filter\nOnly messages including this telephone number will be included\n")
+                .display_order(13)
+                .value_name("+16468885555"),
+        )
 }
 
 /// Parse arguments from the command line
@@ -529,6 +554,19 @@ mod arg_tests {
     fn cant_build_option_diagnostic_flag_with_caller_id() {
         // Get matches from sample args
         let cli_args: Vec<&str> = vec!["imessage-exporter", "-d", "-i"];
+        let command = get_command();
+        let args = command.get_matches_from(cli_args);
+
+        // Build the Options
+        let actual = Options::from_args(&args);
+
+        assert!(actual.is_err());
+    }
+
+    #[test]
+    fn cant_build_option_diagnostic_flag_with_telephone() {
+        // Get matches from sample args
+        let cli_args: Vec<&str> = vec!["imessage-exporter", "-d", "-t", "+16468885555"];
         let command = get_command();
         let args = command.get_matches_from(cli_args);
 
@@ -769,6 +807,19 @@ mod arg_tests {
     fn cant_build_option_caller_id_no_export() {
         // Get matches from sample args
         let cli_args: Vec<&str> = vec!["imessage-exporter", "-f", "txt", "-m", "Name", "-i"];
+        let command = get_command();
+        let args = command.get_matches_from(cli_args);
+
+        // Build the Options
+        let actual = Options::from_args(&args);
+
+        assert!(actual.is_err());
+    }
+
+    #[test]
+    fn cant_build_option_telephone_path_no_export_type() {
+        // Get matches from sample args
+        let cli_args: Vec<&str> = vec!["imessage-exporter", "-t", "+16468885555"];
         let command = get_command();
         let args = command.get_matches_from(cli_args);
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -227,7 +227,7 @@ impl Config {
             AttachmentManager::Efficient => None,
         };
 
-        Ok(Config {
+        let mut config = Config {
             chatrooms,
             real_chatrooms: ChatToHandle::dedupe(&chatroom_participants),
             chatroom_participants,
@@ -238,7 +238,12 @@ impl Config {
             offset: get_offset(),
             db: conn,
             converter,
-        })
+        };
+
+        let telephone = config.options.query_context.telephone.clone().unwrap();
+        config.participants.retain(|_, v| *v == telephone);
+
+        Ok(config)
     }
 
     /// Ensure there is available disk space for the requested export


### PR DESCRIPTION
Updated with most recent code. I solved #61 with my limited understanding of the CLI arguments and _chat handles_. This relies on a telephone number. And the number isn't thoroughly sanitized. I presented a North American telephony bias here. If this can be improved or better documented by the maintainer, then I can improve the feature by including an e-mail address. It's challenging to navigate the code of another person.

I successfully isolated a chat from _iMessage_ on my laptop. There is probably a cleaner way to do this, but this works. I still don't understand how to setup the test data to prove this with a test, so I proved it locally. One of the three unit tests also fails, because I didn't invest the energy into validating the telephony number format. Initially, I used a conversion to _i64_ as a measure of validation, but that became irrelevant when I retained the telephone number as a _String_.