### PR TITLE
Add support for --debug-participants to print the participants map

### DIFF
--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -42,6 +42,7 @@ pub const OPTION_USE_CALLER_ID: &str = "use-caller-id";
 pub const OPTION_CONVERSATION_FILTER: &str = "conversation-filter";
 pub const OPTION_CLEARTEXT_PASSWORD: &str = "cleartext-password";
 pub const OPTION_CUSTOM_CONTACTS_DB_PATH: &str = "contacts-path";
+pub const OPTION_DEBUG_PARTICIPANTS: &str = "debug-participants";
 
 // Other CLI Text
 pub const SUPPORTED_FILE_TYPES: &str = "txt, html";
@@ -86,6 +87,8 @@ pub struct Options {
     pub cleartext_password: Option<String>,
     /// An optional path to a custom contacts database
     pub contacts_path: Option<PathBuf>,
+    /// If true, print the participants map to stderr (for debugging -t filter)
+    pub debug_participants: bool,
 }
 
 // MARK: Validation
@@ -107,6 +110,7 @@ impl Options {
         let conversation_filter: Option<&String> = args.get_one(OPTION_CONVERSATION_FILTER);
         let cleartext_password: Option<&String> = args.get_one(OPTION_CLEARTEXT_PASSWORD);
         let contacts_path: Option<&String> = args.get_one(OPTION_CUSTOM_CONTACTS_DB_PATH);
+        let debug_participants = args.get_flag(OPTION_DEBUG_PARTICIPANTS);
 
         // Build the export type
         let export_type: Option<ExportType> = match export_file_type {
@@ -129,6 +133,7 @@ impl Options {
                 (custom_name.is_some(), OPTION_CUSTOM_NAME),
                 (use_caller_id, OPTION_USE_CALLER_ID),
                 (conversation_filter.is_some(), OPTION_CONVERSATION_FILTER),
+                (debug_participants, OPTION_DEBUG_PARTICIPANTS),
             ];
             for (set, opt) in format_deps {
                 if set {
@@ -150,6 +155,7 @@ impl Options {
             (use_caller_id, OPTION_USE_CALLER_ID),
             (custom_name.is_some(), OPTION_CUSTOM_NAME),
             (conversation_filter.is_some(), OPTION_CONVERSATION_FILTER),
+            (debug_participants, OPTION_DEBUG_PARTICIPANTS),
         ];
         for (set, opt) in diag_conflicts {
             if diagnostic && set {
@@ -267,6 +273,7 @@ impl Options {
             conversation_filter: conversation_filter.cloned(),
             cleartext_password: cleartext_password.cloned(),
             contacts_path: contacts_path.cloned().map(PathBuf::from),
+            debug_participants,
         })
     }
 
@@ -463,6 +470,13 @@ fn get_command() -> Command {
                 .display_order(15)
                 .value_name("path"),
         )
+        .arg(
+            Arg::new(OPTION_DEBUG_PARTICIPANTS)
+                .long(OPTION_DEBUG_PARTICIPANTS)
+                .help("Print the participants map to stderr before export (for debugging -t conversation filter)\n")
+                .action(ArgAction::SetTrue)
+                .display_order(16),
+        )
 }
 
 #[cfg(test)]
@@ -488,6 +502,7 @@ impl Options {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         }
     }
 }
@@ -537,6 +552,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -620,6 +636,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -654,6 +671,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -734,6 +752,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -773,6 +792,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: Some("password".to_string()),
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -828,6 +848,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -859,6 +880,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -891,6 +913,7 @@ mod arg_tests {
             conversation_filter: Some(String::from("steve@apple.com")),
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -922,6 +945,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -953,6 +977,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);
@@ -1026,6 +1051,7 @@ mod arg_tests {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
+            debug_participants: false,
         };
 
         assert_eq!(actual, expected);

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -348,6 +348,25 @@ impl Config {
         }
     }
 
+    /// Print participants map to stderr when `--debug-participants` was passed.
+    pub fn debug_print_participants(&self) {
+        if !self.options.debug_participants {
+            return;
+        }
+        eprintln!("--- participants_map ({} entries) ---", self.participants.len());
+        let mut keys: Vec<_> = self.participants.keys().collect();
+        keys.sort();
+        for &internal_id in keys {
+            let name = self.participants.get(&internal_id).unwrap();
+            let handle_ids: Vec<String> = name.handle_ids.iter().map(|id: &i32| id.to_string()).collect();
+            eprintln!(
+                "  internal_id={} | first={:?} last={:?} full={:?} details={:?} handle_ids=[{}]",
+                internal_id, name.first, name.last, name.full, name.details, handle_ids.join(", ")
+            );
+        }
+        eprintln!("--- end participants_map ---");
+    }
+
     /// Ensure there is available disk space for the requested export
     fn ensure_free_space(&self) -> Result<(), RuntimeError> {
         // Export size is usually about 6% the size of the db;

--- a/imessage-exporter/src/main.rs
+++ b/imessage-exporter/src/main.rs
@@ -25,6 +25,8 @@ fn main() {
                 Ok(mut app) => {
                     // Resolve the filtered contacts, if provided
                     app.resolve_filtered_handles();
+                    // Optional: dump participants map when --debug-participants was passed
+                    app.debug_print_participants();
 
                     if let Err(why) = app.start() {
                         eprintln!("Unable to export: {why}");


### PR DESCRIPTION
Adds an optional `--debug-partipants` option to make it easier to troubleshoot `--conversation-filter` (`-t`) filtering.


Example output:

```
imessage-exporter -f txt -c disabled -o ~/imessage-export-$(date "+%Y-%m-%d") -i -t "+12145551234"  --debug-participants
Building cache...
  [1/5] Caching chats...
  [2/5] Caching chatrooms...
  [3/5] Caching participants...
  [4/5] Caching tapbacks...
  [5/5] Caching translations...
Cache built!
Filtering for 1 handle across 1 chatrooms...
--- participants_map (1622 entries) ---
  internal_id=0 | first="" last="" full="" details="Me" handle_ids=[0]

[ ..... ]

  internal_id=1 | first="Joe" last="Smith" full="Joe Smith" details="+15550101001" handle_ids=[1734, 8, 1]
  internal_id=2 | first="" last="" full="" details="+15550101002" handle_ids=[2]
  internal_id=3 | first="Bart" last="Edwards" full="Bart Edwards" details="+15550101003" handle_ids=[3, 422]
  internal_id=4 | first="Mary" last="Edwards" full="Mary Edwards" details="+15550101004" handle_ids=[368, 2012, 4]
  internal_id=5 | first="Alex" last="Edwards" full="Alex Edwards" details="+15550101005" handle_ids=[441, 1685, 5]
  internal_id=6 | first="Daniel" last="Edwards" full="Daniel Edwards" details="+15550101006" handle_ids=[6, 259, 1612]
  internal_id=7 | first="Emily" last="Harrison" full="Emily Harrison" details="+15550101007" handle_ids=[245, 7, 2010]
  internal_id=8 | first="Chris" last="Edwards" full="Chris Edwards" details="+15550101008" handle_ids=[2017, 433, 1491, 10]
  internal_id=9 | first="" last="" full="" details="+15550101009" handle_ids=[13]
 
[ ..... ]

[   internal_id=1621 | first="" last="" full="" details="+18339883917" handle_ids=[2674]
--- end participants_map ---
Estimated export size: 40.79 MB
Exporting to ~/imessage-export-2026-01-31 as txt...
  [0s] [####################] 774/774 (82,752.3473/s, ETA: 0s)                                                                                                                               Done!
```