### PR TITLE
Flamegraph Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Documentation for the library is located [here](imessage-database/README.md).
 
 ### Supported Features
 
-This crate supports every iMessage feature as of macOS 15.2 (24C101) and iOS 18.2.1 (22C161):
+This crate supports every iMessage feature as of 15.3 (24D60) and iOS 18.3 (22D63):
 
 - Multi-part messages
 - Replies/Threads
@@ -59,4 +59,4 @@ The FAQ document is located [here](/docs/faq.md).
 - [SQLiteFlow](https://www.sqliteflow.com), the SQL viewer I used to explore and reverse engineer the iMessage database
 - [Xplist](https://github.com/ic005k/Xplist), an invaluable tool for reverse engineering the `payload_data` plist format
 - [Compart](https://www.compart.com/en/unicode/), an amazing resource for looking up esoteric unicode details
-- [Archive.org](https://archive.org/details/darwin_0.1), for hosting the Darwin source referenced in reverse engineering the `typedstream` format
+- [GNU Project](https://github.com/gnustep/libobjc) and [Archive.org](https://archive.org/details/darwin_0.1), for hosting source code referenced to reverse engineer the `typedstream` format

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Documentation for the library is located [here](imessage-database/README.md).
 
 ### Supported Features
 
-This crate supports every iMessage feature as of 15.3 (24D60) and iOS 18.3 (22D63):
+This crate supports every iMessage feature as of macOS 15.3 (24D60) and iOS 18.3 (22D63):
 
 - Multi-part messages
 - Replies/Threads

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,7 +90,7 @@ On my M1 Max MacBook Pro, approximate performance is as follows:
 
 | `--copy-method` | Messages exported per second |
 |---|---|
-| `disabled` | 40,800 |
+| `disabled` | 58,000 |
 | `clone` | 29,000 |
 | `basic` | < 350 |
 | `full` | < 20 |

--- a/docs/features.md
+++ b/docs/features.md
@@ -82,7 +82,7 @@ This tool targets the current latest public release for macOS and iMessage. It m
     - Preview images display in HTML exports
     - URLs that have rotten may still retain some context if they have cached data
   - Handles cases where URL messages are overloaded with other message types
-    - Apple Music (including preview streams)
+    - Apple Music (including preview streams and lyrics)
     - Apple Maps (including `Placemark` data)
     - App Store (including app metadata)
     - Rich Collaboration

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -105,7 +105,7 @@ pub trait AttributedBody {
 /// ```
 pub fn get_connection(path: &Path) -> Result<Connection, TableError> {
     if path.exists() && path.is_file() {
-        return match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        return match Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX) {
             Ok(res) => Ok(res),
             Err(why) => Err(
                 TableError::CannotConnect(

--- a/imessage-database/src/util/typedstream/models.rs
+++ b/imessage-database/src/util/typedstream/models.rs
@@ -171,6 +171,8 @@ impl Archivable {
 }
 
 /// Represents primitive types of data that can be stored in a `typedstream`
+/// 
+/// These type encodings are partially documented [here](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html#//apple_ref/doc/uid/TP40008048-CH100-SW1) by Apple.
 // TODO: Remove clone
 #[derive(Debug, Clone, PartialEq)]
 pub enum Type {

--- a/imessage-database/src/util/typedstream/parser.rs
+++ b/imessage-database/src/util/typedstream/parser.rs
@@ -1,10 +1,10 @@
 /*!
- Logic used to deserialize data from a `typedstream`, focussing specifically on [NSAttributedString](https://developer.apple.com/documentation/foundation/nsattributedstring).
+ Logic used to deserialize data from a `typedstream`, focussing specifically on [`NSAttributedString`](https://developer.apple.com/documentation/foundation/nsattributedstring).
 
  Logic reverse engineered from `typedstream` source located at:
-   - [`typedstream.h`](https://opensource.apple.com/source/gcc/gcc-1493/libobjc/objc/typedstream.h.auto.html)
-   - [`archive.c`](https://opensource.apple.com/source/gcc/gcc-5484/libobjc/archive.c.auto.html)
-   - [`objc/typedstream.m`](https://archive.org/details/darwin_0.1)
+   - [`typedstream.h`](https://github.com/gnustep/libobjc/blob/master/objc/typedstream.h)
+   - [`archive.c`](https://github.com/gnustep/libobjc/blob/master/archive.c)
+   - [`objc/typedstream.m`](https://securitronlinux.com/news/html/d4/d6c/typedstream_8m.html)
 */
 use std::collections::HashSet;
 
@@ -497,6 +497,9 @@ impl<'a> TypedStreamReader<'a> {
     }
 
     /// Attempt to get the data from the `typedstream`.
+    ///
+    /// Yields a new [`Archivable`] as they occur in the stream, but does not retain the object's inheritance heirarchy.
+    /// Callers are responsible for assembling the stream into a useful data structure.
     ///
     /// Given a stream, construct a reader object to parse it. `typedstream` data doesn't include property
     /// names, so data is stored on [`Object`](crate::util::typedstream::models::Archivable::Object)s in order of appearance.


### PR DESCRIPTION
Changes:
- [x] `Attachment::from_row()`
  - Double attachment query performance (+3% overall)
- [x] `Message::get_replies()`
  - No changes needed
- [x] `TypedStreamReader::parse()`
- [x] `Message::from_row()`
  - Set `SQLITE_OPEN_NOMUTEX` (+40% overall)

Original flamegraph (calls in pink were removed or improved):

<img width="1505" alt="image" src="https://github.com/user-attachments/assets/abba0684-0f97-4f60-bd46-bb64cc9ad6cb" />

Final flamegraph:

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/267e9c87-d6dc-4895-b1d6-a12aed9d773f" />
