### PR TITLE
Chaparral Lotus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "byteorder"
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -233,9 +233,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "console"
-version = "0.16.1"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b430743a6eb14e9764d4260d4c0d8123087d504eeb9c48f2b2a5e810dd369df4"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "foldhash"
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -575,15 +575,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -597,15 +597,15 @@ checksum = "17ab85f84ca42c5ec520e6f3c9966ba1fd62909ce260f8837e248857d2560509"
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.11.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
 
 [[package]]
 name = "powerfmt"
@@ -740,9 +740,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
@@ -809,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
@@ -830,9 +830,9 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]
@@ -895,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -989,9 +989,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1000,14 +1000,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.23.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
  "getrandom",
  "once_cell",
- "rustix 1.1.2",
+ "rustix 1.1.3",
  "windows-sys 0.61.2",
 ]
 
@@ -1033,30 +1033,30 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -200,18 +200,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,22 +72,22 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.10"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -110,9 +110,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "0e050f626429857a27ddccb31e0aca21356bfa709c04041aefddac081a8f068a"
 
 [[package]]
 name = "bitflags"
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.45"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -200,18 +200,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.51"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -283,9 +283,9 @@ checksum = "fafbe57c349843caca2aa70b4a98bf688123845ac080c324f407f9ecb71873c1"
 
 [[package]]
 name = "crc"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
 dependencies = [
  "crc-catalog",
 ]
@@ -298,9 +298,9 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "foldhash"
@@ -418,9 +418,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "hashlink"
@@ -536,19 +536,19 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
 name = "indicatif"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade6dfcba0dfb62ad59e59e7241ec8912af34fd29e0e743e3db992bd278e8b65"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
  "console",
  "portable-atomic",
@@ -581,9 +581,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.82"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -597,9 +597,9 @@ checksum = "17ab85f84ca42c5ec520e6f3c9966ba1fd62909ce260f8837e248857d2560509"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libredox"
@@ -637,9 +637,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lzma-rs"
@@ -800,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
 ]
