### PR TITLE
Fix extension handling during failed conversions

### DIFF
--- a/imessage-exporter/src/app/compatibility/converters/audio.rs
+++ b/imessage-exporter/src/app/compatibility/converters/audio.rs
@@ -26,14 +26,21 @@ pub(crate) fn audio_copy_convert(
         MediaType::Audio("caf") | MediaType::Audio("CAF") | MediaType::Audio("x-caf; codecs=opus")
     ) {
         let output_type = AudioType::Mp4;
+
         // Update extension for conversion
-        to.set_extension(output_type.to_str());
-        if convert_caf(from, to, converter).is_none() {
-            eprintln!("Unable to convert {from:?}");
-        } else {
+        let mut converted_path = to.clone();
+        converted_path.set_extension(output_type.to_str());
+
+        if convert_caf(from, &converted_path, converter).is_some() {
+            // If the conversion was successful, update the path
+            *to = converted_path;
             return Some(MediaType::Audio(output_type.to_str()));
+        } else {
+            eprintln!("Unable to convert {from:?}");
         }
     }
+
+    // Fallback
     copy_raw(from, to);
     None
 }

--- a/imessage-exporter/src/app/compatibility/converters/image.rs
+++ b/imessage-exporter/src/app/compatibility/converters/image.rs
@@ -26,12 +26,17 @@ pub(crate) fn image_copy_convert(
         MediaType::Image("heic") | MediaType::Image("HEIC")
     ) {
         let output_type = ImageType::Jpeg;
+
         // Update extension for conversion
-        to.set_extension(output_type.to_str());
-        if convert_heic(from, to, converter, &output_type).is_none() {
-            eprintln!("Unable to convert {from:?}");
-        } else {
+        let mut converted_path = to.clone();
+        converted_path.set_extension(output_type.to_str());
+
+        if convert_heic(from, &converted_path, converter, &output_type).is_some() {
+            // If the conversion was successful, update the path
+            *to = converted_path;
             return Some(MediaType::Image(output_type.to_str()));
+        } else {
+            eprintln!("Unable to convert {from:?}");
         }
     }
 

--- a/imessage-exporter/src/app/compatibility/converters/video.rs
+++ b/imessage-exporter/src/app/compatibility/converters/video.rs
@@ -26,12 +26,16 @@ pub(crate) fn video_copy_convert(
         MediaType::Video("mov") | MediaType::Video("MOV") | MediaType::Video("quicktime")
     ) {
         let output_type = VideoType::Mp4;
+
         // Update extension for conversion
-        to.set_extension(output_type.to_str());
-        if convert_mov(from, to, converter).is_none() {
-            eprintln!("Unable to convert {from:?}");
-        } else {
+        let mut converted_path = to.clone();
+        converted_path.set_extension(output_type.to_str());
+
+        if convert_mov(from, &converted_path, converter).is_some() {
+            *to = converted_path;
             return Some(MediaType::Video(output_type.to_str()));
+        } else {
+            eprintln!("Unable to convert {from:?}");
         }
     }
 


### PR DESCRIPTION
- Fix attachment extension logic for #431 

Previously, when HEIC->JPEG or CAF->MP4  conversion failed, the code would copy the original file to a path with the wrong extension  (e.g., copying a .heic file to .jpg). Now it only updates the extension if the conversion succeeds.


