### PR TITLE
Add necessary + remove unnecessary lifetime parameters

### DIFF
--- a/imessage-database/src/message_types/app.rs
+++ b/imessage-database/src/message_types/app.rs
@@ -63,7 +63,7 @@ impl<'a> BalloonProvider<'a> for AppMessage<'a> {
     }
 }
 
-impl<'a> AppMessage<'a> {
+impl AppMessage<'_> {
     /// Parse key/value pairs from the query string in the balloon's a URL
     pub fn parse_query_string(&self) -> HashMap<&str, &str> {
         let mut map = HashMap::new();

--- a/imessage-database/src/message_types/url.rs
+++ b/imessage-database/src/message_types/url.rs
@@ -62,7 +62,7 @@ impl<'a> BalloonProvider<'a> for URLMessage<'a> {
 
 impl<'a> URLMessage<'a> {
     /// Gets the subtype of the URL message based on the payload
-    pub fn get_url_message_override(payload: &'a Value) -> Result<URLOverride, PlistParseError> {
+    pub fn get_url_message_override(payload: &'a Value) -> Result<URLOverride<'a>, PlistParseError> {
         if let Ok(balloon) = CollaborationMessage::from_map(payload) {
             return Ok(URLOverride::Collaboration(balloon));
         }

--- a/imessage-database/src/message_types/variants.rs
+++ b/imessage-database/src/message_types/variants.rs
@@ -60,7 +60,7 @@ pub enum Tapback<'a> {
     Emoji(Option<&'a str>),
 }
 
-impl<'a> Display for Tapback<'a> {
+impl Display for Tapback<'_> {
     fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Tapback::Emoji(emoji) => match emoji {

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -44,7 +44,7 @@ pub enum MediaType<'a> {
     Unknown,
 }
 
-impl<'a> MediaType<'a> {
+impl MediaType<'_> {
     pub fn as_mime_type(&self) -> String {
         match self {
             MediaType::Image(subtype) => format!("image/{subtype}"),

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -974,11 +974,11 @@ impl Message {
             return Some(Announcement::FullyUnsent);
         }
 
-        return match &self.group_action_type {
+        match &self.group_action_type {
             0 => None,
             1 => Some(Announcement::PhotoChange),
             other => Some(Announcement::Unknown(other)),
-        };
+        }
     }
 
     /// Determine the service the message was sent from, i.e. iMessage, SMS, IRC, etc.

--- a/imessage-database/src/tables/messages/models.rs
+++ b/imessage-database/src/tables/messages/models.rs
@@ -58,7 +58,7 @@ impl<'a> Service<'a> {
     }
 }
 
-impl<'a> Display for Service<'a> {
+impl Display for Service<'_> {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {
             Service::iMessage => write!(fmt, "iMessage"),

--- a/imessage-exporter/src/exporters/exporter.rs
+++ b/imessage-exporter/src/exporters/exporter.rs
@@ -16,7 +16,7 @@ use imessage_database::{
     },
     tables::{
         attachment::Attachment,
-        messages::{Message, models::AttachmentMeta},
+        messages::{models::AttachmentMeta, Message},
     },
 };
 
@@ -76,7 +76,7 @@ pub(super) trait Writer<'a> {
         indent: &str,
     ) -> Option<String>;
     /// Format some attributed text
-    fn format_attributed(&'a self, text: &'a str, attribute: &'a TextEffect) -> Cow<str>;
+    fn format_attributed(&'a self, text: &'a str, attribute: &'a TextEffect) -> Cow<'a, str>;
     fn write_to_file(file: &mut BufWriter<File>, text: &str) -> Result<(), RuntimeError>;
 }
 

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -156,7 +156,7 @@ impl<'a> Exporter<'a> for HTML<'a> {
         match self.config.conversation(message) {
             Some((chatroom, _)) => {
                 let filename = self.config.filename(chatroom);
-                return match self.files.entry(filename) {
+                match self.files.entry(filename) {
                     Occupied(entry) => Ok(entry.into_mut()),
                     Vacant(entry) => {
                         let mut path = self.config.options.export_path.clone();
@@ -182,7 +182,7 @@ impl<'a> Exporter<'a> for HTML<'a> {
 
                         Ok(entry.insert(buf))
                     }
-                };
+                }
             }
             None => Ok(&mut self.orphaned),
         }
@@ -554,7 +554,7 @@ impl<'a> Writer<'a> for HTML<'a> {
         // Build a relative filepath from the fully qualified one on the `Attachment`
         let embed_path = self.config.message_attachment_path(attachment);
 
-        return Ok(match attachment.mime_type() {
+        Ok(match attachment.mime_type() {
             MediaType::Image(_) => {
                 if self.config.options.no_lazy {
                     format!("<img src=\"{embed_path}\">")
@@ -590,7 +590,7 @@ impl<'a> Writer<'a> for HTML<'a> {
             MediaType::Other(media_type) => {
                 format!("<p>Unable to embed {media_type} attachments: {embed_path}</p>")
             }
-        });
+        })
     }
 
     fn format_sticker(&self, sticker: &'a mut Attachment, message: &Message) -> String {
@@ -778,7 +778,7 @@ impl<'a> Writer<'a> for HTML<'a> {
         }
         let timestamp = format(&msg.date(&self.config.offset));
 
-        return match msg.get_announcement() {
+        match msg.get_announcement() {
             Some(announcement) => match announcement {
                 Announcement::NameChange(name) => {
                     let clean_name = sanitize_html(name);
@@ -805,7 +805,7 @@ impl<'a> Writer<'a> for HTML<'a> {
             None => String::from(
                 "\n<div class =\"announcement\"><p>Unable to format announcement!</p></div>\n",
             ),
-        };
+        }
     }
 
     fn format_shareplay(&self) -> &str {
@@ -894,7 +894,7 @@ impl<'a> Writer<'a> for HTML<'a> {
         None
     }
 
-    fn format_attributed(&'a self, text: &'a str, attribute: &'a TextEffect) -> Cow<str> {
+    fn format_attributed(&'a self, text: &'a str, attribute: &'a TextEffect) -> Cow<'a, str> {
         match attribute {
             TextEffect::Default => Cow::Borrowed(text),
             TextEffect::Mention(mentioned) => Cow::Owned(self.format_mention(text, mentioned)),
@@ -1397,7 +1397,7 @@ impl<'a> BalloonFormatter<&'a Message> for HTML<'a> {
     }
 }
 
-impl<'a> TextEffectFormatter for HTML<'a> {
+impl TextEffectFormatter for HTML<'_> {
     fn format_mention(&self, text: &str, mentioned: &str) -> String {
         format!("<span title=\"{mentioned}\"><b>{text}</b></span>")
     }
@@ -1438,7 +1438,7 @@ impl<'a> TextEffectFormatter for HTML<'a> {
     }
 }
 
-impl<'a> HTML<'a> {
+impl HTML<'_> {
     fn get_time(&self, message: &Message) -> String {
         let mut date = format(&message.date(&self.config.offset));
         let read_after = message.time_until_read(&self.config.offset);

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -144,7 +144,7 @@ impl<'a> Exporter<'a> for TXT<'a> {
         match self.config.conversation(message) {
             Some((chatroom, _)) => {
                 let filename = self.config.filename(chatroom);
-                return match self.files.entry(filename) {
+                match self.files.entry(filename) {
                     Occupied(entry) => Ok(entry.into_mut()),
                     Vacant(entry) => {
                         let mut path = self.config.options.export_path.clone();
@@ -159,7 +159,7 @@ impl<'a> Exporter<'a> for TXT<'a> {
 
                         Ok(entry.insert(BufWriter::new(file)))
                     }
-                };
+                }
             }
             None => Ok(&mut self.orphaned),
         }
@@ -581,7 +581,7 @@ impl<'a> Writer<'a> for TXT<'a> {
 
         let timestamp = format(&msg.date(&self.config.offset));
 
-        return match msg.get_announcement() {
+        match msg.get_announcement() {
             Some(announcement) => match announcement {
                 Announcement::NameChange(name) => {
                     format!("{timestamp} {who} renamed the conversation to {name}\n\n")
@@ -595,7 +595,7 @@ impl<'a> Writer<'a> for TXT<'a> {
                 Announcement::FullyUnsent => format!("{timestamp} {who} unsent a message!\n\n"),
             },
             None => String::from("Unable to format announcement!\n\n"),
-        };
+        }
     }
 
     fn format_shareplay(&self) -> &str {
@@ -687,7 +687,7 @@ impl<'a> Writer<'a> for TXT<'a> {
         None
     }
 
-    fn format_attributed(&'a self, msg: &'a str, _: &'a TextEffect) -> Cow<str> {
+    fn format_attributed(&'a self, msg: &'a str, _: &'a TextEffect) -> Cow<'a, str> {
         // There isn't really a way to represent formatted text in a plain text export
         Cow::Borrowed(msg)
     }
@@ -1031,7 +1031,7 @@ impl<'a> BalloonFormatter<&'a str> for TXT<'a> {
     }
 }
 
-impl<'a> TXT<'a> {
+impl TXT<'_> {
     fn get_time(&self, message: &Message) -> String {
         let mut date = format(&message.date(&self.config.offset));
         let read_after = message.time_until_read(&self.config.offset);


### PR DESCRIPTION
- Add explicit lifetime parameter to `Cow` return types
- Remove explicit lifetimes when not necessary
- Remove some unnecessary return statements