### PR TITLE
Feat/cs/handle recoverable with filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,18 +160,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Documentation for the library is located [here](imessage-database/README.md).
 
 ### Supported Features
 
-This crate supports every iMessage feature as of macOS 15.2 (24C101) and iOS 18.2 (22C152):
+This crate supports every iMessage feature as of macOS 15.2 (24C101) and iOS 18.2.1 (22C161):
 
 - Multi-part messages
 - Replies/Threads

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -646,24 +646,33 @@ impl Message {
         include_recoverable: bool,
     ) -> String {
         let mut filters = String::new();
+
+        // Start date filter
         if let Some(start) = context.start {
             filters.push_str(&format!("    m.date >= {start}"));
         }
+
+        // End date filter
         if let Some(end) = context.end {
             if !filters.is_empty() {
                 filters.push_str(" AND ");
             }
             filters.push_str(&format!("    m.date <= {end}"));
         }
+
+        // Chat ID filter, optionally including recoverable messages
         if let Some(chat_ids) = &context.selected_chat_ids {
             if !filters.is_empty() {
                 filters.push_str(" AND ");
             }
+
+            // Allocate the filter string for interpolation
             let ids = chat_ids
                 .iter()
                 .map(|x| x.to_string())
                 .collect::<Vec<String>>()
                 .join(", ");
+
             if include_recoverable {
                 filters.push_str(&format!(
                     "    (c.chat_id IN ({ids}) OR d.chat_id IN ({ids}))"

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -154,11 +154,12 @@ impl Table for Message {
                  {COLS},
                  c.chat_id,
                  (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
-                 (SELECT b.chat_id FROM {RECENTLY_DELETED} b WHERE m.ROWID = b.message_id) as deleted_from,
+                 d.chat_id as deleted_from,
                  (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
              FROM
                  message as m
              LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
+             LEFT JOIN {RECENTLY_DELETED} as d ON m.ROWID = d.message_id
              ORDER BY
                  m.date;
             "

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -642,7 +642,9 @@ impl Message {
 
     /// Generate the SQL `WHERE` clause described by a [`QueryContext`].
     ///
-    /// If `include_recoverable` is included, add relevant filter details to the query
+    /// If `include_recoverable` is `true`, the filter includes messages from the recently deleted messages
+    /// table that match the chat IDs. This allows recovery of deleted messages that are still
+    /// present in the database but no longer visible in the Messages app.
     pub(crate) fn generate_filter_statement(
         context: &QueryContext,
         include_recoverable: bool,

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -119,7 +119,7 @@ impl Table for Message {
             date_read: row.get("date_read").unwrap_or(0),
             date_delivered: row.get("date_delivered").unwrap_or(0),
             is_from_me: row.get("is_from_me")?,
-            is_read: row.get("is_read")?,
+            is_read: row.get("is_read").unwrap_or(false),
             item_type: row.get("item_type").unwrap_or_default(),
             other_handle: row.get("other_handle").unwrap_or_default(),
             share_status: row.get("share_status").unwrap_or(false),

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -577,7 +577,7 @@ impl Message {
 
     /// `true` if all message components were unsent, else `false`
     pub fn is_fully_unsent(&self) -> bool {
-        self.edited_parts.as_ref().map_or(false, |ep| {
+        self.edited_parts.as_ref().is_some_and(|ep| {
             ep.parts
                 .iter()
                 .all(|part| matches!(part.status, EditStatus::Unsent))

--- a/imessage-database/src/tables/messages/tests/query_tests.rs
+++ b/imessage-database/src/tables/messages/tests/query_tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod false_tests {
+mod exclude_recoverable_tests {
     use std::{collections::BTreeSet, env::set_var};
 
     use crate::{tables::messages::Message, util::query_context::QueryContext};
@@ -105,7 +105,7 @@ mod false_tests {
 }
 
 #[cfg(test)]
-mod true_tests {
+mod include_recoverable_tests {
     use std::{collections::BTreeSet, env::set_var};
 
     use crate::{tables::messages::Message, util::query_context::QueryContext};

--- a/imessage-database/src/tables/messages/tests/query_tests.rs
+++ b/imessage-database/src/tables/messages/tests/query_tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod tests {
+mod false_tests {
     use std::{collections::BTreeSet, env::set_var};
 
     use crate::{tables::messages::Message, util::query_context::QueryContext};
@@ -8,7 +8,7 @@ mod tests {
     fn can_generate_filter_statement_empty() {
         let context = QueryContext::default();
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
         assert_eq!(statement, "")
     }
 
@@ -19,7 +19,7 @@ mod tests {
         let mut context = QueryContext::default();
         context.set_start("2020-01-01").unwrap();
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
         assert_eq!(
             statement,
             " WHERE\n                     m.date >= 599558400000000000"
@@ -33,7 +33,7 @@ mod tests {
         let mut context = QueryContext::default();
         context.set_end("2020-01-01").unwrap();
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
         assert_eq!(
             statement,
             " WHERE\n                     m.date <= 599558400000000000"
@@ -48,7 +48,7 @@ mod tests {
         context.set_start("2020-01-01").unwrap();
         context.set_end("2020-02-02").unwrap();
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
         assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000")
     }
 
@@ -59,7 +59,7 @@ mod tests {
         let mut context = QueryContext::default();
         context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
         assert_eq!(
             statement,
             " WHERE\n                     c.chat_id IN (1, 2, 3)"
@@ -75,7 +75,7 @@ mod tests {
         context.set_end("2020-02-02").unwrap();
         context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
         assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000 AND     c.chat_id IN (1, 2, 3)")
     }
 
@@ -87,7 +87,7 @@ mod tests {
         assert!(context.set_start("2020-13-32").is_err());
         assert!(!context.has_filters());
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
         assert_eq!(statement, "");
     }
 
@@ -99,7 +99,113 @@ mod tests {
         assert!(context.set_end("fake").is_err());
         assert!(!context.has_filters());
 
-        let statement = Message::generate_filter_statement(&context);
+        let statement = Message::generate_filter_statement(&context, false);
+        assert_eq!(statement, "");
+    }
+}
+
+#[cfg(test)]
+mod true_tests {
+    use std::{collections::BTreeSet, env::set_var};
+
+    use crate::{tables::messages::Message, util::query_context::QueryContext};
+
+    #[test]
+    fn can_generate_filter_statement_empty() {
+        let context = QueryContext::default();
+
+        let statement = Message::generate_filter_statement(&context, true);
+        assert_eq!(statement, "")
+    }
+
+    #[test]
+    fn can_generate_filter_statement_start() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        context.set_start("2020-01-01").unwrap();
+
+        let statement = Message::generate_filter_statement(&context, true);
+        assert_eq!(
+            statement,
+            " WHERE\n                     m.date >= 599558400000000000"
+        )
+    }
+
+    #[test]
+    fn can_generate_filter_statement_end() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        context.set_end("2020-01-01").unwrap();
+
+        let statement = Message::generate_filter_statement(&context, true);
+        assert_eq!(
+            statement,
+            " WHERE\n                     m.date <= 599558400000000000"
+        )
+    }
+
+    #[test]
+    fn can_generate_filter_statement_start_end() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        context.set_start("2020-01-01").unwrap();
+        context.set_end("2020-02-02").unwrap();
+
+        let statement = Message::generate_filter_statement(&context, true);
+        assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000")
+    }
+
+    #[test]
+    fn can_generate_filter_statement_chat_ids() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
+
+        let statement = Message::generate_filter_statement(&context, true);
+        assert_eq!(
+            statement,
+            " WHERE\n                     (c.chat_id IN (1, 2, 3) OR d.chat_id IN (1, 2, 3))"
+        )
+    }
+
+    #[test]
+    fn can_generate_filter_statement_start_end_chat_ids() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        context.set_start("2020-01-01").unwrap();
+        context.set_end("2020-02-02").unwrap();
+        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
+
+        let statement = Message::generate_filter_statement(&context, true);
+        assert_eq!(statement, " WHERE\n                     m.date >= 599558400000000000 AND     m.date <= 602323200000000000 AND     (c.chat_id IN (1, 2, 3) OR d.chat_id IN (1, 2, 3))")
+    }
+
+    #[test]
+    fn can_create_invalid_start() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        assert!(context.set_start("2020-13-32").is_err());
+        assert!(!context.has_filters());
+
+        let statement = Message::generate_filter_statement(&context, true);
+        assert_eq!(statement, "");
+    }
+
+    #[test]
+    fn can_create_invalid_end() {
+        set_var("TZ", "PST");
+
+        let mut context = QueryContext::default();
+        assert!(context.set_end("fake").is_err());
+        assert!(!context.has_filters());
+
+        let statement = Message::generate_filter_statement(&context, true);
         assert_eq!(statement, "");
     }
 }

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ReagentX/imessage-exporter"
 version = "0.0.0"
 
 [dependencies]
-clap = { version = "=4.5.23", features = ["cargo"] }
+clap = { version = "=4.5.26", features = ["cargo"] }
 filetime = "=0.2.25"
 fdlimit = "=0.3.0"
 fs2 = "=0.4.3"

--- a/imessage-exporter/src/app/compatibility/models.rs
+++ b/imessage-exporter/src/app/compatibility/models.rs
@@ -4,7 +4,7 @@
 
 use std::{
     fmt::{Display, Formatter, Result},
-    process::{Command, Stdio},
+    process::Command,
 };
 
 pub trait Converter {
@@ -161,18 +161,11 @@ impl Display for VideoConverter {
 /// Determine if a shell program exists on the system
 #[cfg(not(target_family = "windows"))]
 fn exists(name: &str) -> bool {
-    if let Ok(process) = Command::new("type")
-        .args(vec![name])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .stdin(Stdio::null())
-        .spawn()
-    {
-        if let Ok(output) = process.wait_with_output() {
-            return output.status.success();
-        }
-    };
-    false
+    Command::new("which")
+        .arg(name)
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
 }
 
 /// Determine if a shell program exists on the system

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -114,7 +114,7 @@ impl Config {
                     &self.options.db_path,
                     self.options.attachment_root.as_deref(),
                 )
-                .unwrap_or(attachment.filename().to_string()),
+                .unwrap_or_else(|| attachment.filename().to_string()),
         }
     }
 


### PR DESCRIPTION
- 70% performance improvement when using filters `-s`, `-e`, and/or `-t`
- Fix #426 
- Fix #420 