### PR TITLE
Feat/cs/table streaming

### DIFF
--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -3,10 +3,10 @@
 
  # Iterating over Message Data
 
- Generally, use [`Message::get()`] or [`Message::stream_rows()`] to iterate over message rows.
+ Generally, use [`Message::stream()`] to iterate over message rows.
 
  ## Example
- ```rust
+ ```no_run
  use imessage_database::{
      tables::{
          messages::Message,
@@ -15,14 +15,20 @@
      util::dirs::default_db_path,
  };
 
+ // Your custom error type
+ struct ProgramError;
+
+ // Get the default database path and connect to it
  let db_path = default_db_path();
  let conn = get_connection(&db_path).unwrap();
 
- let mut statement = Message::get(&conn).unwrap();
-
- let messages = statement.query_map([], |row| Ok(Message::from_row(row))).unwrap();
-
- messages.map(|msg| println!("{:#?}", Message::extract(msg)));
+ Message::stream(&conn, |message_result| {
+    match message_result {
+        Ok(message) => println!("Message: {:#?}", message),
+        Err(e) => eprintln!("Error: {:?}", e),
+    }
+    Ok::<(), ProgramError>(())
+ }).unwrap();
  ```
 
  # Making Custom Message Queries
@@ -75,7 +81,7 @@
  The following will return an iterator over messages that have an associated emoji:
 
 
- ```rust
+ ```no_run
  use imessage_database::{
      tables::{
          messages::Message,
@@ -105,7 +111,7 @@
 
  let messages = statement.query_map([], |row| Ok(Message::from_row(row))).unwrap();
 
- messages.map(|msg| println!("{:#?}", Message::extract(msg)));
+ messages.for_each(|msg| println!("{:#?}", Message::extract(msg)));
  ```
 */
 

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -4,7 +4,6 @@
  # Zero-Allocation Streaming API
 
  This module provides zero-allocation streaming capabilities for all database tables through a callback-based API.
- This allows processing large tables without loading them entirely into memory, which is crucial for performance and memory efficiency.
 
  ```no_run
  use imessage_database::{

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -102,42 +102,44 @@ impl<'a> Exporter<'a> for HTML<'a> {
             Message::get_count(self.config.db(), &self.config.options.query_context)?;
         self.pb.start(total_messages);
 
-        let mut statement =
-            Message::stream_rows(self.config.db(), &self.config.options.query_context)?;
+        Message::stream(self.config.db(), |message_result| {
+            match message_result {
+                Ok(mut msg) => {
+                    // Early escape if we try and render the same message GUID twice
+                    // See https://github.com/ReagentX/imessage-exporter/issues/135 for rationale
+                    if msg.rowid == current_message_row {
+                        current_message += 1;
+                        return Ok(());
+                    }
+                    current_message_row = msg.rowid;
 
-        let messages = statement
-            .query_map([], |row| Ok(Message::from_row(row)))
-            .map_err(|err| RuntimeError::DatabaseError(TableError::QueryError(err)))?;
+                    // Generate the text of the message
+                    let _ = msg.generate_text(self.config.db());
 
-        for message in messages {
-            let mut msg = Message::extract(message)?;
+                    // Render the announcement in-line
+                    if msg.is_announcement() {
+                        let announcement = self.format_announcement(&msg);
+                        HTML::write_to_file(self.get_or_create_file(&msg)?, &announcement)?;
+                    }
+                    // Message replies and tapbacks are rendered in context, so no need to render them separately
+                    else if !msg.is_tapback() {
+                        let message = self.format_message(&msg, 0)?;
+                        HTML::write_to_file(self.get_or_create_file(&msg)?, &message)?;
+                    }
 
-            // Early escape if we try and render the same message GUID twice
-            // See https://github.com/ReagentX/imessage-exporter/issues/135 for rationale
-            if msg.rowid == current_message_row {
-                current_message += 1;
-                continue;
+                    current_message += 1;
+                    if current_message % 99 == 0 {
+                        self.pb.set_position(current_message);
+                    }
+                }
+                Err(err) => {
+                    // If we encounter an error, log it and continue
+                    eprintln!("Error processing message: {}", err);
+                }
             }
-            current_message_row = msg.rowid;
+            Ok::<(), RuntimeError>(())
+        })?;
 
-            // Generate the text of the message
-            let _ = msg.generate_text(self.config.db());
-
-            // Render the announcement in-line
-            if msg.is_announcement() {
-                let announcement = self.format_announcement(&msg);
-                HTML::write_to_file(self.get_or_create_file(&msg)?, &announcement)?;
-            }
-            // Message replies and tapbacks are rendered in context, so no need to render them separately
-            else if !msg.is_tapback() {
-                let message = self.format_message(&msg, 0)?;
-                HTML::write_to_file(self.get_or_create_file(&msg)?, &message)?;
-            }
-            current_message += 1;
-            if current_message % 99 == 0 {
-                self.pb.set_position(current_message);
-            }
-        }
         self.pb.finish();
 
         eprintln!("Writing HTML footers...");

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -134,7 +134,7 @@ impl<'a> Exporter<'a> for HTML<'a> {
                 }
                 Err(err) => {
                     // If we encounter an error, log it and continue
-                    eprintln!("Error processing message: {}", err);
+                    eprintln!("Error retrieving message: {}", err);
                 }
             }
             Ok::<(), RuntimeError>(())

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -127,7 +127,7 @@ impl<'a> Exporter<'a> for TXT<'a> {
                 }
                 Err(err) => {
                     // If we encounter an error, log it and continue
-                    eprintln!("Error processing message: {}", err);
+                    eprintln!("Error retrieving message: {}", err);
                 }
             }
             Ok::<(), RuntimeError>(())


### PR DESCRIPTION
- Permit continuing over failed message parsing in exporter
- Add `Table::stream()` method, simplifies table iteration usage
  - Zero-allocation table iteration via callback-based streaming
  - Removes need for `rusqlite` boilerplate from library consumers

Previously:

```rust
 let mut statement = Message::get(&conn)?;

 let messages = statement.query_map([], |row| Ok(Message::from_row(row)))?;

 messages.for_each(|msg| println!("{:#?}", Message::extract(msg)?));
```

With streaming trait method:

```rust
 Message::stream(&conn, |message_result| {
    println!("Message: {:#?}", message?)
    Ok(())
 })?;
```