### PR TITLE
Fix magick sticker bug

### DIFF
--- a/imessage-exporter/src/app/compatibility/converters/image.rs
+++ b/imessage-exporter/src/app/compatibility/converters/image.rs
@@ -50,7 +50,7 @@ pub(crate) fn image_copy_convert(
 /// of failing, `sips` will create a file called `fake` in `/`. Subsequent writes
 /// by `sips` to the same location will not fail, but since it is a file instead
 /// of a directory, this will fail for non-`sips` copies.
-pub(super) fn convert_heic(
+fn convert_heic(
     from: &Path,
     to: &Path,
     converter: &ImageConverter,

--- a/imessage-exporter/src/app/compatibility/converters/sticker.rs
+++ b/imessage-exporter/src/app/compatibility/converters/sticker.rs
@@ -73,7 +73,7 @@ pub(crate) fn sticker_copy_convert(
 ///
 /// Sticker HEIC files contain 5 images: 320x320, 160x160, 96x96, 64x64, and 40x40
 /// `magick` attempts to extract all of them; but for compatibility purposes we only
-/// take the hightest resolution. This is done automatically in `sips` but requires
+/// take the highest resolution. This is done automatically in `sips` but requires
 /// manual adjustment in `magick`: https://github.com/ImageMagick/ImageMagick/issues/1391
 fn convert_heic(
     from: &Path,

--- a/imessage-exporter/src/app/compatibility/converters/sticker.rs
+++ b/imessage-exporter/src/app/compatibility/converters/sticker.rs
@@ -72,6 +72,7 @@ pub(crate) fn sticker_copy_convert(
 /// of a directory, this will fail for non-`sips` copies.
 ///
 /// Sticker HEIC files contain 5 images: 320x320, 160x160, 96x96, 64x64, and 40x40
+///
 /// `magick` attempts to extract all of them; but for compatibility purposes we only
 /// take the highest resolution. This is done automatically in `sips` but requires
 /// manual adjustment in `magick`: https://github.com/ImageMagick/ImageMagick/issues/1391
@@ -82,24 +83,25 @@ fn convert_heic(
     output_image_type: &ImageType,
 ) -> Option<()> {
     let (from_path, to_path) = ensure_paths(from, to)?;
-    // Used for `magick` conversion
-    let formatted_from = format!("{from_path}[0]");
 
-    let args = match converter {
-        ImageConverter::Sips => vec![
-            "-s",
-            "format",
-            output_image_type.to_str(),
-            from_path,
-            "-o",
-            to_path,
-        ],
-        ImageConverter::Imagemagick => {
-            vec![&formatted_from, to_path]
+    match converter {
+        ImageConverter::Sips => {
+            let args = vec![
+                "-s",
+                "format",
+                output_image_type.to_str(),
+                from_path,
+                "-o",
+                to_path,
+            ];
+            run_command(converter.name(), args)
         }
-    };
-
-    run_command(converter.name(), args)
+        ImageConverter::Imagemagick => {
+            let formatted_from = format!("{from_path}[0]");
+            let args = vec![&formatted_from, to_path];
+            run_command(converter.name(), args)
+        }
+    }
 }
 
 fn convert_heics(from: &Path, to: &Path, video_converter: &VideoConverter) -> Option<()> {


### PR DESCRIPTION
Sticker HEIC files contain 5 images: `320x320`, `160x160`, `96x96`, `64x64`, and `40x40` 

`magick` attempts to extract all of them; but for compatibility purposes we only take the highest resolution and convert to `png`. 

This is done automatically in `sips` but requires manual adjustment in `magick`: https://github.com/ImageMagick/ImageMagick/issues/1391