### PR TITLE
Feat/cs/choose conversations

### DIFF
--- a/imessage-database/src/tables/messages/body.rs
+++ b/imessage-database/src/tables/messages/body.rs
@@ -307,46 +307,9 @@ mod typedstream_tests {
         util::typedstream::parser::TypedStreamReader,
     };
 
-    pub(super) fn blank() -> Message {
-        Message {
-            rowid: i32::default(),
-            guid: String::default(),
-            text: None,
-            service: Some("iMessage".to_string()),
-            handle_id: Some(i32::default()),
-            destination_caller_id: None,
-            subject: None,
-            date: i64::default(),
-            date_read: i64::default(),
-            date_delivered: i64::default(),
-            is_from_me: false,
-            is_read: false,
-            item_type: 0,
-            other_handle: 0,
-            share_status: false,
-            share_direction: false,
-            group_title: None,
-            group_action_type: 0,
-            associated_message_guid: None,
-            associated_message_type: Some(i32::default()),
-            balloon_bundle_id: None,
-            expressive_send_style_id: None,
-            thread_originator_guid: None,
-            thread_originator_part: None,
-            date_edited: 0,
-            associated_message_emoji: None,
-            chat_id: None,
-            num_attachments: 0,
-            deleted_from: None,
-            num_replies: 0,
-            components: None,
-            edited_parts: None,
-        }
-    }
-
     #[test]
     fn can_get_message_body_simple() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Noter test".to_string());
 
         let typedstream_path = current_dir()
@@ -372,7 +335,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_app() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("\u{FFFC}".to_string());
 
         let typedstream_path = current_dir()
@@ -396,7 +359,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_simple_two() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Test 3".to_string());
 
         let typedstream_path = current_dir()
@@ -422,7 +385,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_multi_part() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("\u{FFFC}test 1\u{FFFC}test 2 \u{FFFC}test 3".to_string());
 
         let typedstream_path = current_dir()
@@ -451,7 +414,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_multi_part_deleted() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some(
             "From arbitrary byte stream:\r\u{FFFC}To native Rust data structures:\r".to_string(),
         );
@@ -479,7 +442,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_multi_part_deleted_edited() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some(
             "From arbitrary byte stream:\r\u{FFFC}To native Rust data structures:\r".to_string(),
         );
