### PR TITLE
Improve page breaking behavior when printing/saving as PDF

### DIFF
--- a/imessage-exporter/src/exporters/resources/style.css
+++ b/imessage-exporter/src/exporters/resources/style.css
@@ -26,6 +26,7 @@ a[href^="#"] {
 .message {
 	margin: 1%;
 	overflow-wrap: break-word;
+	break-inside: avoid;
 }
 
 .message .sent,


### PR DESCRIPTION
I noticed that, when saving the HTML output as a PDF from the browser, messages frequently spanned across page breaks. This simply adds a CSS hint to avoid having page breaks within the messages themselves. It has no effect on anything other than when generating a paged document.

Messages longer than a page will still work as they currently do, but when a shorter message would be broken across the page, instead the renderer will try to leave space and render it on the next page.

Here's a comparison of the outputs, on the left having applied this change, on the right without it:

![image](https://github.com/user-attachments/assets/461d61c9-6f40-43bc-a15b-4fc9e88b45cb)

Thanks again for this tool!