@@ -989,9 +989,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.110"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1082,9 +1082,9 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unit-prefix"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "323402cff2dd658f39ca17c789b502021b3f18707c91cdf22e3838e1b4023817"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "utf8parse"
@@ -1115,9 +1115,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1128,9 +1128,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1138,9 +1138,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1151,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.105"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "crabapple"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdacd9870cf0b34b69fa176a1aa243fff04d36039680b5fe51f84b04c5a84848"
+checksum = "a152742e9f420fd51a0465448c92e7fb2818d7a7e2a16591be9d4e2f01c94b9d"
 dependencies = [
  "aes",
  "aes-kw",
@@ -379,7 +379,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -402,9 +402,9 @@ checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "fs2"
@@ -440,26 +440,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-
-[[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown",
 ]
 
 [[package]]
@@ -541,7 +535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
 ]
 
 [[package]]
@@ -614,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "95b4103cffefa72eb8428cb6b47d6627161e51c2739fc5e3b734584157bc642a"
 dependencies = [
  "cc",
  "pkg-config",
@@ -755,7 +749,7 @@ checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -770,7 +764,7 @@ dependencies = [
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -785,7 +779,7 @@ dependencies = [
  "protobuf",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "which",
 ]
 
@@ -795,7 +789,7 @@ version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -868,9 +862,9 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "f1c93dd1c9683b438c392c492109cb702b8090b2bfc8fed6f6e4eb4523f17af3"
 dependencies = [
  "bitflags",
  "fallible-iterator",
@@ -878,6 +872,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -976,6 +971,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e98301bf8b0540c7de45ecd760539b9c62f5772aed172f08efba597c11cd5d"
+dependencies = [
+ "cc",
+ "hashbrown",
+ "js-sys",
+ "thiserror 2.0.17",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1017,7 +1025,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -1025,6 +1042,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Documentation for the library is located [here](imessage-database/README.md).
 
 ### Supported Features
 
-This crate supports every iMessage feature as of macOS Tahoe 26.1 (25B78) and iOS 26.1 (23B85):
+This crate supports every iMessage feature as of macOS Tahoe 26.2 (25C56) and iOS 26.2 (23C55):
 
 - iMessage, RCS, SMS, and MMS
 - Multi-part messages

--- a/imessage-database/Cargo.toml
+++ b/imessage-database/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ReagentX/imessage-exporter"
 version = "0.0.0"
 
 [dependencies]
-chrono = "=0.4.42"
+chrono = "=0.4.43"
 plist = "=1.8.0"
 rusqlite = { version = "=0.37.0", features = ["blob", "bundled"] }
 sha1 = "=0.10.6"

--- a/imessage-database/Cargo.toml
+++ b/imessage-database/Cargo.toml
@@ -12,7 +12,7 @@ version = "0.0.0"
 [dependencies]
 chrono = "=0.4.43"
 plist = "=1.8.0"
-rusqlite = { version = "=0.37.0", features = ["blob", "bundled"] }
+rusqlite = { version = "=0.38.0", features = ["blob", "bundled"] }
 sha1 = "=0.10.6"
 protobuf = "=3.7.2"
 lzma-rs = "=0.3.0"

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -32,7 +32,7 @@ use crate::{
 };
 
 // MARK: Constants
-/// The default root directory for iMessage database files, which replace with the custom attachment root if provided
+/// The default root directory for iMessage database files, which is replaced with the custom attachment root if provided
 pub const DEFAULT_MESSAGES_ROOT: &str = "~/Library/Messages";
 /// The default root directory for iMessage attachment data
 pub const DEFAULT_ATTACHMENT_ROOT: &str = "~/Library/Messages/Attachments";
@@ -680,7 +680,7 @@ mod tests {
     fn can_get_resolved_path_macos_custom_sticker() {
         let db_path = PathBuf::from("fake_root");
         let mut attachment = sample_attachment();
-        // Sample path like `~/Library/Messages/Attachments/0a/10/.../image.jpeg`
+        // Sample path like `~/Library/Messages/StickerCache/0a/10/.../image.jpeg`
         attachment.filename = Some(format!("{DEFAULT_STICKER_CACHE_ROOT}/a/b/c.png"));
 
         assert_eq!(

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -32,8 +32,12 @@ use crate::{
 };
 
 // MARK: Constants
+/// The default root directory for iMessage database files, which replace with the custom attachment root if provided
+pub const DEFAULT_MESSAGES_ROOT: &str = "~/Library/Messages";
 /// The default root directory for iMessage attachment data
 pub const DEFAULT_ATTACHMENT_ROOT: &str = "~/Library/Messages/Attachments";
+/// The default root directory for iMessage sticker cache data
+pub const DEFAULT_STICKER_CACHE_ROOT: &str = "~/Library/Messages/StickerCache";
 const COLS: &str = "a.rowid, a.filename, a.uti, a.mime_type, a.transfer_name, a.total_bytes, a.is_sticker, a.hide_attachment, a.emoji_image_short_description";
 
 // MARK: MediaType
@@ -349,10 +353,14 @@ impl Attachment {
         custom_attachment_root: Option<&str>,
     ) -> Option<String> {
         if let Some(mut path_str) = self.filename.clone() {
-            // Apply custom attachment path
-            if let Some(custom_attachment_path) = custom_attachment_root {
-                path_str = path_str.replace(DEFAULT_ATTACHMENT_ROOT, custom_attachment_path);
+            // Apply custom attachment path, if provided
+            if let Some(custom_attachment_path) = custom_attachment_root
+                && (path_str.starts_with(DEFAULT_STICKER_CACHE_ROOT)
+                    || path_str.starts_with(DEFAULT_ATTACHMENT_ROOT))
+            {
+                path_str = path_str.replace(DEFAULT_MESSAGES_ROOT, custom_attachment_path);
             }
+
             return match platform {
                 Platform::macOS => Some(Attachment::gen_macos_attachment(&path_str)),
                 Platform::iOS => Attachment::gen_ios_attachment(&path_str, db_path),
@@ -534,7 +542,9 @@ impl Attachment {
 mod tests {
     use crate::{
         tables::{
-            attachment::{Attachment, DEFAULT_ATTACHMENT_ROOT, MediaType},
+            attachment::{
+                Attachment, DEFAULT_ATTACHMENT_ROOT, DEFAULT_STICKER_CACHE_ROOT, MediaType,
+            },
             table::get_connection,
         },
         util::{platform::Platform, query_context::QueryContext},
@@ -662,7 +672,20 @@ mod tests {
 
         assert_eq!(
             attachment.resolved_attachment_path(&Platform::macOS, &db_path, Some("custom/root")),
-            Some("custom/root/a/b/c.png".to_string())
+            Some("custom/root/Attachments/a/b/c.png".to_string())
+        );
+    }
+
+    #[test]
+    fn can_get_resolved_path_macos_custom_sticker() {
+        let db_path = PathBuf::from("fake_root");
+        let mut attachment = sample_attachment();
+        // Sample path like `~/Library/Messages/Attachments/0a/10/.../image.jpeg`
+        attachment.filename = Some(format!("{DEFAULT_STICKER_CACHE_ROOT}/a/b/c.png"));
+
+        assert_eq!(
+            attachment.resolved_attachment_path(&Platform::macOS, &db_path, Some("custom/root")),
+            Some("custom/root/StickerCache/a/b/c.png".to_string())
         );
     }
 

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -358,7 +358,7 @@ impl Attachment {
                 && (path_str.starts_with(DEFAULT_STICKER_CACHE_ROOT)
                     || path_str.starts_with(DEFAULT_ATTACHMENT_ROOT))
             {
-                path_str = path_str.replace(DEFAULT_MESSAGES_ROOT, custom_attachment_path);
+                path_str = path_str.replacen(DEFAULT_MESSAGES_ROOT, custom_attachment_path, 1);
             }
 
             return match platform {

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -930,7 +930,7 @@ impl Message {
     /// let context = QueryContext::default();
     /// Message::get_count(&conn, &context);
     /// ```
-    pub fn get_count(db: &Connection, context: &QueryContext) -> Result<u64, TableError> {
+    pub fn get_count(db: &Connection, context: &QueryContext) -> Result<i64, TableError> {
         let mut statement = if context.has_filters() {
             db.prepare_cached(&format!(
                 "SELECT
@@ -955,7 +955,7 @@ impl Message {
             db.prepare_cached(&format!("SELECT COUNT(*) FROM {MESSAGE}"))?
         };
         // Execute query, defaulting to zero if it fails
-        let count: u64 = statement.query_row([], |r| r.get(0)).unwrap_or(0);
+        let count: i64 = statement.query_row([], |r| r.get(0)).unwrap_or(0);
 
         Ok(count)
     }

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -796,7 +796,7 @@ impl Message {
         self.deleted_from.is_some()
     }
 
-    /// `true` if the message was translated, else `false`
+    /// `true` if the message was translated, else `false`. Only works on iOS 16+ databases.
     pub fn has_translation(&self, db: &Connection) -> bool {
         // `7472616E736C6174696F6E4C616E6775616765` -> "translationLanguage"
         // `7472616E736C6174656454657874` -> "translatedText"
@@ -824,7 +824,7 @@ impl Message {
         Ok(None)
     }
 
-    /// Cache all message GUIDs that contain translation data
+    /// Cache all message GUIDs that contain translation data. Only works on iOS 16+ databases.
     pub fn cache_translations(db: &Connection) -> Result<HashSet<String>, TableError> {
         // `7472616E736C6174696F6E4C616E6775616765` -> "translationLanguage"
         // `7472616E736C6174656454657874` -> "translatedText"

--- a/imessage-database/src/util/dates.rs
+++ b/imessage-database/src/util/dates.rs
@@ -50,7 +50,15 @@ pub fn get_offset() -> i64 {
 /// let local = get_local_time(&674526582885055488, &current_offset).unwrap();
 /// ```
 pub fn get_local_time(date_stamp: &i64, offset: &i64) -> Result<DateTime<Local>, MessageError> {
-    let utc_stamp = DateTime::from_timestamp((date_stamp / TIMESTAMP_FACTOR) + offset, 0)
+    // Newer databases store timestamps as nanoseconds since 2001-01-01,
+    // while older ones store plain seconds since 2001-01-01.
+    let seconds_since_2001 = if *date_stamp >= 1_000_000_000_000 {
+        date_stamp / TIMESTAMP_FACTOR
+    } else {
+        *date_stamp
+    };
+
+    let utc_stamp = DateTime::from_timestamp(seconds_since_2001 + offset, 0)
         .ok_or(MessageError::InvalidTimestamp(*date_stamp))?
         .naive_utc();
     Ok(Local.from_utc_datetime(&utc_stamp))
@@ -155,7 +163,7 @@ pub fn readable_diff(
 mod tests {
     use crate::{
         error::message::MessageError,
-        util::dates::{format, readable_diff},
+        util::dates::{TIMESTAMP_FACTOR, format, get_local_time, get_offset, readable_diff},
     };
     use chrono::prelude::*;
 
@@ -281,5 +289,74 @@ mod tests {
         let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
         let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
         assert_eq!(readable_diff(start, end), Some(String::new()));
+    }
+
+    #[test]
+    fn can_get_local_time_from_seconds_timestamp() {
+        let offset = get_offset();
+        let expected_utc = Utc
+            .with_ymd_and_hms(2020, 5, 20, 9, 10, 11)
+            .single()
+            .unwrap();
+
+        // Older databases store seconds since 2001-01-01 00:00:00
+        let stamp_secs = expected_utc.timestamp() - offset;
+
+        let local = get_local_time(&stamp_secs, &offset).unwrap();
+        let expected_local = expected_utc.with_timezone(&Local);
+
+        assert_eq!(local, expected_local);
+    }
+
+    #[test]
+    fn can_get_local_time_from_nanoseconds_timestamp() {
+        let offset = get_offset();
+        let expected_utc = Utc
+            .with_ymd_and_hms(2020, 5, 20, 9, 10, 11)
+            .single()
+            .unwrap();
+
+        // Newer databases store nanoseconds since 2001-01-01 00:00:00
+        let stamp_ns = (expected_utc.timestamp() - offset) * TIMESTAMP_FACTOR;
+
+        let local = get_local_time(&stamp_ns, &offset).unwrap();
+        let expected_local = expected_utc.with_timezone(&Local);
+
+        assert_eq!(local, expected_local);
+    }
+
+    #[test]
+    fn can_get_local_time_from_hardcoded_seconds_timestamp() {
+        let offset = get_offset();
+
+        // Legacy-style seconds timestamp
+        let stamp_secs: i64 = 347_670_404;
+
+        let expected_utc = Utc.timestamp_opt(stamp_secs + offset, 0).single().unwrap();
+
+        let local = get_local_time(&stamp_secs, &offset).unwrap();
+        let expected_local = expected_utc.with_timezone(&Local);
+
+        assert_eq!(local, expected_local);
+    }
+
+    #[test]
+    fn can_get_local_time_from_hardcoded_nanoseconds_timestamp() {
+        let offset = get_offset();
+
+        // Nanosecond-style timestamp
+        let stamp_ns: i64 = 549_948_395_013_559_360;
+
+        let seconds_since_2001 = stamp_ns / TIMESTAMP_FACTOR;
+
+        let expected_utc = Utc
+            .timestamp_opt(seconds_since_2001 + offset, 0)
+            .single()
+            .unwrap();
+
+        let local = get_local_time(&stamp_ns, &offset).unwrap();
+        let expected_local = expected_utc.with_timezone(&Local);
+
+        assert_eq!(local, expected_local);
     }
 }

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/ReagentX/imessage-exporter"
 version = "0.0.0"
 
 [dependencies]
-clap = { version = "=4.5.53", features = ["cargo"] }
+clap = { version = "=4.5.54", features = ["cargo"] }
 filetime = "=0.2.26"
 fdlimit = "=0.3.0"
 fs2 = "=0.4.3"

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/ReagentX/imessage-exporter"
 version = "0.0.0"
 
 [dependencies]
-clap = { version = "=4.5.51", features = ["cargo"] }
+clap = { version = "=4.5.53", features = ["cargo"] }
 filetime = "=0.2.26"
 fdlimit = "=0.3.0"
 fs2 = "=0.4.3"
 imessage-database = { path = "../imessage-database" }
-indicatif = "=0.18.2"
+indicatif = "=0.18.3"
 rusqlite = { version = "0.37.0", features = ["blob", "bundled"] }
 crabapple = { version = "=0.4.4" }

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -16,5 +16,5 @@ fdlimit = "=0.3.0"
 fs2 = "=0.4.3"
 imessage-database = { path = "../imessage-database" }
 indicatif = "=0.18.3"
-rusqlite = { version = "0.37.0", features = ["blob", "bundled"] }
-crabapple = { version = "=0.4.4" }
+rusqlite = { version = "0.38.0", features = ["blob", "bundled"] }
+crabapple = { version = "=0.4.5" }

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -70,7 +70,7 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         Specify an optional custom path to look for attachment data in (macOS only)
         Only use this if attachments are stored separately from the database's default location
         This option affects both the `Attachments` and `StickerCache` directories
-        The default location is /Users/chris/Library/Messages
+        The default location is ~Library/Messages
         
 -a, --platform <macOS, iOS>
         Specify the platform the database was created on

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -67,9 +67,10 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         If omitted, the default directory is ~/Library/Messages/chat.db
         
 -r, --attachment-root <path/to/attachments>
-        Specify an optional custom path to look for attachments in (macOS only)
+        Specify an optional custom path to look for attachment data in (macOS only)
         Only use this if attachments are stored separately from the database's default location
-        The default location is ~/Library/Messages/Attachments
+        This option affects both the `Attachments` and `StickerCache` directories
+        The default location is /Users/chris/Library/Messages
         
 -a, --platform <macOS, iOS>
         Specify the platform the database was created on

--- a/imessage-exporter/src/app/contacts.rs
+++ b/imessage-exporter/src/app/contacts.rs
@@ -228,11 +228,10 @@ impl ContactsIndex {
         for id_part in id.split_whitespace() {
             if looks_like_email(id_part) {
                 return normalize_email(id_part).and_then(|k| self.index.get(&k).cloned());
-            } else {
-                for k in phone_keys(id_part) {
-                    if let Some(n) = self.index.get(&k) {
-                        return Some(n.clone());
-                    }
+            }
+            for k in phone_keys(id_part) {
+                if let Some(n) = self.index.get(&k) {
+                    return Some(n.clone());
                 }
             }
         }

--- a/imessage-exporter/src/app/contacts.rs
+++ b/imessage-exporter/src/app/contacts.rs
@@ -9,6 +9,7 @@ use imessage_database::{
 };
 use rusqlite::{Connection, Result};
 
+/// The default contacts file location from the root of an iOS backup
 pub const DEFAULT_PATH_IOS: &str = "31/31bb7ba8914766d4ba40d6dfb6113c8b614be442";
 
 // MARK: Name

--- a/imessage-exporter/src/app/contacts.rs
+++ b/imessage-exporter/src/app/contacts.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
 };
@@ -23,6 +23,8 @@ pub struct Name {
     pub full: String,
     /// Combined handle details from iMessage's database
     pub details: String,
+    /// Set of original handle IDs that map to this name
+    pub handle_ids: HashSet<i32>,
 }
 
 impl Name {
@@ -50,6 +52,7 @@ impl Name {
             last: last.unwrap_or_default(),
             full,
             details: String::new(),
+            handle_ids: HashSet::new(),
         })
     }
 
@@ -82,6 +85,7 @@ impl Name {
             last: String::new(),
             full: String::new(),
             details: details.into(),
+            handle_ids: HashSet::new(),
         }
     }
 }
@@ -95,6 +99,7 @@ impl Name {
             last: String::new(),
             full: String::new(),
             details: name.to_string(),
+            handle_ids: HashSet::new(),
         }
     }
 }
@@ -244,18 +249,28 @@ impl ContactsIndex {
         participants: &HashMap<i32, String>,
         deduped_handles: &HashMap<i32, i32>,
     ) -> HashMap<i32, Name> {
-        let mut result = HashMap::new();
+        let mut result: HashMap<i32, Name> = HashMap::new();
 
-        for (handle_id, details) in participants {
-            if let Some(deduped_id) = deduped_handles.get(handle_id) {
-                let mut name = self
-                    .lookup(details)
-                    .unwrap_or_else(|| Name::from_details(details.clone()));
+        for (&handle_id, details) in participants {
+            let Some(&deduped_id) = deduped_handles.get(&handle_id) else {
+                continue;
+            };
 
-                // Update details field for the resolved Name
-                name.details = details.clone();
-                result.insert(*deduped_id, name);
-            }
+            result
+                .entry(deduped_id)
+                .and_modify(|name| {
+                    name.handle_ids.insert(handle_id);
+                })
+                .or_insert_with(|| {
+                    let mut name = self
+                        .lookup(details)
+                        .unwrap_or_else(|| Name::from_details(details.clone()));
+
+                    // Keep the original details string for display/fallback
+                    name.details = details.clone();
+                    name.handle_ids.insert(handle_id);
+                    name
+                });
         }
 
         result

--- a/imessage-exporter/src/app/data_source.rs
+++ b/imessage-exporter/src/app/data_source.rs
@@ -90,7 +90,7 @@ impl DataSource {
 
                     // Build contacts index
                     let contacts_index =
-                        Self::get_contacts_index(Some(Path::new(DEFAULT_PATH_IOS)))
+                        Self::get_contacts_index(Some(&options.db_path.join(DEFAULT_PATH_IOS)))
                             .unwrap_or_default();
 
                     Ok(Self {

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use clap::{Arg, ArgAction, ArgMatches, Command, crate_version};
 
 use imessage_database::{
-    tables::{attachment::DEFAULT_ATTACHMENT_ROOT, table::DEFAULT_PATH_IOS},
+    tables::{attachment::DEFAULT_MESSAGES_ROOT, table::DEFAULT_PATH_IOS},
     util::{
         dirs::{default_db_path, home},
         platform::Platform,
@@ -372,7 +372,7 @@ fn get_command() -> Command {
             Arg::new(OPTION_ATTACHMENT_ROOT)
                 .short('r')
                 .long(OPTION_ATTACHMENT_ROOT)
-                .help(format!("Specify an optional custom path to look for attachments in (macOS only)\nOnly use this if attachments are stored separately from the database's default location\nThe default location is {}\n", DEFAULT_ATTACHMENT_ROOT.replacen('~', &home(), 1)))
+                .help(format!("Specify an optional custom path to look for attachment data in (macOS only)\nOnly use this if attachments are stored separately from the database's default location\nThs option affects both the `Attachments` and `StickerCache` directories\nThe default location is {}\n", DEFAULT_MESSAGES_ROOT.replacen('~', &home(), 1)))
                 .display_order(4)
                 .value_name("path/to/attachments"),
         )

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -372,7 +372,7 @@ fn get_command() -> Command {
             Arg::new(OPTION_ATTACHMENT_ROOT)
                 .short('r')
                 .long(OPTION_ATTACHMENT_ROOT)
-                .help(format!("Specify an optional custom path to look for attachment data in (macOS only)\nOnly use this if attachments are stored separately from the database's default location\nThs option affects both the `Attachments` and `StickerCache` directories\nThe default location is {}\n", DEFAULT_MESSAGES_ROOT.replacen('~', &home(), 1)))
+                .help(format!("Specify an optional custom path to look for attachment data in (macOS only)\nOnly use this if attachments are stored separately from the database's default location\nThis option affects both the `Attachments` and `StickerCache` directories\nThe default location is {}\n", DEFAULT_MESSAGES_ROOT.replacen('~', &home(), 1)))
                 .display_order(4)
                 .value_name("path/to/attachments"),
         )

--- a/imessage-exporter/src/app/progress.rs
+++ b/imessage-exporter/src/app/progress.rs
@@ -31,10 +31,10 @@ impl ExportProgress {
     }
 
     /// Starts the progress bar with the specified total length
-    pub fn start(&self, length: u64) {
+    pub fn start(&self, length: i64) {
         self.bar.set_position(0);
         self.bar.enable_steady_tick(Duration::from_millis(100));
-        self.bar.set_length(length);
+        self.bar.set_length(length as u64);
         self.bar.set_draw_target(ProgressDrawTarget::stdout());
     }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -279,15 +279,13 @@ impl Config {
             let mut included_handles: BTreeSet<i32> = BTreeSet::new();
 
             // First: Scan the list of participants for included handle IDs
-            self.participants
-                .iter()
-                .for_each(|(handle_id, handle_name)| {
-                    for included_name in &parsed_handle_filter {
-                        if handle_name.contains(included_name) {
-                            included_handles.insert(*handle_id);
-                        }
+            self.participants.iter().for_each(|(_, handle_name)| {
+                for included_name in &parsed_handle_filter {
+                    if handle_name.contains(included_name) {
+                        included_handles.extend(&handle_name.handle_ids);
                     }
-                });
+                }
+            });
 
             // Second: scan the list of chatrooms for IDs that contain the selected participants
             self.chatroom_participants
@@ -1111,6 +1109,11 @@ mod chat_filter_tests {
         app.participants.insert(12, Name::fake_name("Person 12")); // Included
         app.participants.insert(13, Name::fake_name("Person 13")); // Excluded
 
+        // Set the chatroom participant IDs
+        for (id, participant) in app.participants.iter_mut() {
+            participant.handle_ids.insert(*id);
+        }
+
         // Chatroom 1: Included
         let mut chatroom_1 = BTreeSet::new();
         chatroom_1.insert(10);
@@ -1168,6 +1171,11 @@ mod chat_filter_tests {
         app.participants.insert(11, Name::fake_name("Person 11")); // Excluded
         app.participants.insert(12, Name::fake_name("Person 12")); // Excluded
         app.participants.insert(13, Name::fake_name("Person 13")); // Included
+
+        // Set the chatroom participant IDs
+        for (id, participant) in app.participants.iter_mut() {
+            participant.handle_ids.insert(*id);
+        }
 
         // Chatroom 1: Excluded
         let mut chatroom_1 = BTreeSet::new();

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -140,12 +140,16 @@ impl Config {
     ///
     /// If it does not, first try and make a flat list of its members. Failing that, use the unique `chat_identifier` field.
     pub fn filename(&self, chatroom: &Chat) -> String {
+        // Calculate effective max length accounting for export path
+        let export_path_len = self.options.export_path.as_os_str().len();
+        let max_len = MAX_LENGTH.saturating_sub(export_path_len + 1);
+
         let mut filename = match &chatroom.display_name() {
             // If there is a display name, use that
             Some(name) => {
                 format!(
                     "{} - {}",
-                    &name[..min(MAX_LENGTH, name.len())],
+                    &name[..min(max_len, name.len())],
                     // Get the deduplicated chat ID to ensure the filename is unique, even if the group name is not
                     self.real_chatrooms
                         .get(&chatroom.rowid)
@@ -181,15 +185,19 @@ impl Config {
     /// - Truncated Names
     ///   - Contact 1, Contact 2, ... Contact 13 and 4 others
     fn filename_from_participants(&self, participants: &BTreeSet<i32>) -> String {
+        // Calculate effective max length accounting for export path
+        let export_path_len = self.options.export_path.as_os_str().len();
+        let max_len = MAX_LENGTH.saturating_sub(export_path_len + 1);
+
         let mut added = 0;
-        let mut out_s = String::with_capacity(MAX_LENGTH);
+        let mut out_s = String::with_capacity(max_len);
         for participant_id in participants {
             let participant_details = match self.resolve_participant(*participant_id) {
                 Some(name) => name.details.as_str(),
                 None => UNKNOWN,
             };
 
-            if participant_details.len() + out_s.len() < MAX_LENGTH {
+            if participant_details.len() + out_s.len() < max_len {
                 if !out_s.is_empty() {
                     out_s.push_str(", ");
                 }
@@ -198,10 +206,10 @@ impl Config {
             } else {
                 let extra = format!(", and {} others", participants.len() - added);
                 let space_remaining = extra.len() + out_s.len();
-                if space_remaining >= MAX_LENGTH {
-                    out_s.replace_range((MAX_LENGTH - extra.len()).., &extra);
+                if space_remaining >= max_len {
+                    out_s.replace_range((max_len - extra.len()).., &extra);
                 } else if out_s.is_empty() {
-                    out_s.push_str(&participant_details[..MAX_LENGTH]);
+                    out_s.push_str(&participant_details[..max_len]);
                 } else {
                     out_s.push_str(&extra);
                 }
@@ -712,7 +720,7 @@ mod filename_tests {
 
         // Get filename
         let filename = app.filename_from_participants(&people);
-        assert_eq!(filename, "Person With An Extremely and Excessively Long Name 10, Person With An Extremely and Excessively Long Name 11, Person With An Extremely and Excessively Long Name 12, Person With An Extremely and Excessively Long Name 13, and 4 others".to_string());
+        assert_eq!(filename, "Person With An Extremely and Excessively Long Name 10, Person With An Extremely and Excessively Long Name 11, Person With An Extremely and Excessively Long Name 12, Person With An Extremely and Excessively Long Name , and 4 others".to_string());
         assert!(filename.len() <= MAX_LENGTH);
     }
 
@@ -731,7 +739,7 @@ mod filename_tests {
 
         // Get filename
         let filename = app.filename_from_participants(&people);
-        assert_eq!(filename, "He slipped his key into the lock, and we all very quietly entered the cell. The sleeper half turned, and then settled down once more into a deep slumber. Holmes stooped to the water-jug, moistened his sponge, and then rubbed it twice v".to_string());
+        assert_eq!(filename, "He slipped his key into the lock, and we all very quietly entered the cell. The sleeper half turned, and then settled down once more into a deep slumber. Holmes stooped to the water-jug, moistened his sponge, and then rubbed it tw".to_string());
         assert!(filename.len() <= MAX_LENGTH);
     }
 
@@ -748,7 +756,7 @@ mod filename_tests {
         let filename = app.filename(&chat);
         assert_eq!(
             filename,
-            "Life is infinitely stranger than anything which the mind of man could invent. We would not dare to conceive the things which are really mere commonplaces of existence. If we could fly out of that window hand in hand, hover over this gr - 0.html"
+            "Life is infinitely stranger than anything which the mind of man could invent. We would not dare to conceive the things which are really mere commonplaces of existence. If we could fly out of that window hand in hand, hover over th - 0.html"
         );
     }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -249,7 +249,8 @@ impl Config {
         let tapbacks = Message::cache(data_source.db())?;
 
         eprintln!("  [5/5] Caching translations...");
-        let translated_messages = Message::cache_translations(data_source.db())?;
+        // Translations are not available in older database versions, so we default to an empty set
+        let translated_messages = Message::cache_translations(data_source.db()).unwrap_or_default();
         eprintln!("Cache built!");
 
         Ok(Config {

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -623,10 +623,10 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
             MediaType::Audio(media_type) => {
                 if let Some(transcription) = &metadata.transcription {
                     return Ok(format!(
-                        "<div><audio controls src=\"{embed_path}\" type=\"{media_type}\" </audio></div> <hr><span class=\"transcription\">Transcription: {transcription}</span>"
+                        "<div><audio controls src=\"{embed_path}\" type=\"{media_type}\"> </audio></div> <hr><span class=\"transcription\">Transcription: {transcription}</span>"
                     ));
                 }
-                format!("<audio controls src=\"{embed_path}\" type=\"{media_type}\" </audio>")
+                format!("<audio controls src=\"{embed_path}\" type=\"{media_type}\"> </audio>")
             }
             MediaType::Text(_) => {
                 format!(
@@ -1214,7 +1214,7 @@ impl<'a> BalloonFormatter<&'a Message> for HTML<'a> {
         if let Some(preview) = balloon.preview {
             out_s.push_str("<audio controls src=\"");
             out_s.push_str(preview);
-            out_s.push_str("\" </audio>");
+            out_s.push_str("\"> </audio>");
         }
 
         // Add lyrics, if any
@@ -3005,7 +3005,7 @@ mod tests {
 
         assert_eq!(
             actual,
-            "<div><audio controls src=\"Audio Message.caf\" type=\"x-caf; codecs=opus\" </audio></div> <hr><span class=\"transcription\">Transcription: Test</span>"
+            "<div><audio controls src=\"Audio Message.caf\" type=\"x-caf; codecs=opus\"> </audio></div> <hr><span class=\"transcription\">Transcription: Test</span>"
         );
     }
 
@@ -3159,7 +3159,7 @@ mod balloon_format_tests {
         };
 
         let expected = exporter.format_music(&balloon, &Config::fake_message());
-        let actual = "<div class=\"app_header\"><div class=\"name\">track_name</div><audio controls src=\"preview\" </audio></div><a href=\"url\"><div class=\"app_footer\"><div class=\"caption\">artist</div><div class=\"subcaption\">album</div></div></a>";
+        let actual = "<div class=\"app_header\"><div class=\"name\">track_name</div><audio controls src=\"preview\"> </audio></div><a href=\"url\"><div class=\"app_footer\"><div class=\"caption\">artist</div><div class=\"subcaption\">album</div></div></a>";
 
         assert_eq!(expected, actual);
     }

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -224,7 +224,7 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
             // Add an ID for any top-level message so we can link to them in threads
             self.add_line(
                 &mut formatted_message,
-                &format!("<div class=\"message\", id=\"r-{}\">", message.guid),
+                &format!("<div class=\"message\" id=\"r-{}\">", message.guid),
                 "",
                 "",
             );
@@ -1146,7 +1146,7 @@ impl<'a> BalloonFormatter<&'a Message> for HTML<'a> {
             if self.config.options.no_lazy {
                 out_s.push_str("\" onerror=\"this.style.display='none'\">");
             } else {
-                out_s.push_str("\" loading=\"lazy\", onerror=\"this.style.display='none'\">");
+                out_s.push_str("\" loading=\"lazy\" onerror=\"this.style.display='none'\">");
             }
         });
 
@@ -3040,7 +3040,7 @@ mod tests {
 
         assert_eq!(
             actual,
-            "<div class=\"message\">\n<div class=\"received\">\n<p><span class=\"timestamp\"><a title=\"Reveal in Messages app\" href=\"sms://open?message-guid=FAKEGUID-D0C8-4212-AA87-DD8AE4FD1203\">May 17, 2022  5:29:42 PM</a> </span>\n<span class=\"sender\">Unknown</span></p>\n<hr><div class=\"message_part\">\n<div class=\"app\"><a href=\"https://www.ghacks.net/2020/01/23/lastpass-no-longer-listed-on-the-chrome-web-store/\"><div class=\"app_header\"><img src=\"https://www.ghacks.net/wp-content/uploads/2020/01/lastpass-chrome-extension.png\" loading=\"lazy\", onerror=\"this.style.display='none'\"><div class=\"name\">gHacks Technology News</div></div><div class=\"app_footer\"><div class=\"caption\">LastPass no longer listed on the Chrome Web Store - gHacks Tech News</div><div class=\"subcaption\">LastPass customers and new users searching for password managers on Google&apos;s Chrome Web Store may have noticed that the LastPass extension for Google Chrome is currently no longer listed on the store.</div></div></a></div>\n</div>\n</div>\n</div>\n"
+            "<div class=\"message\">\n<div class=\"received\">\n<p><span class=\"timestamp\"><a title=\"Reveal in Messages app\" href=\"sms://open?message-guid=FAKEGUID-D0C8-4212-AA87-DD8AE4FD1203\">May 17, 2022  5:29:42 PM</a> </span>\n<span class=\"sender\">Unknown</span></p>\n<hr><div class=\"message_part\">\n<div class=\"app\"><a href=\"https://www.ghacks.net/2020/01/23/lastpass-no-longer-listed-on-the-chrome-web-store/\"><div class=\"app_header\"><img src=\"https://www.ghacks.net/wp-content/uploads/2020/01/lastpass-chrome-extension.png\" loading=\"lazy\" onerror=\"this.style.display='none'\"><div class=\"name\">gHacks Technology News</div></div><div class=\"app_footer\"><div class=\"caption\">LastPass no longer listed on the Chrome Web Store - gHacks Tech News</div><div class=\"subcaption\">LastPass customers and new users searching for password managers on Google&apos;s Chrome Web Store may have noticed that the LastPass extension for Google Chrome is currently no longer listed on the store.</div></div></a></div>\n</div>\n</div>\n</div>\n"
         );
     }
 
@@ -3110,7 +3110,7 @@ mod balloon_format_tests {
 
         let expected =
             exporter.format_url(&Config::fake_message(), &balloon, &Config::fake_message());
-        let actual = "<a href=\"url\"><div class=\"app_header\"><img src=\"images\" loading=\"lazy\", onerror=\"this.style.display='none'\"><div class=\"name\">site_name</div></div><div class=\"app_footer\"><div class=\"caption\">title</div><div class=\"subcaption\">summary</div></div></a>";
+        let actual = "<a href=\"url\"><div class=\"app_header\"><img src=\"images\" loading=\"lazy\" onerror=\"this.style.display='none'\"><div class=\"name\">site_name</div></div><div class=\"app_footer\"><div class=\"caption\">title</div><div class=\"subcaption\">summary</div></div></a>";
 
         assert_eq!(expected, actual);
     }


### PR DESCRIPTION
- Bug Fixes
  - Improve backwards compatibility for #322 and #590  
  - Fix handle filtering logic for #635 
  - Add missing closing brackets for HTML audio tags for #641
  - Account for export path in filename length truncation for #661 
  - Include backup root in contacts path for unencrypted iOS backups for #663
  - Support both `StickerCache` and `Attachments` directories when using the `--attachment-root` flag for #655 
- Miscellaneous
  - Remove extraneous commas from some HTML attribute lists
  - Bump dependencies
  - Build with latest `rustc`