@@ -536,7 +499,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_attachment() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some(
             "\u{FFFC}This is how the notes look to me fyi, in case it helps make sense of anything"
                 .to_string(),
@@ -564,7 +527,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_attachment_i16() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("\u{FFFC}".to_string());
 
         let typedstream_path = current_dir()
@@ -588,7 +551,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_url() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("https://twitter.com/xxxxxxxxx/status/0000223300009216128".to_string());
 
         let typedstream_path = current_dir()
@@ -621,7 +584,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_mention() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Test Dad ".to_string());
 
         let typedstream_path = current_dir()
@@ -654,7 +617,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_code() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("000123 is your security code. Don't share your code.".to_string());
 
         let typedstream_path = current_dir()
@@ -686,7 +649,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_phone() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("What about 0000000000".to_string());
 
         let typedstream_path = current_dir()
@@ -718,7 +681,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_email() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("asdfghjklq@gmail.com might work".to_string());
 
         let typedstream_path = current_dir()
@@ -750,7 +713,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_date() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Hi. Right now or tomorrow?".to_string());
 
         let typedstream_path = current_dir()
@@ -783,7 +746,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_custom_tapback() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("".to_string());
 
         let typedstream_path = current_dir()
@@ -815,7 +778,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_deleted_only() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.edited_parts = Some(EditedMessage {
             parts: vec![EditedMessagePart {
                 status: EditStatus::Unsent,
@@ -831,7 +794,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_text_styles() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Bold underline italic strikethrough all four".to_string());
 
         let typedstream_path = current_dir()
@@ -879,7 +842,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_text_effects() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Big small shake nod explode ripple bloom jitter".to_string());
 
         let typedstream_path = current_dir()
@@ -922,7 +885,7 @@ mod typedstream_tests {
 
     #[test]
     fn can_get_message_body_text_effects_styles_mixed() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Underline normal jitter normal".to_string());
 
         let typedstream_path = current_dir()
@@ -957,19 +920,18 @@ mod typedstream_tests {
 
 #[cfg(test)]
 mod legacy_tests {
-    use super::typedstream_tests::blank;
-
     use crate::{
         message_types::text_effects::TextEffect,
         tables::messages::{
             body::parse_body_legacy,
             models::{BubbleComponent, TextAttributes},
+            Message,
         },
     };
 
     #[test]
     fn can_get_message_body_single_emoji() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("🙈".to_string());
         assert_eq!(
             parse_body_legacy(&m),
@@ -983,7 +945,7 @@ mod legacy_tests {
 
     #[test]
     fn can_get_message_body_multiple_emoji() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("🙈🙈🙈".to_string());
         assert_eq!(
             parse_body_legacy(&m),
@@ -997,7 +959,7 @@ mod legacy_tests {
 
     #[test]
     fn can_get_message_body_text_only() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("Hello world".to_string());
         assert_eq!(
             parse_body_legacy(&m),
@@ -1011,7 +973,7 @@ mod legacy_tests {
 
     #[test]
     fn can_get_message_body_attachment_text() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("\u{FFFC}Hello world".to_string());
         assert_eq!(
             parse_body_legacy(&m),
@@ -1024,7 +986,7 @@ mod legacy_tests {
 
     #[test]
     fn can_get_message_body_app_text() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("\u{FFFD}Hello world".to_string());
         assert_eq!(
             parse_body_legacy(&m),
@@ -1037,7 +999,7 @@ mod legacy_tests {
 
     #[test]
     fn can_get_message_body_app_attachment_text_mixed_start_text() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("One\u{FFFD}\u{FFFC}Two\u{FFFC}Three\u{FFFC}four".to_string());
         assert_eq!(
             parse_body_legacy(&m),
@@ -1056,7 +1018,7 @@ mod legacy_tests {
 
     #[test]
     fn can_get_message_body_app_attachment_text_mixed_start_app() {
-        let mut m = blank();
+        let mut m = Message::blank();
         m.text = Some("\u{FFFD}\u{FFFC}Two\u{FFFC}Three\u{FFFC}".to_string());
         assert_eq!(
             parse_body_legacy(&m),

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -622,6 +622,41 @@ impl Message {
         0
     }
 
+    /// Generate the SQL `WHERE` clause described by a [`QueryContext`]
+    pub(crate) fn generate_filter_statement(context: &QueryContext) -> String {
+        let mut filters = String::new();
+        if let Some(start) = context.start {
+            filters.push_str(&format!("    m.date >= {start}"));
+        }
+        if let Some(end) = context.end {
+            if !filters.is_empty() {
+                filters.push_str(" AND ");
+            }
+            filters.push_str(&format!("    m.date <= {end}"));
+        }
+        if let Some(chat_ids) = &context.selected_handle_ids {
+            if !filters.is_empty() {
+                filters.push_str(" AND ");
+            }
+            filters.push_str(&format!(
+                "    m.chat_id IN ({})",
+                chat_ids
+                    .iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", "),
+            ));
+        }
+
+        if !filters.is_empty() {
+            return format!(
+                " WHERE
+                 {filters}"
+            );
+        }
+        filters
+    }
+
     /// Get the number of messages in the database
     ///
     /// # Example:
@@ -641,7 +676,7 @@ impl Message {
         let mut statement = if context.has_filters() {
             db.prepare(&format!(
                 "SELECT COUNT(*) FROM {MESSAGE} as m {}",
-                context.generate_filter_statement("m.date")
+                Self::generate_filter_statement(context)
             ))
             .map_err(TableError::Messages)?
         } else {
@@ -676,7 +711,7 @@ impl Message {
             return Self::get(db);
         }
 
-        let filters = context.generate_filter_statement("m.date");
+        let filters = Self::generate_filter_statement(context);
 
         // If database has `thread_originator_guid`, we can parse replies, otherwise default to 0
         Ok(db.prepare(&format!(
@@ -712,7 +747,7 @@ impl Message {
     }
 
     /// See [`Tapback`] for details on this data.
-    fn clean_associated_guid(&self) -> Option<(usize, &str)> {
+    pub(crate) fn clean_associated_guid(&self) -> Option<(usize, &str)> {
         if let Some(guid) = &self.associated_message_guid {
             if guid.starts_with("p:") {
                 let mut split = guid.split('/');
@@ -828,7 +863,7 @@ impl Message {
     ///
     /// For example, a Bundle ID like `com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.SafetyMonitorApp.SafetyMonitorMessages`
     /// should get parsed into `com.apple.SafetyMonitorApp.SafetyMonitorMessages`.
-    fn parse_balloon_bundle_id(&self) -> Option<&str> {
+    pub(crate) fn parse_balloon_bundle_id(&self) -> Option<&str> {
         if let Some(bundle_id) = &self.balloon_bundle_id {
             let mut parts = bundle_id.split(':');
             let bundle_id = parts.next();
@@ -1064,18 +1099,8 @@ impl Message {
 }
 
 #[cfg(test)]
-mod tests {
-    use crate::{
-        message_types::{
-            edited::{EditStatus, EditedMessage, EditedMessagePart},
-            expressives,
-            variants::{CustomBalloon, Variant},
-        },
-        tables::messages::Message,
-        util::dates::get_offset,
-    };
-
-    fn blank() -> Message {
+impl Message {
+    pub fn blank() -> Message {
         Message {
             rowid: i32::default(),
             guid: String::default(),
@@ -1110,299 +1135,5 @@ mod tests {
             components: None,
             edited_parts: None,
         }
-    }
-
-    #[test]
-    fn can_gen_message() {
-        blank();
-    }
-
-    #[test]
-    fn can_get_time_date_read_after_date() {
-        // Get offset
-        let offset = get_offset();
-
-        // Create message
-        let mut message = blank();
-        // May 17, 2022  8:29:42 PM
-        message.date = 674526582885055488;
-        // May 17, 2022  8:29:42 PM
-        message.date_delivered = 674526582885055488;
-        // May 17, 2022  9:30:31 PM
-        message.date_read = 674530231992568192;
-
-        assert_eq!(
-            message.time_until_read(&offset),
-            Some("1 hour, 49 seconds".to_string())
-        );
-    }
-
-    #[test]
-    fn can_get_time_date_read_before_date() {
-        // Get offset
-        let offset = get_offset();
-
-        // Create message
-        let mut message = blank();
-        // May 17, 2022  9:30:31 PM
-        message.date = 674530231992568192;
-        // May 17, 2022  9:30:31 PM
-        message.date_delivered = 674530231992568192;
-        // May 17, 2022  8:29:42 PM
-        message.date_read = 674526582885055488;
-
-        assert_eq!(message.time_until_read(&offset), None);
-    }
-
-    #[test]
-    fn can_get_message_expression_none() {
-        let m = blank();
-        assert_eq!(m.get_expressive(), expressives::Expressive::None);
-    }
-
-    #[test]
-    fn can_get_message_expression_bubble() {
-        let mut m = blank();
-        m.expressive_send_style_id = Some("com.apple.MobileSMS.expressivesend.gentle".to_string());
-        assert_eq!(
-            m.get_expressive(),
-            expressives::Expressive::Bubble(expressives::BubbleEffect::Gentle)
-        );
-    }
-
-    #[test]
-    fn can_get_message_expression_screen() {
-        let mut m = blank();
-        m.expressive_send_style_id =
-            Some("com.apple.messages.effect.CKHappyBirthdayEffect".to_string());
-        assert_eq!(
-            m.get_expressive(),
-            expressives::Expressive::Screen(expressives::ScreenEffect::Balloons)
-        );
-    }
-
-    #[test]
-    fn can_get_no_balloon_bundle_id() {
-        let m = blank();
-        assert_eq!(m.parse_balloon_bundle_id(), None);
-    }
-
-    #[test]
-    fn can_get_balloon_bundle_id_os() {
-        let mut m = blank();
-        m.balloon_bundle_id = Some("com.apple.Handwriting.HandwritingProvider".to_owned());
-        assert_eq!(
-            m.parse_balloon_bundle_id(),
-            Some("com.apple.Handwriting.HandwritingProvider")
-        );
-    }
-
-    #[test]
-    fn can_get_balloon_bundle_id_url() {
-        let mut m = blank();
-        m.balloon_bundle_id = Some("com.apple.messages.URLBalloonProvider".to_owned());
-        assert_eq!(
-            m.parse_balloon_bundle_id(),
-            Some("com.apple.messages.URLBalloonProvider")
-        );
-    }
-
-    #[test]
-    fn can_get_balloon_bundle_id_apple() {
-        let mut m = blank();
-        m.balloon_bundle_id = Some("com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.PassbookUIService.PeerPaymentMessagesExtension".to_owned());
-        assert_eq!(
-            m.parse_balloon_bundle_id(),
-            Some("com.apple.PassbookUIService.PeerPaymentMessagesExtension")
-        );
-    }
-
-    #[test]
-    fn can_get_balloon_bundle_id_third_party() {
-        let mut m = blank();
-        m.balloon_bundle_id = Some("com.apple.messages.MSMessageExtensionBalloonPlugin:QPU8QS3E62:com.contextoptional.OpenTable.Messages".to_owned());
-        assert_eq!(
-            m.parse_balloon_bundle_id(),
-            Some("com.contextoptional.OpenTable.Messages")
-        );
-        assert!(matches!(
-            m.variant(),
-            Variant::App(CustomBalloon::Application(
-                "com.contextoptional.OpenTable.Messages"
-            ))
-        ));
-    }
-
-    #[test]
-    fn can_get_valid_guid() {
-        let mut m = blank();
-        m.associated_message_guid = Some("A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A".to_string());
-
-        assert_eq!(
-            Some((0usize, "A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A")),
-            m.clean_associated_guid()
-        );
-    }
-
-    #[test]
-    fn cant_get_invalid_guid() {
-        let mut m = blank();
-        m.associated_message_guid = Some("FAKE_GUID".to_string());
-
-        assert_eq!(None, m.clean_associated_guid());
-    }
-
-    #[test]
-    fn can_get_valid_guid_p() {
-        let mut m = blank();
-        m.associated_message_guid = Some("p:1/A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A".to_string());
-
-        assert_eq!(
-            Some((1usize, "A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A")),
-            m.clean_associated_guid()
-        );
-    }
-
-    #[test]
-    fn cant_get_invalid_guid_p() {
-        let mut m = blank();
-        m.associated_message_guid = Some("p:1/FAKE_GUID".to_string());
-
-        assert_eq!(None, m.clean_associated_guid());
-    }
-
-    #[test]
-    fn can_get_valid_guid_bp() {
-        let mut m = blank();
-        m.associated_message_guid = Some("bp:A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A".to_string());
-
-        assert_eq!(
-            Some((0usize, "A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A")),
-            m.clean_associated_guid()
-        );
-    }
-
-    #[test]
-    fn cant_get_invalid_guid_bp() {
-        let mut m = blank();
-        m.associated_message_guid = Some("bp:FAKE_GUID".to_string());
-
-        assert_eq!(None, m.clean_associated_guid());
-    }
-
-    #[test]
-    fn can_get_fully_unsent_true_single() {
-        let mut m = blank();
-        m.edited_parts = Some(EditedMessage {
-            parts: vec![EditedMessagePart {
-                status: EditStatus::Unsent,
-                edit_history: vec![],
-            }],
-        });
-
-        assert!(m.is_fully_unsent());
-    }
-
-    #[test]
-    fn can_get_fully_unsent_true_multiple() {
-        let mut m = blank();
-        m.edited_parts = Some(EditedMessage {
-            parts: vec![
-                EditedMessagePart {
-                    status: EditStatus::Unsent,
-                    edit_history: vec![],
-                },
-                EditedMessagePart {
-                    status: EditStatus::Unsent,
-                    edit_history: vec![],
-                },
-            ],
-        });
-
-        assert!(m.is_fully_unsent());
-    }
-
-    #[test]
-    fn can_get_fully_unsent_false() {
-        let mut m = blank();
-        m.edited_parts = Some(EditedMessage {
-            parts: vec![EditedMessagePart {
-                status: EditStatus::Original,
-                edit_history: vec![],
-            }],
-        });
-
-        assert!(!m.is_fully_unsent());
-    }
-
-    #[test]
-    fn can_get_fully_unsent_false_multiple() {
-        let mut m = blank();
-        m.edited_parts = Some(EditedMessage {
-            parts: vec![
-                EditedMessagePart {
-                    status: EditStatus::Unsent,
-                    edit_history: vec![],
-                },
-                EditedMessagePart {
-                    status: EditStatus::Original,
-                    edit_history: vec![],
-                },
-            ],
-        });
-
-        assert!(!m.is_fully_unsent());
-    }
-
-    #[test]
-    fn can_get_part_edited_true() {
-        let mut m = blank();
-        m.edited_parts = Some(EditedMessage {
-            parts: vec![
-                EditedMessagePart {
-                    status: EditStatus::Edited,
-                    edit_history: vec![],
-                },
-                EditedMessagePart {
-                    status: EditStatus::Original,
-                    edit_history: vec![],
-                },
-            ],
-        });
-
-        assert!(m.is_part_edited(0));
-    }
-
-    #[test]
-    fn can_get_part_edited_false() {
-        let mut m = blank();
-        m.edited_parts = Some(EditedMessage {
-            parts: vec![
-                EditedMessagePart {
-                    status: EditStatus::Edited,
-                    edit_history: vec![],
-                },
-                EditedMessagePart {
-                    status: EditStatus::Original,
-                    edit_history: vec![],
-                },
-            ],
-        });
-
-        assert!(!m.is_part_edited(1));
-    }
-
-    #[test]
-    fn can_get_part_edited_blank() {
-        let m = blank();
-
-        assert!(!m.is_part_edited(0));
-    }
-
-    #[test]
-    fn can_get_fully_unsent_none() {
-        let m = blank();
-
-        assert!(!m.is_fully_unsent());
     }
 }

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -157,7 +157,7 @@ impl Table for Message {
                  (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
              FROM
                  message as m
-                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+             LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
              ORDER BY
                  m.date;
             "
@@ -171,7 +171,7 @@ impl Table for Message {
                  (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
              FROM
                  message as m
-                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+             LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
              ORDER BY
                  m.date;
             "
@@ -186,7 +186,7 @@ impl Table for Message {
                  0 as num_replies
              FROM
                  message as m
-                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+             LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
              ORDER BY
                  m.date;
             "
@@ -225,7 +225,7 @@ impl Diagnostic for Message {
                 COUNT(m.rowid)
             FROM
             {MESSAGE} as m
-                LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.rowid = c.message_id
+            LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.rowid = c.message_id
             WHERE
                 c.chat_id is NULL
             ORDER BY
@@ -318,7 +318,7 @@ impl Cacheable for Message {
                  (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
              FROM 
                  message as m 
-                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+             LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
              WHERE m.associated_message_guid NOT NULL
             "
         ));
@@ -634,12 +634,12 @@ impl Message {
             }
             filters.push_str(&format!("    m.date <= {end}"));
         }
-        if let Some(chat_ids) = &context.selected_handle_ids {
+        if let Some(chat_ids) = &context.selected_chat_ids {
             if !filters.is_empty() {
                 filters.push_str(" AND ");
             }
             filters.push_str(&format!(
-                "    m.chat_id IN ({})",
+                "    c.chat_id IN ({})",
                 chat_ids
                     .iter()
                     .map(|x| x.to_string())
@@ -675,7 +675,11 @@ impl Message {
     pub fn get_count(db: &Connection, context: &QueryContext) -> Result<u64, TableError> {
         let mut statement = if context.has_filters() {
             db.prepare(&format!(
-                "SELECT COUNT(*) FROM {MESSAGE} as m {}",
+                "SELECT 
+                    COUNT(*) 
+                 FROM {MESSAGE} as m
+                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+                 {}",
                 Self::generate_filter_statement(context)
             ))
             .map_err(TableError::Messages)?
@@ -723,7 +727,7 @@ impl Message {
                      (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
                  FROM
                      message as m
-                     LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
                  {filters}
                  ORDER BY
                      m.date;
@@ -738,7 +742,7 @@ impl Message {
                      (SELECT 0) as num_replies
                  FROM
                      message as m
-                     LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
                  {filters}
                  ORDER BY
                      m.date;
@@ -790,7 +794,7 @@ impl Message {
                         (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
                     FROM 
                         message as m 
-                        LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+                    LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
                     WHERE m.guid IN ({})
                     ORDER BY 
                         m.date;
@@ -832,7 +836,7 @@ impl Message {
                      (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
                  FROM 
                      message as m 
-                     LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id 
+                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id 
                  WHERE m.thread_originator_guid = \"{}\"
                  ORDER BY 
                      m.date;

--- a/imessage-database/src/tables/messages/mod.rs
+++ b/imessage-database/src/tables/messages/mod.rs
@@ -7,3 +7,4 @@ pub use message::Message;
 pub(crate) mod body;
 pub mod message;
 pub mod models;
+mod tests;

--- a/imessage-database/src/tables/messages/tests/bundle_id_tests.rs
+++ b/imessage-database/src/tables/messages/tests/bundle_id_tests.rs
@@ -1,0 +1,59 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        message_types::variants::{CustomBalloon, Variant},
+        tables::messages::Message,
+    };
+
+    #[test]
+    fn can_get_no_balloon_bundle_id() {
+        let m = Message::blank();
+        assert_eq!(m.parse_balloon_bundle_id(), None);
+    }
+
+    #[test]
+    fn can_get_balloon_bundle_id_os() {
+        let mut m = Message::blank();
+        m.balloon_bundle_id = Some("com.apple.Handwriting.HandwritingProvider".to_owned());
+        assert_eq!(
+            m.parse_balloon_bundle_id(),
+            Some("com.apple.Handwriting.HandwritingProvider")
+        );
+    }
+
+    #[test]
+    fn can_get_balloon_bundle_id_url() {
+        let mut m = Message::blank();
+        m.balloon_bundle_id = Some("com.apple.messages.URLBalloonProvider".to_owned());
+        assert_eq!(
+            m.parse_balloon_bundle_id(),
+            Some("com.apple.messages.URLBalloonProvider")
+        );
+    }
+
+    #[test]
+    fn can_get_balloon_bundle_id_apple() {
+        let mut m = Message::blank();
+        m.balloon_bundle_id = Some("com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.PassbookUIService.PeerPaymentMessagesExtension".to_owned());
+        assert_eq!(
+            m.parse_balloon_bundle_id(),
+            Some("com.apple.PassbookUIService.PeerPaymentMessagesExtension")
+        );
+    }
+
+    #[test]
+    fn can_get_balloon_bundle_id_third_party() {
+        let mut m = Message::blank();
+        m.balloon_bundle_id = Some("com.apple.messages.MSMessageExtensionBalloonPlugin:QPU8QS3E62:com.contextoptional.OpenTable.Messages".to_owned());
+        assert_eq!(
+            m.parse_balloon_bundle_id(),
+            Some("com.contextoptional.OpenTable.Messages")
+        );
+        assert!(matches!(
+            m.variant(),
+            Variant::App(CustomBalloon::Application(
+                "com.contextoptional.OpenTable.Messages"
+            ))
+        ));
+    }
+}

--- a/imessage-database/src/tables/messages/tests/date_tests.rs
+++ b/imessage-database/src/tables/messages/tests/date_tests.rs
@@ -1,0 +1,42 @@
+#[cfg(test)]
+mod tests {
+
+    use crate::{tables::messages::Message, util::dates::get_offset};
+
+    #[test]
+    fn can_get_time_date_read_after_date() {
+        // Get offset
+        let offset = get_offset();
+
+        // Create message
+        let mut message = Message::blank();
+        // May 17, 2022  8:29:42 PM
+        message.date = 674526582885055488;
+        // May 17, 2022  8:29:42 PM
+        message.date_delivered = 674526582885055488;
+        // May 17, 2022  9:30:31 PM
+        message.date_read = 674530231992568192;
+
+        assert_eq!(
+            message.time_until_read(&offset),
+            Some("1 hour, 49 seconds".to_string())
+        );
+    }
+
+    #[test]
+    fn can_get_time_date_read_before_date() {
+        // Get offset
+        let offset = get_offset();
+
+        // Create message
+        let mut message = Message::blank();
+        // May 17, 2022  9:30:31 PM
+        message.date = 674530231992568192;
+        // May 17, 2022  9:30:31 PM
+        message.date_delivered = 674530231992568192;
+        // May 17, 2022  8:29:42 PM
+        message.date_read = 674526582885055488;
+
+        assert_eq!(message.time_until_read(&offset), None);
+    }
+}

--- a/imessage-database/src/tables/messages/tests/edited_tests.rs
+++ b/imessage-database/src/tables/messages/tests/edited_tests.rs
@@ -1,0 +1,123 @@
+#[cfg(test)]
+mod tests {
+    use crate::{
+        message_types::edited::{EditStatus, EditedMessage, EditedMessagePart},
+        tables::messages::Message,
+    };
+
+    #[test]
+    fn can_get_fully_unsent_true_single() {
+        let mut m = Message::blank();
+        m.edited_parts = Some(EditedMessage {
+            parts: vec![EditedMessagePart {
+                status: EditStatus::Unsent,
+                edit_history: vec![],
+            }],
+        });
+
+        assert!(m.is_fully_unsent());
+    }
+
+    #[test]
+    fn can_get_fully_unsent_true_multiple() {
+        let mut m = Message::blank();
+        m.edited_parts = Some(EditedMessage {
+            parts: vec![
+                EditedMessagePart {
+                    status: EditStatus::Unsent,
+                    edit_history: vec![],
+                },
+                EditedMessagePart {
+                    status: EditStatus::Unsent,
+                    edit_history: vec![],
+                },
+            ],
+        });
+
+        assert!(m.is_fully_unsent());
+    }
+
+    #[test]
+    fn can_get_fully_unsent_false() {
+        let mut m = Message::blank();
+        m.edited_parts = Some(EditedMessage {
+            parts: vec![EditedMessagePart {
+                status: EditStatus::Original,
+                edit_history: vec![],
+            }],
+        });
+
+        assert!(!m.is_fully_unsent());
+    }
+
+    #[test]
+    fn can_get_fully_unsent_false_multiple() {
+        let mut m = Message::blank();
+        m.edited_parts = Some(EditedMessage {
+            parts: vec![
+                EditedMessagePart {
+                    status: EditStatus::Unsent,
+                    edit_history: vec![],
+                },
+                EditedMessagePart {
+                    status: EditStatus::Original,
+                    edit_history: vec![],
+                },
+            ],
+        });
+
+        assert!(!m.is_fully_unsent());
+    }
+
+    #[test]
+    fn can_get_part_edited_true() {
+        let mut m = Message::blank();
+        m.edited_parts = Some(EditedMessage {
+            parts: vec![
+                EditedMessagePart {
+                    status: EditStatus::Edited,
+                    edit_history: vec![],
+                },
+                EditedMessagePart {
+                    status: EditStatus::Original,
+                    edit_history: vec![],
+                },
+            ],
+        });
+
+        assert!(m.is_part_edited(0));
+    }
+
+    #[test]
+    fn can_get_part_edited_false() {
+        let mut m = Message::blank();
+        m.edited_parts = Some(EditedMessage {
+            parts: vec![
+                EditedMessagePart {
+                    status: EditStatus::Edited,
+                    edit_history: vec![],
+                },
+                EditedMessagePart {
+                    status: EditStatus::Original,
+                    edit_history: vec![],
+                },
+            ],
+        });
+
+        assert!(!m.is_part_edited(1));
+    }
+
+    #[test]
+    fn can_get_part_edited_blank() {
+        let m = Message::blank();
+
+        assert!(!m.is_part_edited(0));
+    }
+
+    #[test]
+    fn can_get_fully_unsent_none() {
+        let m = Message::blank();
+
+        assert!(!m.is_fully_unsent());
+    }
+}

--- a/imessage-database/src/tables/messages/tests/expressive_tests.rs
+++ b/imessage-database/src/tables/messages/tests/expressive_tests.rs
@@ -1,0 +1,31 @@
+#[cfg(test)]
+mod tests {
+    use crate::{message_types::expressives, tables::messages::Message};
+
+    #[test]
+    fn can_get_message_expression_none() {
+        let m = Message::blank();
+        assert_eq!(m.get_expressive(), expressives::Expressive::None);
+    }
+
+    #[test]
+    fn can_get_message_expression_bubble() {
+        let mut m = Message::blank();
+        m.expressive_send_style_id = Some("com.apple.MobileSMS.expressivesend.gentle".to_string());
+        assert_eq!(
+            m.get_expressive(),
+            expressives::Expressive::Bubble(expressives::BubbleEffect::Gentle)
+        );
+    }
+
+    #[test]
+    fn can_get_message_expression_screen() {
+        let mut m = Message::blank();
+        m.expressive_send_style_id =
+            Some("com.apple.messages.effect.CKHappyBirthdayEffect".to_string());
+        assert_eq!(
+            m.get_expressive(),
+            expressives::Expressive::Screen(expressives::ScreenEffect::Balloons)
+        );
+    }
+}

--- a/imessage-database/src/tables/messages/tests/guid_tests.rs
+++ b/imessage-database/src/tables/messages/tests/guid_tests.rs
@@ -1,0 +1,61 @@
+#[cfg(test)]
+mod tests {
+    use crate::tables::messages::Message;
+
+    #[test]
+    fn can_get_valid_guid() {
+        let mut m = Message::blank();
+        m.associated_message_guid = Some("A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A".to_string());
+
+        assert_eq!(
+            Some((0usize, "A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A")),
+            m.clean_associated_guid()
+        );
+    }
+
+    #[test]
+    fn cant_get_invalid_guid() {
+        let mut m = Message::blank();
+        m.associated_message_guid = Some("FAKE_GUID".to_string());
+
+        assert_eq!(None, m.clean_associated_guid());
+    }
+
+    #[test]
+    fn can_get_valid_guid_p() {
+        let mut m = Message::blank();
+        m.associated_message_guid = Some("p:1/A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A".to_string());
+
+        assert_eq!(
+            Some((1usize, "A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A")),
+            m.clean_associated_guid()
+        );
+    }
+
+    #[test]
+    fn cant_get_invalid_guid_p() {
+        let mut m = Message::blank();
+        m.associated_message_guid = Some("p:1/FAKE_GUID".to_string());
+
+        assert_eq!(None, m.clean_associated_guid());
+    }
+
+    #[test]
+    fn can_get_valid_guid_bp() {
+        let mut m = Message::blank();
+        m.associated_message_guid = Some("bp:A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A".to_string());
+
+        assert_eq!(
+            Some((0usize, "A44CE9D7-AAAA-BBBB-CCCC-23C54E1A9B6A")),
+            m.clean_associated_guid()
+        );
+    }
+
+    #[test]
+    fn cant_get_invalid_guid_bp() {
+        let mut m = Message::blank();
+        m.associated_message_guid = Some("bp:FAKE_GUID".to_string());
+
+        assert_eq!(None, m.clean_associated_guid());
+    }
+}

--- a/imessage-database/src/tables/messages/tests/mod.rs
+++ b/imessage-database/src/tables/messages/tests/mod.rs
@@ -1,0 +1,6 @@
+mod bundle_id_tests;
+mod date_tests;
+mod edited_tests;
+mod expressive_tests;
+mod guid_tests;
+mod query_tests;

--- a/imessage-database/src/tables/messages/tests/query_tests.rs
+++ b/imessage-database/src/tables/messages/tests/query_tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::env::set_var;
+    use std::{collections::BTreeSet, env::set_var};
 
     use crate::{tables::messages::Message, util::query_context::QueryContext};
 
@@ -53,12 +53,12 @@ mod tests {
     #[test]
     fn can_generate_filter_statement_chat_ids() {
         let mut context = QueryContext::default();
-        context.set_selected_handle_ids(vec![1, 2, 3]);
+        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
 
         let statement = Message::generate_filter_statement(&context);
         assert_eq!(
             statement,
-            " WHERE\n                     m.chat_id IN (1, 2, 3)"
+            " WHERE\n                     c.chat_id IN (1, 2, 3)"
         )
     }
 
@@ -67,10 +67,10 @@ mod tests {
         let mut context = QueryContext::default();
         context.set_start("2020-01-01").unwrap();
         context.set_end("2020-02-02").unwrap();
-        context.set_selected_handle_ids(vec![1, 2, 3]);
+        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
 
         let statement = Message::generate_filter_statement(&context);
-        assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000 AND     m.chat_id IN (1, 2, 3)")
+        assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000 AND     c.chat_id IN (1, 2, 3)")
     }
 
     #[test]

--- a/imessage-database/src/tables/messages/tests/query_tests.rs
+++ b/imessage-database/src/tables/messages/tests/query_tests.rs
@@ -1,0 +1,95 @@
+#[cfg(test)]
+mod tests {
+    use std::env::set_var;
+
+    use crate::{tables::messages::Message, util::query_context::QueryContext};
+
+    #[test]
+    fn can_generate_filter_statement_empty() {
+        let context = QueryContext::default();
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(statement, "")
+    }
+
+    #[test]
+    fn can_generate_filter_statement_start() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        context.set_start("2020-01-01").unwrap();
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(
+            statement,
+            " WHERE\n                     m.date >= 599558400000000000"
+        )
+    }
+
+    #[test]
+    fn can_generate_filter_statement_end() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        context.set_end("2020-01-01").unwrap();
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(
+            statement,
+            " WHERE\n                     m.date <= 599558400000000000"
+        )
+    }
+
+    #[test]
+    fn can_generate_filter_statement_start_end() {
+        let mut context = QueryContext::default();
+        context.set_start("2020-01-01").unwrap();
+        context.set_end("2020-02-02").unwrap();
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000")
+    }
+
+    #[test]
+    fn can_generate_filter_statement_chat_ids() {
+        let mut context = QueryContext::default();
+        context.set_selected_handle_ids(vec![1, 2, 3]);
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(
+            statement,
+            " WHERE\n                     m.chat_id IN (1, 2, 3)"
+        )
+    }
+
+    #[test]
+    fn can_generate_filter_statement_start_end_chat_ids() {
+        let mut context = QueryContext::default();
+        context.set_start("2020-01-01").unwrap();
+        context.set_end("2020-02-02").unwrap();
+        context.set_selected_handle_ids(vec![1, 2, 3]);
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000 AND     m.chat_id IN (1, 2, 3)")
+    }
+
+    #[test]
+    fn can_create_invalid_start() {
+        let mut context = QueryContext::default();
+        assert!(context.set_start("2020-13-32").is_err());
+        assert!(!context.has_filters());
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(statement, "");
+    }
+
+    #[test]
+    fn can_create_invalid_end() {
+        let mut context = QueryContext::default();
+        assert!(context.set_end("fake").is_err());
+        assert!(!context.has_filters());
+
+        let statement = Message::generate_filter_statement(&context);
+        assert_eq!(statement, "");
+    }
+}

--- a/imessage-database/src/util/query_context.rs
+++ b/imessage-database/src/util/query_context.rs
@@ -174,10 +174,6 @@ mod use_tests {
         let local = Local.from_utc_datetime(&from_timestamp);
 
         assert_eq!(format(&Ok(local)), "Jan 01, 2020 12:00:00 AM");
-        // assert_eq!(
-        //     context.generate_filter_statement(),
-        //     " WHERE\n                     m.date >= 599558400000000000"
-        // );
         assert!(context.start.is_some());
         assert!(context.end.is_none());
         assert!(context.has_filters());
@@ -198,10 +194,6 @@ mod use_tests {
         let local = Local.from_utc_datetime(&from_timestamp);
 
         assert_eq!(format(&Ok(local)), "Jan 01, 2020 12:00:00 AM");
-        // assert_eq!(
-        //     context.generate_filter_statement(),
-        //     " WHERE\n                     m.date <= 599558400000000000"
-        // );
         assert!(context.start.is_none());
         assert!(context.end.is_some());
         assert!(context.has_filters());
@@ -232,10 +224,6 @@ mod use_tests {
 
         assert_eq!(format(&Ok(local_start)), "Jan 01, 2020 12:00:00 AM");
         assert_eq!(format(&Ok(local_end)), "Feb 02, 2020 12:00:00 AM");
-        // assert_eq!(
-        //     context.generate_filter_statement(),
-        //     " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000"
-        // );
         assert!(context.start.is_some());
         assert!(context.end.is_some());
         assert!(context.has_filters());

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -93,6 +93,12 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         Bypass the disk space check when exporting data
         By default, exports will not run if there is not enough free disk space
         
+-t, --conversation-filter <filter>
+        Filter exported conversations by contact numbers or emails
+        To provide multiple filter criteria, use a comma-separated string
+        All conversations with the specified participants are exported, including group conversations
+        Example: `-t steve@apple.com,5558675309`
+        
 -h, --help
         Print help
 -V, --version
@@ -135,6 +141,30 @@ Export messages from `2020-01-01` to `2020-12-31` as `txt` from the default macO
 
 ```zsh
 imessage-exporter -f txt -o ~/export-2020 -s 2020-01-01 -e 2021-01-01 -a macOS
+```
+
+Export messages from a specific participant as `html` and copy attachments in their original formats from the default iMessage Database location to your home directory:
+
+```zsh
+imessage-exporter -f html -c efficient -t "5558675309"
+```
+
+Export messages from multiple specific participants as `html` without attachments from the default iMessage Database location to your home directory:
+
+```zsh
+imessage-exporter -f html -t "5558675309,steve@apple.com"
+```
+
+Export messages from participants matching a specific country and area code as `html` without attachments from the default iMessage Database location to your home directory:
+
+```zsh
+imessage-exporter -f html -t "+1555"
+```
+
+Export messages from participants using email addresses but not phone numbers as `html` without attachments from the default iMessage Database location to your home directory:
+
+```zsh
+imessage-exporter -f html -t "@"
 ```
 
 ## Features

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -439,7 +439,8 @@ fn get_command() -> Command {
             Arg::new(OPTION_CONVERSATION_FILTER)
                 .short('t')
                 .long(OPTION_CONVERSATION_FILTER)
-                .help("Filter exported conversations by contact numbers or emails\nTo provide multiple filter criteria, use a comma-separated string\nExample: `-t steve@apple.com,5558675309`\n")
+                .help("Filter exported conversations by contact numbers or emails\nTo provide multiple filter criteria, use a comma-separated string\nAll conversations with the specified participants are exported, including group conversations\nExample: `-t steve@apple.com,5558675309`\n")
+                .value_name("filter")
                 .display_order(13)
         )
 }

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -229,7 +229,9 @@ impl Config {
 
         // Update the query context with optionally filtered handle IDs
         // TODO: Convert comma separated list of participant strings into table chat IDs using
-        // TODO:
+        //   1) filter self.participant keys based on the values (by comparing to user values)
+        //   2) get the chat IDs keys from self.chatroom_participants for values that contain the selected handle_ids
+        //   3) send those chat IDs to the query context so they are included in the message table filters
         // let selected_handles: Vec<i64> = todo!();
         options.query_context.set_selected_handle_ids(vec![]);
 
@@ -407,6 +409,57 @@ impl Config {
             offset: get_offset(),
             db: connection,
             converter: Some(crate::app::converter::Converter::Sips),
+        }
+    }
+
+    pub fn fake_message() -> Message {
+        Message {
+            rowid: i32::default(),
+            guid: String::default(),
+            text: None,
+            service: Some("iMessage".to_string()),
+            handle_id: Some(i32::default()),
+            destination_caller_id: None,
+            subject: None,
+            date: i64::default(),
+            date_read: i64::default(),
+            date_delivered: i64::default(),
+            is_from_me: false,
+            is_read: false,
+            item_type: 0,
+            other_handle: 0,
+            share_status: false,
+            share_direction: false,
+            group_title: None,
+            group_action_type: 0,
+            associated_message_guid: None,
+            associated_message_type: Some(i32::default()),
+            balloon_bundle_id: None,
+            expressive_send_style_id: None,
+            thread_originator_guid: None,
+            thread_originator_part: None,
+            date_edited: 0,
+            associated_message_emoji: None,
+            chat_id: None,
+            num_attachments: 0,
+            deleted_from: None,
+            num_replies: 0,
+            components: None,
+            edited_parts: None,
+        }
+    }
+
+    pub(crate) fn fake_attachment() -> Attachment {
+        Attachment {
+            rowid: 0,
+            filename: Some("a/b/c/d.jpg".to_string()),
+            uti: Some("public.png".to_string()),
+            mime_type: Some("image/png".to_string()),
+            transfer_name: Some("d.jpg".to_string()),
+            total_bytes: 100,
+            is_sticker: false,
+            hide_attachment: 0,
+            copied_path: None,
         }
     }
 }
@@ -611,7 +664,7 @@ mod filename_tests {
 #[cfg(test)]
 mod who_tests {
     use crate::{Config, Options};
-    use imessage_database::tables::{chat::Chat, messages::Message};
+    use imessage_database::tables::chat::Chat;
 
     fn fake_chat() -> Chat {
         Chat {
@@ -619,43 +672,6 @@ mod who_tests {
             chat_identifier: "Default".to_string(),
             service_name: Some(String::new()),
             display_name: None,
-        }
-    }
-
-    fn blank() -> Message {
-        Message {
-            rowid: i32::default(),
-            guid: String::default(),
-            text: None,
-            service: Some("iMessage".to_string()),
-            handle_id: Some(i32::default()),
-            destination_caller_id: None,
-            subject: None,
-            date: i64::default(),
-            date_read: i64::default(),
-            date_delivered: i64::default(),
-            is_from_me: false,
-            is_read: false,
-            item_type: 0,
-            other_handle: 0,
-            share_status: false,
-            share_direction: false,
-            group_title: None,
-            group_action_type: 0,
-            associated_message_guid: None,
-            associated_message_type: Some(i32::default()),
-            balloon_bundle_id: None,
-            expressive_send_style_id: None,
-            thread_originator_guid: None,
-            thread_originator_part: None,
-            date_edited: 0,
-            associated_message_emoji: None,
-            chat_id: None,
-            num_attachments: 0,
-            deleted_from: None,
-            num_replies: 0,
-            components: None,
-            edited_parts: None,
         }
     }
 
@@ -758,7 +774,7 @@ mod who_tests {
         app.real_chatrooms.insert(0, 0);
 
         // Create message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.chat_id = Some(0);
 
         // Get filename
@@ -777,7 +793,7 @@ mod who_tests {
         app.real_chatrooms.insert(0, 0);
 
         // Create message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.chat_id = None;
         message.deleted_from = Some(0);
 
@@ -797,7 +813,7 @@ mod who_tests {
         app.real_chatrooms.insert(0, 0);
 
         // Create message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.chat_id = Some(1);
 
         // Get filename
@@ -816,7 +832,7 @@ mod who_tests {
         app.real_chatrooms.insert(0, 0);
 
         // Create message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.chat_id = None;
         message.deleted_from = None;
 

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -1569,25 +1569,16 @@ impl<'a> HTML<'a> {
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashMap,
         env::{current_dir, set_var},
         path::PathBuf,
     };
 
     use crate::{
-        app::attachment_manager::AttachmentManager, exporters::exporter::Writer, Config, Exporter,
-        Options, HTML,
+        app::export_type::ExportType, exporters::exporter::Writer, Config, Exporter, Options, HTML,
     };
     use imessage_database::{
-        tables::{
-            attachment::Attachment,
-            messages::Message,
-            table::{get_connection, ME},
-        },
-        util::{
-            dates::get_offset, dirs::default_db_path, platform::Platform,
-            query_context::QueryContext,
-        },
+        tables::{attachment::Attachment, messages::Message, table::ME},
+        util::platform::Platform,
     };
 
     pub(super) fn blank() -> Message {
@@ -1627,39 +1618,6 @@ mod tests {
         }
     }
 
-    pub(super) fn fake_options() -> Options {
-        Options {
-            db_path: default_db_path(),
-            attachment_root: None,
-            attachment_manager: AttachmentManager::Disabled,
-            diagnostic: false,
-            export_type: None,
-            export_path: PathBuf::from("/tmp"),
-            query_context: QueryContext::default(),
-            no_lazy: false,
-            custom_name: None,
-            use_caller_id: false,
-            platform: Platform::macOS,
-            ignore_disk_space: false,
-        }
-    }
-
-    pub(super) fn fake_config(options: Options) -> Config {
-        let db = get_connection(&options.get_db_path()).unwrap();
-        Config {
-            chatrooms: HashMap::new(),
-            real_chatrooms: HashMap::new(),
-            chatroom_participants: HashMap::new(),
-            participants: HashMap::new(),
-            real_participants: HashMap::new(),
-            tapbacks: HashMap::new(),
-            options,
-            offset: get_offset(),
-            db,
-            converter: None,
-        }
-    }
-
     pub(super) fn fake_attachment() -> Attachment {
         Attachment {
             rowid: 0,
@@ -1676,8 +1634,8 @@ mod tests {
 
     #[test]
     fn can_create() {
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
         assert_eq!(exporter.files.len(), 0);
     }
@@ -1688,9 +1646,9 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
-        // let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
+        // let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         // Create fake message
@@ -1714,8 +1672,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         // Create fake message
@@ -1732,8 +1690,8 @@ mod tests {
     #[test]
     fn can_add_line_no_indent() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         // Create sample data
@@ -1746,8 +1704,8 @@ mod tests {
     #[test]
     fn can_add_line() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         // Create sample data
@@ -1760,8 +1718,8 @@ mod tests {
     #[test]
     fn can_add_line_pre_post() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         // Create sample data
@@ -1777,8 +1735,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -1800,8 +1758,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -1823,8 +1781,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -1846,8 +1804,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -1871,8 +1829,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1896,8 +1854,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1926,9 +1884,9 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let mut options = fake_options();
+        let mut options = Options::fake_options(ExportType::Html);
         options.custom_name = Some("Name".to_string());
-        let mut config = fake_config(options);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1957,8 +1915,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = HTML::new(&config).unwrap();
@@ -1980,8 +1938,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = HTML::new(&config).unwrap();
@@ -2004,9 +1962,9 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let mut options = fake_options();
+        let mut options = Options::fake_options(ExportType::Html);
         options.custom_name = Some("Name".to_string());
-        let mut config = fake_config(options);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = HTML::new(&config).unwrap();
@@ -2028,8 +1986,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = HTML::new(&config).unwrap();
@@ -2052,8 +2010,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -2078,8 +2036,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -2106,8 +2064,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -2133,8 +2091,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2156,8 +2114,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2179,8 +2137,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2203,8 +2161,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2224,8 +2182,8 @@ mod tests {
     #[test]
     fn can_format_html_attachment_macos() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let message = blank();
@@ -2242,8 +2200,8 @@ mod tests {
     #[test]
     fn can_format_html_attachment_macos_invalid() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let message = blank();
@@ -2259,8 +2217,8 @@ mod tests {
     #[test]
     fn can_format_html_attachment_ios() {
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let mut config = Config::fake_app(options);
         config.options.no_lazy = true;
         config.options.platform = Platform::iOS;
         let exporter = HTML::new(&config).unwrap();
@@ -2278,8 +2236,8 @@ mod tests {
     #[test]
     fn can_format_html_attachment_ios_invalid() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let message = blank();
@@ -2295,10 +2253,10 @@ mod tests {
     #[test]
     fn can_format_html_attachment_sticker() {
         // Create exporter
-        let mut options = fake_options();
+        let mut options = Options::fake_options(ExportType::Html);
         options.export_path = current_dir().unwrap().parent().unwrap().to_path_buf();
 
-        let config = fake_config(options);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2333,8 +2291,8 @@ mod tests {
 mod balloon_format_tests {
     use std::env::set_var;
 
-    use super::tests::{blank, fake_config, fake_options};
-    use crate::{exporters::exporter::BalloonFormatter, Exporter, HTML};
+    use super::tests::blank;
+    use crate::{exporters::exporter::BalloonFormatter, Config, Exporter, Options, HTML};
     use imessage_database::message_types::{
         app::AppMessage,
         app_store::AppStoreMessage,
@@ -2347,8 +2305,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_url() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = URLMessage {
@@ -2372,9 +2330,9 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_url_no_lazy() {
         // Create exporter
-        let mut options = fake_options();
+        let mut options = Options::fake_options(crate::app::export_type::ExportType::Html);
         options.no_lazy = true;
-        let config = fake_config(options);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = URLMessage {
@@ -2398,8 +2356,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_music() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = MusicMessage {
@@ -2419,8 +2377,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_collaboration() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = CollaborationMessage {
@@ -2441,8 +2399,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_apple_pay() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2467,8 +2425,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_fitness() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2493,8 +2451,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_slideshow() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2519,8 +2477,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_find_my() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2548,8 +2506,8 @@ mod balloon_format_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2577,8 +2535,8 @@ mod balloon_format_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2606,8 +2564,8 @@ mod balloon_format_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2632,8 +2590,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_app_store() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppStoreMessage {
@@ -2654,8 +2612,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_placemark() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = PlacemarkMessage {
@@ -2685,8 +2643,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_html_generic_app() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2711,10 +2669,10 @@ mod balloon_format_tests {
 
 #[cfg(test)]
 mod text_effect_tests {
-    use super::tests::{blank, fake_config, fake_options};
+    use super::tests::blank;
     use crate::{
         exporters::exporter::{TextEffectFormatter, Writer},
-        Exporter, HTML,
+        Config, Exporter, Options, HTML,
     };
     use imessage_database::{
         message_types::text_effects::{Style, TextEffect, Unit},
@@ -2729,8 +2687,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_default() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_attributed("Chris", &TextEffect::Default);
@@ -2742,8 +2700,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_mention() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_mention("Chris", "+15558675309");
@@ -2755,8 +2713,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_link() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_link("chrissardegna.com", "https://chrissardegna.com");
@@ -2768,8 +2726,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_otp() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_otp("123456");
@@ -2781,8 +2739,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_style_single() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_styles("Bold", &[Style::Bold]);
@@ -2794,8 +2752,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_style_multiple() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_styles("Bold", &[Style::Bold, Style::Strikethrough]);
@@ -2807,8 +2765,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_style_all() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_styles(
@@ -2828,8 +2786,8 @@ mod text_effect_tests {
     #[test]
     fn can_format_html_conversion() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let expected = exporter.format_conversion("100 Miles", &Unit::Distance);
@@ -2844,8 +2802,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2879,8 +2837,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2914,8 +2872,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2949,8 +2907,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -2984,8 +2942,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -3019,8 +2977,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -3054,8 +3012,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -3089,8 +3047,8 @@ mod text_effect_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -3127,9 +3085,9 @@ mod edited_tests {
         io::Read,
     };
 
-    use super::tests::{blank, fake_config, fake_options};
+    use super::tests::blank;
 
-    use crate::{exporters::exporter::Writer, Exporter, HTML};
+    use crate::{exporters::exporter::Writer, Config, Exporter, Options, HTML};
     use imessage_database::{
         message_types::edited::{EditStatus, EditedMessage, EditedMessagePart},
         util::typedstream::parser::TypedStreamReader,
@@ -3141,8 +3099,8 @@ mod edited_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -3199,8 +3157,8 @@ mod edited_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();
@@ -3236,8 +3194,8 @@ mod edited_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Html);
+        let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
         let mut message = blank();

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -1576,61 +1576,7 @@ mod tests {
     use crate::{
         app::export_type::ExportType, exporters::exporter::Writer, Config, Exporter, Options, HTML,
     };
-    use imessage_database::{
-        tables::{attachment::Attachment, messages::Message, table::ME},
-        util::platform::Platform,
-    };
-
-    pub(super) fn blank() -> Message {
-        Message {
-            rowid: i32::default(),
-            guid: String::default(),
-            text: None,
-            service: Some("iMessage".to_string()),
-            handle_id: Some(i32::default()),
-            destination_caller_id: None,
-            subject: None,
-            date: i64::default(),
-            date_read: i64::default(),
-            date_delivered: i64::default(),
-            is_from_me: false,
-            is_read: false,
-            item_type: 0,
-            other_handle: 0,
-            share_status: false,
-            share_direction: false,
-            group_title: None,
-            group_action_type: 0,
-            associated_message_guid: None,
-            associated_message_type: Some(i32::default()),
-            balloon_bundle_id: None,
-            expressive_send_style_id: None,
-            thread_originator_guid: None,
-            thread_originator_part: None,
-            date_edited: 0,
-            chat_id: None,
-            associated_message_emoji: None,
-            num_attachments: 0,
-            deleted_from: None,
-            num_replies: 0,
-            components: None,
-            edited_parts: None,
-        }
-    }
-
-    pub(super) fn fake_attachment() -> Attachment {
-        Attachment {
-            rowid: 0,
-            filename: Some("a/b/c/d.jpg".to_string()),
-            uti: Some("public.png".to_string()),
-            mime_type: Some("image/png".to_string()),
-            transfer_name: Some("d.jpg".to_string()),
-            total_bytes: 100,
-            is_sticker: false,
-            hide_attachment: 0,
-            copied_path: None,
-        }
-    }
+    use imessage_database::{tables::table::ME, util::platform::Platform};
 
     #[test]
     fn can_create() {
@@ -1652,7 +1598,7 @@ mod tests {
         let exporter = HTML::new(&config).unwrap();
 
         // Create fake message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         // May 17, 2022  8:29:42 PM
@@ -1677,7 +1623,7 @@ mod tests {
         let exporter = HTML::new(&config).unwrap();
 
         // Create fake message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  9:30:31 PM
         message.date = 674530231992568192;
         // May 17, 2022  9:30:31 PM
@@ -1739,7 +1685,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Hello world".to_string());
@@ -1762,7 +1708,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("<table></table>".to_string());
@@ -1785,7 +1731,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.text = Some("Hello world".to_string());
         message.date = 674526582885055488;
@@ -1808,7 +1754,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.text = Some("Hello world".to_string());
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
@@ -1836,7 +1782,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Hello world".to_string());
@@ -1861,7 +1807,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = Some(999999);
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
@@ -1892,7 +1838,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = Some(999999);
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
@@ -1921,7 +1867,7 @@ mod tests {
 
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.item_type = 6;
@@ -1944,7 +1890,7 @@ mod tests {
 
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.group_title = Some("Hello world".to_string());
@@ -1969,7 +1915,7 @@ mod tests {
 
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.group_title = Some("Hello world".to_string());
@@ -1992,7 +1938,7 @@ mod tests {
 
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2000);
@@ -2017,7 +1963,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2000);
@@ -2043,7 +1989,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2006);
@@ -2071,7 +2017,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2007);
@@ -2095,7 +2041,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.is_from_me = false;
         message.other_handle = 2;
         message.share_status = false;
@@ -2118,7 +2064,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.is_from_me = false;
         message.other_handle = 2;
         message.share_status = true;
@@ -2141,7 +2087,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = None;
         message.is_from_me = false;
         message.other_handle = 0;
@@ -2165,7 +2111,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = None;
         message.is_from_me = false;
         message.other_handle = 0;
@@ -2186,9 +2132,9 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
 
         let actual = exporter
             .format_attachment(&mut attachment, &message)
@@ -2204,9 +2150,9 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
         attachment.filename = None;
 
         let actual = exporter.format_attachment(&mut attachment, &message);
@@ -2222,9 +2168,9 @@ mod tests {
         config.options.no_lazy = true;
         config.options.platform = Platform::iOS;
         let exporter = HTML::new(&config).unwrap();
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
 
         let actual = exporter
             .format_attachment(&mut attachment, &message)
@@ -2240,9 +2186,9 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
         attachment.filename = None;
 
         let actual = exporter.format_attachment(&mut attachment, &message);
@@ -2259,11 +2205,11 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // Set message to sticker variant
         message.associated_message_type = Some(1000);
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
         attachment.is_sticker = true;
         let sticker_path = current_dir()
             .unwrap()
@@ -2291,7 +2237,6 @@ mod tests {
 mod balloon_format_tests {
     use std::env::set_var;
 
-    use super::tests::blank;
     use crate::{exporters::exporter::BalloonFormatter, Config, Exporter, Options, HTML};
     use imessage_database::message_types::{
         app::AppMessage,
@@ -2321,7 +2266,8 @@ mod balloon_format_tests {
             placeholder: false,
         };
 
-        let expected = exporter.format_url(&blank(), &balloon, &blank());
+        let expected =
+            exporter.format_url(&Config::fake_message(), &balloon, &Config::fake_message());
         let actual = "<a href=\"url\"><div class=\"app_header\"><img src=\"images\" loading=\"lazy\", onerror=\"this.style.display='none'\"><div class=\"name\">site_name</div></div><div class=\"app_footer\"><div class=\"caption\">title</div><div class=\"subcaption\">summary</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2347,7 +2293,8 @@ mod balloon_format_tests {
             placeholder: false,
         };
 
-        let expected = exporter.format_url(&blank(), &balloon, &blank());
+        let expected =
+            exporter.format_url(&Config::fake_message(), &balloon, &Config::fake_message());
         let actual = "<a href=\"url\"><div class=\"app_header\"><img src=\"images\" onerror=\"this.style.display='none'\"><div class=\"name\">site_name</div></div><div class=\"app_footer\"><div class=\"caption\">title</div><div class=\"subcaption\">summary</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2368,7 +2315,7 @@ mod balloon_format_tests {
             track_name: Some("track_name"),
         };
 
-        let expected = exporter.format_music(&balloon, &blank());
+        let expected = exporter.format_music(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">track_name</div><audio controls src=\"preview\" </audio></div><a href=\"url\"><div class=\"app_footer\"><div class=\"caption\">artist</div><div class=\"subcaption\">album</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2390,7 +2337,7 @@ mod balloon_format_tests {
             app_name: Some("app_name"),
         };
 
-        let expected = exporter.format_collaboration(&balloon, &blank());
+        let expected = exporter.format_collaboration(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">app_name</div></div><a href=\"url\"><div class=\"app_footer\"><div class=\"caption\">title</div><div class=\"subcaption\">url</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2416,7 +2363,7 @@ mod balloon_format_tests {
             ldtext: Some("ldtext"),
         };
 
-        let expected = exporter.format_apple_pay(&balloon, &blank());
+        let expected = exporter.format_apple_pay(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">app_name</div></div><div class=\"app_footer\"><div class=\"caption\">ldtext</div></div>";
 
         assert_eq!(expected, actual);
@@ -2442,7 +2389,7 @@ mod balloon_format_tests {
             ldtext: Some("ldtext"),
         };
 
-        let expected = exporter.format_fitness(&balloon, &blank());
+        let expected = exporter.format_fitness(&balloon, &Config::fake_message());
         let actual = "<a href=\"url\"><div class=\"app_header\"><img src=\"image\"><div class=\"name\">app_name</div><div class=\"image_title\">title</div><div class=\"image_subtitle\">subtitle</div><div class=\"ldtext\">ldtext</div></div><div class=\"app_footer\"><div class=\"caption\">caption</div><div class=\"subcaption\">subcaption</div><div class=\"trailing_caption\">trailing_caption</div><div class=\"trailing_subcaption\">trailing_subcaption</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2468,7 +2415,7 @@ mod balloon_format_tests {
             ldtext: Some("ldtext"),
         };
 
-        let expected = exporter.format_slideshow(&balloon, &blank());
+        let expected = exporter.format_slideshow(&balloon, &Config::fake_message());
         let actual = "<a href=\"url\"><div class=\"app_header\"><img src=\"image\"><div class=\"name\">app_name</div><div class=\"image_title\">title</div><div class=\"image_subtitle\">subtitle</div><div class=\"ldtext\">ldtext</div></div><div class=\"app_footer\"><div class=\"caption\">caption</div><div class=\"subcaption\">subcaption</div><div class=\"trailing_caption\">trailing_caption</div><div class=\"trailing_subcaption\">trailing_subcaption</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2494,7 +2441,7 @@ mod balloon_format_tests {
             ldtext: Some("ldtext"),
         };
 
-        let expected = exporter.format_find_my(&balloon, &blank());
+        let expected = exporter.format_find_my(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">app_name</div></div><div class=\"app_footer\"><div class=\"caption\">ldtext</div></div>";
 
         assert_eq!(expected, actual);
@@ -2523,7 +2470,7 @@ mod balloon_format_tests {
             ldtext: Some("Check In: Timer Started"),
         };
 
-        let expected = exporter.format_check_in(&balloon, &blank());
+        let expected = exporter.format_check_in(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">Check\u{a0}In</div><div class=\"ldtext\">Check\u{a0}In: Timer Started</div></div><div class=\"app_footer\"><div class=\"caption\">Checked in at Oct 14, 2023  1:54:29 PM</div></div>";
 
         assert_eq!(expected, actual);
@@ -2552,7 +2499,7 @@ mod balloon_format_tests {
             ldtext: Some("Check In: Has not checked in when expected, location shared"),
         };
 
-        let expected = exporter.format_check_in(&balloon, &blank());
+        let expected = exporter.format_check_in(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">Check\u{a0}In</div><div class=\"ldtext\">Check\u{a0}In: Has not checked in when expected, location shared</div></div><div class=\"app_footer\"><div class=\"caption\">Checked in at Oct 14, 2023  1:54:29 PM</div></div>";
 
         assert_eq!(expected, actual);
@@ -2581,7 +2528,7 @@ mod balloon_format_tests {
             ldtext: Some("Check In: Fake Location"),
         };
 
-        let expected = exporter.format_check_in(&balloon, &blank());
+        let expected = exporter.format_check_in(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">Check\u{a0}In</div><div class=\"ldtext\">Check\u{a0}In: Fake Location</div></div><div class=\"app_footer\"><div class=\"caption\">Checked in at Oct 14, 2023  1:54:29 PM</div></div>";
 
         assert_eq!(expected, actual);
@@ -2603,7 +2550,7 @@ mod balloon_format_tests {
             genre: Some("genre"),
         };
 
-        let expected = exporter.format_app_store(&balloon, &blank());
+        let expected = exporter.format_app_store(&balloon, &Config::fake_message());
         let actual = "<div class=\"app_header\"><div class=\"name\">app_name</div></div><a href=\"url\"><div class=\"app_footer\"><div class=\"caption\">description</div><div class=\"subcaption\">platform</div><div class=\"trailing_subcaption\">genre</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2634,7 +2581,7 @@ mod balloon_format_tests {
             },
         };
 
-        let expected = exporter.format_placemark(&balloon, &blank());
+        let expected = exporter.format_placemark(&balloon, &Config::fake_message());
         let actual = "<a href=\"url\"><div class=\"app_header\"><div class=\"name\">Name</div></div><div class=\"app_footer\"><div class=\"caption\">address</div><div class=\"trailing_caption\">postal_code</div><div class=\"subcaption\">country</div><div class=\"trailing_subcaption\">sub_administrative_area</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2660,7 +2607,12 @@ mod balloon_format_tests {
             ldtext: Some("ldtext"),
         };
 
-        let expected = exporter.format_generic_app(&balloon, "bundle_id", &mut vec![], &blank());
+        let expected = exporter.format_generic_app(
+            &balloon,
+            "bundle_id",
+            &mut vec![],
+            &Config::fake_message(),
+        );
         let actual = "<a href=\"url\"><div class=\"app_header\"><img src=\"image\"><div class=\"name\">app_name</div><div class=\"image_title\">title</div><div class=\"image_subtitle\">subtitle</div><div class=\"ldtext\">ldtext</div></div><div class=\"app_footer\"><div class=\"caption\">caption</div><div class=\"subcaption\">subcaption</div><div class=\"trailing_caption\">trailing_caption</div><div class=\"trailing_subcaption\">trailing_subcaption</div></div></a>";
 
         assert_eq!(expected, actual);
@@ -2669,7 +2621,6 @@ mod balloon_format_tests {
 
 #[cfg(test)]
 mod text_effect_tests {
-    use super::tests::blank;
     use crate::{
         exporters::exporter::{TextEffectFormatter, Writer},
         Config, Exporter, Options, HTML,
@@ -2806,7 +2757,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Test Dad ".to_string());
@@ -2841,7 +2792,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("000123 is your security code. Don't share your code.".to_string());
@@ -2876,7 +2827,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("https://twitter.com/xxxxxxxxx/status/0000223300009216128".to_string());
@@ -2911,7 +2862,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Hi. Right now or tomorrow?".to_string());
@@ -2946,7 +2897,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Big small shake nod explode ripple bloom jitter".to_string());
@@ -2981,7 +2932,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Bold underline italic strikethrough all four".to_string());
@@ -3016,7 +2967,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Everything".to_string());
@@ -3051,7 +3002,7 @@ mod text_effect_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Underline normal jitter normal".to_string());
@@ -3085,8 +3036,6 @@ mod edited_tests {
         io::Read,
     };
 
-    use super::tests::blank;
-
     use crate::{exporters::exporter::Writer, Config, Exporter, Options, HTML};
     use imessage_database::{
         message_types::edited::{EditStatus, EditedMessage, EditedMessagePart},
@@ -3103,7 +3052,7 @@ mod edited_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.date_edited = 674530231992568192;
@@ -3161,7 +3110,7 @@ mod edited_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some(
@@ -3198,7 +3147,7 @@ mod edited_tests {
         let config = Config::fake_app(options);
         let exporter = HTML::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.date_edited = 674530231992568192;

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -1042,61 +1042,7 @@ mod tests {
     use crate::{
         app::export_type::ExportType, exporters::exporter::Writer, Config, Exporter, Options, TXT,
     };
-    use imessage_database::{
-        tables::{attachment::Attachment, messages::Message, table::ME},
-        util::platform::Platform,
-    };
-
-    pub(super) fn blank() -> Message {
-        Message {
-            rowid: i32::default(),
-            guid: String::default(),
-            text: None,
-            service: Some("iMessage".to_string()),
-            handle_id: Some(i32::default()),
-            destination_caller_id: None,
-            subject: None,
-            date: i64::default(),
-            date_read: i64::default(),
-            date_delivered: i64::default(),
-            is_from_me: false,
-            is_read: false,
-            item_type: 0,
-            other_handle: 0,
-            share_status: false,
-            share_direction: false,
-            group_title: None,
-            group_action_type: 0,
-            associated_message_guid: None,
-            associated_message_type: Some(i32::default()),
-            balloon_bundle_id: None,
-            expressive_send_style_id: None,
-            thread_originator_guid: None,
-            thread_originator_part: None,
-            date_edited: 0,
-            chat_id: None,
-            associated_message_emoji: None,
-            num_attachments: 0,
-            deleted_from: None,
-            num_replies: 0,
-            components: None,
-            edited_parts: None,
-        }
-    }
-
-    pub(super) fn fake_attachment() -> Attachment {
-        Attachment {
-            rowid: 0,
-            filename: Some("a/b/c/d.jpg".to_string()),
-            uti: Some("public.png".to_string()),
-            mime_type: Some("image/png".to_string()),
-            transfer_name: Some("d.jpg".to_string()),
-            total_bytes: 100,
-            is_sticker: false,
-            hide_attachment: 0,
-            copied_path: None,
-        }
-    }
+    use imessage_database::{tables::table::ME, util::platform::Platform};
 
     #[test]
     fn can_create() {
@@ -1117,7 +1063,7 @@ mod tests {
         let exporter = TXT::new(&config).unwrap();
 
         // Create fake message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         // May 17, 2022  8:29:42 PM
@@ -1142,7 +1088,7 @@ mod tests {
         let exporter = TXT::new(&config).unwrap();
 
         // Create fake message
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  9:30:31 PM
         message.date = 674530231992568192;
         // May 17, 2022  9:30:31 PM
@@ -1190,7 +1136,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Hello world".to_string());
@@ -1213,7 +1159,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.text = Some("Hello world".to_string());
         message.date = 674526582885055488;
@@ -1237,7 +1183,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.text = Some("Hello world".to_string());
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
@@ -1265,7 +1211,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some("Hello world".to_string());
@@ -1290,7 +1236,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = Some(999999);
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
@@ -1321,7 +1267,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = Some(999999);
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
@@ -1350,7 +1296,7 @@ mod tests {
 
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.item_type = 6;
@@ -1373,7 +1319,7 @@ mod tests {
 
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.group_title = Some("Hello world".to_string());
@@ -1398,7 +1344,7 @@ mod tests {
 
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.group_title = Some("Hello world".to_string());
@@ -1421,7 +1367,7 @@ mod tests {
 
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2000);
@@ -1446,7 +1392,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2000);
@@ -1472,7 +1418,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2006);
@@ -1499,7 +1445,7 @@ mod tests {
             .insert(999999, "Sample Contact".to_string());
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.associated_message_type = Some(2007);
@@ -1523,7 +1469,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.is_from_me = false;
         message.other_handle = 2;
         message.share_status = false;
@@ -1546,7 +1492,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.is_from_me = false;
         message.other_handle = 2;
         message.share_status = true;
@@ -1569,7 +1515,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = None;
         message.is_from_me = false;
         message.other_handle = 0;
@@ -1593,7 +1539,7 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         message.handle_id = None;
         message.is_from_me = false;
         message.other_handle = 0;
@@ -1614,9 +1560,9 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
 
         let actual = exporter
             .format_attachment(&mut attachment, &message)
@@ -1632,9 +1578,9 @@ mod tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
         attachment.filename = None;
 
         let actual = exporter.format_attachment(&mut attachment, &message);
@@ -1650,9 +1596,9 @@ mod tests {
         config.options.platform = Platform::iOS;
         let exporter = TXT::new(&config).unwrap();
 
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
 
         let actual = exporter
             .format_attachment(&mut attachment, &message)
@@ -1670,9 +1616,9 @@ mod tests {
         config.options.platform = Platform::iOS;
         let exporter = TXT::new(&config).unwrap();
 
-        let message = blank();
+        let message = Config::fake_message();
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
         attachment.filename = None;
 
         let actual = exporter.format_attachment(&mut attachment, &message);
@@ -1691,11 +1637,11 @@ mod tests {
 
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // Set message to sticker variant
         message.associated_message_type = Some(1000);
 
-        let mut attachment = fake_attachment();
+        let mut attachment = Config::fake_attachment();
         attachment.is_sticker = true;
         let sticker_path = current_dir()
             .unwrap()
@@ -1726,7 +1672,6 @@ mod tests {
 mod balloon_format_tests {
     use std::env::set_var;
 
-    use super::tests::blank;
     use crate::{exporters::exporter::BalloonFormatter, Config, Exporter, Options, TXT};
     use imessage_database::message_types::{
         app::AppMessage,
@@ -1756,7 +1701,7 @@ mod balloon_format_tests {
             placeholder: false,
         };
 
-        let expected = exporter.format_url(&blank(), &balloon, "");
+        let expected = exporter.format_url(&Config::fake_message(), &balloon, "");
         let actual = "url\ntitle\nsummary";
 
         assert_eq!(expected, actual);
@@ -2084,8 +2029,6 @@ mod edited_tests {
         io::Read,
     };
 
-    use super::tests::blank;
-
     use crate::{exporters::exporter::Writer, Config, Exporter, Options, TXT};
     use imessage_database::{
         message_types::edited::{EditStatus, EditedMessage, EditedMessagePart},
@@ -2102,7 +2045,7 @@ mod edited_tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.date_edited = 674530231992568192;
@@ -2160,7 +2103,7 @@ mod edited_tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.text = Some(
@@ -2197,7 +2140,7 @@ mod edited_tests {
         let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
-        let mut message = blank();
+        let mut message = Config::fake_message();
         // May 17, 2022  8:29:42 PM
         message.date = 674526582885055488;
         message.date_edited = 674530231992568192;

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -1035,25 +1035,16 @@ impl<'a> TXT<'a> {
 #[cfg(test)]
 mod tests {
     use std::{
-        collections::HashMap,
         env::{current_dir, set_var},
         path::PathBuf,
     };
 
     use crate::{
-        app::attachment_manager::AttachmentManager, exporters::exporter::Writer, Config, Exporter,
-        Options, TXT,
+        app::export_type::ExportType, exporters::exporter::Writer, Config, Exporter, Options, TXT,
     };
     use imessage_database::{
-        tables::{
-            attachment::Attachment,
-            messages::Message,
-            table::{get_connection, ME},
-        },
-        util::{
-            dates::get_offset, dirs::default_db_path, platform::Platform,
-            query_context::QueryContext,
-        },
+        tables::{attachment::Attachment, messages::Message, table::ME},
+        util::platform::Platform,
     };
 
     pub(super) fn blank() -> Message {
@@ -1093,39 +1084,6 @@ mod tests {
         }
     }
 
-    pub(super) fn fake_options() -> Options {
-        Options {
-            db_path: default_db_path(),
-            attachment_root: None,
-            attachment_manager: AttachmentManager::Disabled,
-            diagnostic: false,
-            export_type: None,
-            export_path: PathBuf::from("/tmp"),
-            query_context: QueryContext::default(),
-            no_lazy: false,
-            custom_name: None,
-            use_caller_id: false,
-            platform: Platform::macOS,
-            ignore_disk_space: false,
-        }
-    }
-
-    pub(super) fn fake_config(options: Options) -> Config {
-        let db = get_connection(&options.get_db_path()).unwrap();
-        Config {
-            chatrooms: HashMap::new(),
-            real_chatrooms: HashMap::new(),
-            chatroom_participants: HashMap::new(),
-            participants: HashMap::new(),
-            real_participants: HashMap::new(),
-            tapbacks: HashMap::new(),
-            options,
-            offset: get_offset(),
-            db,
-            converter: None,
-        }
-    }
-
     pub(super) fn fake_attachment() -> Attachment {
         Attachment {
             rowid: 0,
@@ -1142,8 +1100,8 @@ mod tests {
 
     #[test]
     fn can_create() {
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
         assert_eq!(exporter.files.len(), 0);
     }
@@ -1154,8 +1112,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         // Create fake message
@@ -1179,8 +1137,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         // Create fake message
@@ -1197,8 +1155,8 @@ mod tests {
     #[test]
     fn can_add_line_no_indent() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         // Create sample data
@@ -1211,8 +1169,8 @@ mod tests {
     #[test]
     fn can_add_line_indent() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         // Create sample data
@@ -1228,8 +1186,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -1251,8 +1209,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -1275,8 +1233,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -1300,8 +1258,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1325,8 +1283,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1355,9 +1313,9 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let mut options = fake_options();
+        let mut options = Options::fake_options(ExportType::Txt);
         options.custom_name = Some("Name".to_string());
-        let mut config = fake_config(options);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1386,8 +1344,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = TXT::new(&config).unwrap();
@@ -1409,8 +1367,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = TXT::new(&config).unwrap();
@@ -1433,9 +1391,9 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let mut options = fake_options();
+        let mut options = Options::fake_options(ExportType::Txt);
         options.custom_name = Some("Name".to_string());
-        let mut config = fake_config(options);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = TXT::new(&config).unwrap();
@@ -1457,8 +1415,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = TXT::new(&config).unwrap();
@@ -1481,8 +1439,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1507,8 +1465,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1534,8 +1492,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config
             .participants
             .insert(999999, "Sample Contact".to_string());
@@ -1561,8 +1519,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -1584,8 +1542,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -1607,8 +1565,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -1631,8 +1589,8 @@ mod tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -1652,8 +1610,8 @@ mod tests {
     #[test]
     fn can_format_txt_attachment_macos() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let message = blank();
@@ -1670,8 +1628,8 @@ mod tests {
     #[test]
     fn can_format_txt_attachment_macos_invalid() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let message = blank();
@@ -1687,8 +1645,8 @@ mod tests {
     #[test]
     fn can_format_txt_attachment_ios() {
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         config.options.platform = Platform::iOS;
         let exporter = TXT::new(&config).unwrap();
 
@@ -1706,8 +1664,8 @@ mod tests {
     #[test]
     fn can_format_txt_attachment_ios_invalid() {
         // Create exporter
-        let options = fake_options();
-        let mut config = fake_config(options);
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
         // Modify this
         config.options.platform = Platform::iOS;
         let exporter = TXT::new(&config).unwrap();
@@ -1725,10 +1683,10 @@ mod tests {
     #[test]
     fn can_format_txt_attachment_sticker() {
         // Create exporter
-        let mut options = fake_options();
+        let mut options = Options::fake_options(ExportType::Txt);
         options.export_path = current_dir().unwrap().parent().unwrap().to_path_buf();
 
-        let mut config = fake_config(options);
+        let mut config = Config::fake_app(options);
         config.participants.insert(0, ME.to_string());
 
         let exporter = TXT::new(&config).unwrap();
@@ -1768,8 +1726,8 @@ mod tests {
 mod balloon_format_tests {
     use std::env::set_var;
 
-    use super::tests::{blank, fake_config, fake_options};
-    use crate::{exporters::exporter::BalloonFormatter, Exporter, TXT};
+    use super::tests::blank;
+    use crate::{exporters::exporter::BalloonFormatter, Config, Exporter, Options, TXT};
     use imessage_database::message_types::{
         app::AppMessage,
         app_store::AppStoreMessage,
@@ -1782,8 +1740,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_url() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = URLMessage {
@@ -1807,8 +1765,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_music() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = MusicMessage {
@@ -1828,8 +1786,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_collaboration() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = CollaborationMessage {
@@ -1850,8 +1808,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_apple_pay() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -1876,8 +1834,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_fitness() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -1902,8 +1860,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_slideshow() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -1928,8 +1886,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_find_my() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -1957,8 +1915,8 @@ mod balloon_format_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -1986,8 +1944,8 @@ mod balloon_format_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2015,8 +1973,8 @@ mod balloon_format_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2041,8 +1999,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_app_store() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppStoreMessage {
@@ -2063,8 +2021,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_placemark() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = PlacemarkMessage {
@@ -2094,8 +2052,8 @@ mod balloon_format_tests {
     #[test]
     fn can_format_txt_generic_app() {
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let balloon = AppMessage {
@@ -2126,9 +2084,9 @@ mod edited_tests {
         io::Read,
     };
 
-    use super::tests::{blank, fake_config, fake_options};
+    use super::tests::blank;
 
-    use crate::{exporters::exporter::Writer, Exporter, TXT};
+    use crate::{exporters::exporter::Writer, Config, Exporter, Options, TXT};
     use imessage_database::{
         message_types::edited::{EditStatus, EditedMessage, EditedMessagePart},
         util::typedstream::parser::TypedStreamReader,
@@ -2140,8 +2098,8 @@ mod edited_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -2198,8 +2156,8 @@ mod edited_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();
@@ -2235,8 +2193,8 @@ mod edited_tests {
         set_var("TZ", "PST");
 
         // Create exporter
-        let options = fake_options();
-        let config = fake_config(options);
+        let options = Options::fake_options(crate::app::export_type::ExportType::Txt);
+        let config = Config::fake_app(options);
         let exporter = TXT::new(&config).unwrap();
 
         let mut message = blank();

--- a/imessage-exporter/src/main.rs
+++ b/imessage-exporter/src/main.rs
@@ -22,7 +22,10 @@ fn main() {
     } else {
         match options {
             Ok(options) => match Config::new(options) {
-                Ok(app) => {
+                Ok(mut app) => {
+                    // Resolve the filtered contacts, if provided
+                    app.resolve_filtered_handles();
+
                     if let Err(why) = app.start() {
                         eprintln!("Unable to export: {why}");
                     }


### PR DESCRIPTION
- Support #61 
  - Adds `--conversation-filter` CLI arg to filter conversations based on a specified string pattern
  - <details><summary>Supports partial matches and multiple patterns</summary><li><code>--conversation-filter &quot;steve@apple.com&quot;</code> exports conversations with <code>steve@apple.com</code></li><li><code>--conversation-filter &quot;steve@apple.com,+15558675309&quot;</code> exports all conversations with <code>steve@apple.com</code> or <code>+15558675309</code></li><li><code>--conversation-filter &quot;@apple.com&quot;</code> exports all conversations where the participant info contains <code>apple.com</code></li><li>Group conversations with selected participants are always included</li></ul></details>
- Rework test fixtures