### PR TITLE
Feat/cs/fix group action handle data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "autocfg"
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -396,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -476,9 +476,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.64"
+version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -653,9 +653,9 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
 
 [[package]]
 name = "num-traits"
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f89776e4d69bb58bc6993e99ffa1d11f228b839984854c7daeb5d37f87cbe950"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "powerfmt"
@@ -734,9 +734,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
 dependencies = [
  "proc-macro2",
 ]
@@ -833,9 +833,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -856,9 +856,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
 name = "rsqlite-vfs"
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -1085,15 +1085,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -1143,128 +1143,22 @@ impl Message {
             return Variant::Edited;
         }
 
-        // Handle different types of bundle IDs next, as those are most common
+        // Handle different types of associated message types
         if let Some(associated_message_type) = self.associated_message_type {
-            return match associated_message_type {
+            match associated_message_type {
                 // Standard iMessages with either text or a message payload
-                0 | 2 | 3 => match parse_balloon_bundle_id(self.balloon_bundle_id.as_deref()) {
-                    // This is the most common case
-                    None => Variant::Normal,
-                    Some(bundle_id) => match bundle_id {
-                        "com.apple.messages.URLBalloonProvider" => Variant::App(CustomBalloon::URL),
-                        "com.apple.Handwriting.HandwritingProvider" => {
-                            Variant::App(CustomBalloon::Handwriting)
-                        }
-                        "com.apple.DigitalTouchBalloonProvider" => {
-                            Variant::App(CustomBalloon::DigitalTouch)
-                        }
-                        "com.apple.PassbookUIService.PeerPaymentMessagesExtension" => {
-                            Variant::App(CustomBalloon::ApplePay)
-                        }
-                        "com.apple.ActivityMessagesApp.MessagesExtension" => {
-                            Variant::App(CustomBalloon::Fitness)
-                        }
-                        "com.apple.mobileslideshow.PhotosMessagesApp" => {
-                            Variant::App(CustomBalloon::Slideshow)
-                        }
-                        "com.apple.SafetyMonitorApp.SafetyMonitorMessages" => {
-                            Variant::App(CustomBalloon::CheckIn)
-                        }
-                        "com.apple.findmy.FindMyMessagesApp" => Variant::App(CustomBalloon::FindMy),
-                        "com.apple.messages.Polls" => match &self.associated_message_guid {
-                            Some(id) => {
-                                if id == &self.guid {
-                                    Variant::App(CustomBalloon::Polls)
-                                } else {
-                                    Variant::PollUpdate
-                                }
-                            }
-                            None => Variant::App(CustomBalloon::Polls),
-                        },
-                        _ => Variant::App(CustomBalloon::Application(bundle_id)),
-                    },
-                },
-
-                // Stickers overlaid on messages
-                1000 => {
-                    Variant::Tapback(self.tapback_index(), TapbackAction::Added, Tapback::Sticker)
+                0 | 2 | 3 => return self.get_app_variant().unwrap_or(Variant::Normal),
+                // Tapbacks (added or removed)
+                1000 | 2000..=2007 | 3000..=3007 => {
+                    if let Some((action, tapback)) = self.get_tapback() {
+                        return Variant::Tapback(self.tapback_index(), action, tapback);
+                    }
                 }
-
-                // Tapbacks
-                2000 => {
-                    Variant::Tapback(self.tapback_index(), TapbackAction::Added, Tapback::Loved)
-                }
-                2001 => {
-                    Variant::Tapback(self.tapback_index(), TapbackAction::Added, Tapback::Liked)
-                }
-                2002 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Added,
-                    Tapback::Disliked,
-                ),
-                2003 => {
-                    Variant::Tapback(self.tapback_index(), TapbackAction::Added, Tapback::Laughed)
-                }
-                2004 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Added,
-                    Tapback::Emphasized,
-                ),
-                2005 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Added,
-                    Tapback::Questioned,
-                ),
-                2006 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Added,
-                    Tapback::Emoji(self.associated_message_emoji.as_deref()),
-                ),
-                2007 => {
-                    Variant::Tapback(self.tapback_index(), TapbackAction::Added, Tapback::Sticker)
-                }
-                3000 => {
-                    Variant::Tapback(self.tapback_index(), TapbackAction::Removed, Tapback::Loved)
-                }
-                3001 => {
-                    Variant::Tapback(self.tapback_index(), TapbackAction::Removed, Tapback::Liked)
-                }
-                3002 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Removed,
-                    Tapback::Disliked,
-                ),
-                3003 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Removed,
-                    Tapback::Laughed,
-                ),
-                3004 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Removed,
-                    Tapback::Emphasized,
-                ),
-                3005 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Removed,
-                    Tapback::Questioned,
-                ),
-                3006 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Removed,
-                    Tapback::Emoji(self.associated_message_emoji.as_deref()),
-                ),
-                3007 => Variant::Tapback(
-                    self.tapback_index(),
-                    TapbackAction::Removed,
-                    Tapback::Sticker,
-                ),
                 // A vote was cast on a poll
-                4000 => Variant::Vote,
-
+                4000 => return Variant::Vote,
                 // Unknown
-                x => Variant::Unknown(x),
-            };
+                x => return Variant::Unknown(x),
+            }
         }
 
         // Any other rarer cases belong here
@@ -1273,6 +1167,63 @@ impl Message {
         }
 
         Variant::Normal
+    }
+
+    /// Helper to determine app variants based on balloon bundle ID.
+    #[must_use]
+    fn get_app_variant(&self) -> Option<Variant<'_>> {
+        let bundle_id = parse_balloon_bundle_id(self.balloon_bundle_id.as_deref())?;
+        let custom = match bundle_id {
+            "com.apple.messages.URLBalloonProvider" => CustomBalloon::URL,
+            "com.apple.Handwriting.HandwritingProvider" => CustomBalloon::Handwriting,
+            "com.apple.DigitalTouchBalloonProvider" => CustomBalloon::DigitalTouch,
+            "com.apple.PassbookUIService.PeerPaymentMessagesExtension" => CustomBalloon::ApplePay,
+            "com.apple.ActivityMessagesApp.MessagesExtension" => CustomBalloon::Fitness,
+            "com.apple.mobileslideshow.PhotosMessagesApp" => CustomBalloon::Slideshow,
+            "com.apple.SafetyMonitorApp.SafetyMonitorMessages" => CustomBalloon::CheckIn,
+            "com.apple.findmy.FindMyMessagesApp" => CustomBalloon::FindMy,
+            "com.apple.messages.Polls" => {
+                // Special case: Check if this is the original poll or an update
+                if self.associated_message_guid.as_ref() == Some(&self.guid) {
+                    CustomBalloon::Polls
+                } else {
+                    return Some(Variant::PollUpdate);
+                }
+            }
+            _ => CustomBalloon::Application(bundle_id),
+        };
+        Some(Variant::App(custom))
+    }
+
+    /// Helper to determine tapback variants based on associated message type.
+    #[must_use]
+    fn get_tapback(&self) -> Option<(TapbackAction, Tapback<'_>)> {
+        match self.associated_message_type? {
+            1000 => Some((TapbackAction::Added, Tapback::Sticker)),
+            2000 => Some((TapbackAction::Added, Tapback::Loved)),
+            2001 => Some((TapbackAction::Added, Tapback::Liked)),
+            2002 => Some((TapbackAction::Added, Tapback::Disliked)),
+            2003 => Some((TapbackAction::Added, Tapback::Laughed)),
+            2004 => Some((TapbackAction::Added, Tapback::Emphasized)),
+            2005 => Some((TapbackAction::Added, Tapback::Questioned)),
+            2006 => Some((
+                TapbackAction::Added,
+                Tapback::Emoji(self.associated_message_emoji.as_deref()),
+            )),
+            2007 => Some((TapbackAction::Added, Tapback::Sticker)),
+            3000 => Some((TapbackAction::Removed, Tapback::Loved)),
+            3001 => Some((TapbackAction::Removed, Tapback::Liked)),
+            3002 => Some((TapbackAction::Removed, Tapback::Disliked)),
+            3003 => Some((TapbackAction::Removed, Tapback::Laughed)),
+            3004 => Some((TapbackAction::Removed, Tapback::Emphasized)),
+            3005 => Some((TapbackAction::Removed, Tapback::Questioned)),
+            3006 => Some((
+                TapbackAction::Removed,
+                Tapback::Emoji(self.associated_message_emoji.as_deref()),
+            )),
+            3007 => Some((TapbackAction::Removed, Tapback::Sticker)),
+            _ => None,
+        }
     }
 
     /// Determine the type of announcement a message contains, if it contains one

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -759,8 +759,11 @@ impl Message {
     /// `true` if the message was sent by the database owner, else `false`
     #[must_use]
     pub fn is_from_me(&self) -> bool {
-        if let (Some(other_handle), Some(share_direction)) =
-            (self.other_handle, self.share_direction)
+        // Share direction and other handle are only populated for shared location messages,
+        // so this check is only necessary for those
+        if self.item_type == 4
+            && let (Some(other_handle), Some(share_direction)) =
+                (self.other_handle, self.share_direction)
         {
             self.is_from_me || other_handle != 0 && !share_direction
         } else {

--- a/imessage-database/src/tables/messages/models.rs
+++ b/imessage-database/src/tables/messages/models.rs
@@ -196,6 +196,8 @@ pub enum GroupAction<'a> {
     ChatBackgroundChanged,
     /// The chat background was removed
     ChatBackgroundRemoved,
+    /// A participant changed their phone number
+    PhoneNumberChanged(i32),
 }
 
 impl<'a> GroupAction<'a> {
@@ -208,6 +210,10 @@ impl<'a> GroupAction<'a> {
             message.other_handle,
             &message.group_title,
         ) {
+            // If the handle_id of the message matches the other_handle, the sender changed their own phone number
+            (1, 0, Some(who), _) if message.handle_id == Some(who) => {
+                Some(Self::PhoneNumberChanged(who))
+            }
             (1, 0, Some(who), _) => Some(Self::ParticipantAdded(who)),
             (1, 1, Some(who), _) => Some(Self::ParticipantRemoved(who)),
             (2, _, _, Some(name)) => Some(Self::NameChange(name)),

--- a/imessage-database/src/tables/messages/tests/announcement.rs
+++ b/imessage-database/src/tables/messages/tests/announcement.rs
@@ -7,11 +7,26 @@ mod group_action_tests {
         let mut msg = Message::blank();
         msg.item_type = 1;
         msg.group_action_type = 0;
+        msg.handle_id = Some(100);
         msg.other_handle = Some(123);
 
         assert!(matches!(
             Message::group_action(&msg),
             Some(GroupAction::ParticipantAdded(123))
+        ));
+    }
+
+    #[test]
+    fn test_group_action_phone_number_changed() {
+        let mut msg = Message::blank();
+        msg.item_type = 1;
+        msg.group_action_type = 0;
+        msg.handle_id = Some(349);
+        msg.other_handle = Some(349);
+
+        assert!(matches!(
+            Message::group_action(&msg),
+            Some(GroupAction::PhoneNumberChanged(349))
         ));
     }
 
@@ -145,6 +160,7 @@ mod announcement_tests {
         let mut msg = Message::blank();
         msg.item_type = 1;
         msg.group_action_type = 0;
+        msg.handle_id = Some(100);
         msg.other_handle = Some(123);
 
         assert!(matches!(

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -897,6 +897,7 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
         let mut who = self
             .config
             .who(msg.handle_id, msg.is_from_me(), &msg.destination_caller_id);
+
         // Rename yourself so we render the proper grammar here
         if who == ME {
             who = self.config.options.custom_name.as_deref().unwrap_or("You");
@@ -939,6 +940,9 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
                         }
                         GroupAction::ChatBackgroundRemoved => {
                             "removed the chat background.".to_string()
+                        }
+                        GroupAction::PhoneNumberChanged(_) => {
+                            "changed their phone number.".to_string()
                         }
                     },
                     Announcement::AudioMessageKept => "kept an audio message.".to_string(),
@@ -2293,6 +2297,64 @@ mod tests {
 
         let actual = exporter.format_announcement(&message);
         let expected = "\n<div class =\"announcement\"><p><span class=\"timestamp\">May 17, 2022  5:29:42 PM</span> You removed Other from the conversation.</p></div>\n";
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn can_format_html_group_removed_other() {
+        // Create exporter
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
+        config.participants.insert(0, Name::fake_name(ME));
+        config.participants.insert(1, Name::fake_name("Other"));
+        config.participants.insert(2, Name::fake_name("Second"));
+        config.real_participants.insert(0, 0);
+        config.real_participants.insert(1, 1);
+        config.real_participants.insert(2, 2);
+
+        let exporter = HTML::new(&config).unwrap();
+
+        let mut message = Config::fake_message();
+        // May 17, 2022  8:29:42 PM
+        message.date = 674526582885055488;
+        message.group_title = Some("Hello world".to_string());
+        message.is_from_me = false;
+        message.handle_id = Some(1);
+        message.item_type = 1;
+        message.group_action_type = 1;
+        message.other_handle = Some(2);
+
+        let actual = exporter.format_announcement(&message);
+        let expected = "\n<div class =\"announcement\"><p><span class=\"timestamp\">May 17, 2022  5:29:42 PM</span> Other removed Second from the conversation.</p></div>\n";
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn can_format_html_group_changed_number() {
+        // Create exporter
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
+        config.participants.insert(0, Name::fake_name(ME));
+        config.participants.insert(1, Name::fake_name("Other"));
+        config.real_participants.insert(0, 0);
+        config.real_participants.insert(1, 1);
+
+        let exporter = HTML::new(&config).unwrap();
+
+        let mut message = Config::fake_message();
+        // May 17, 2022  8:29:42 PM
+        message.date = 674526582885055488;
+        message.group_title = Some("Hello world".to_string());
+        message.is_from_me = false;
+        message.handle_id = Some(1);
+        message.item_type = 1;
+        message.group_action_type = 0;
+        message.other_handle = Some(1);
+
+        let actual = exporter.format_announcement(&message);
+        let expected = "\n<div class =\"announcement\"><p><span class=\"timestamp\">May 17, 2022  5:29:42 PM</span> Other changed their phone number.</p></div>\n";
 
         assert_eq!(actual, expected);
     }

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -642,6 +642,7 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
         let mut who = self
             .config
             .who(msg.handle_id, msg.is_from_me(), &msg.destination_caller_id);
+
         // Rename yourself so we render the proper grammar here
         if who == ME {
             who = self.config.options.custom_name.as_deref().unwrap_or(YOU);
@@ -684,6 +685,9 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
                         }
                         GroupAction::ChatBackgroundRemoved => {
                             "removed the chat background.".to_string()
+                        }
+                        GroupAction::PhoneNumberChanged(_) => {
+                            "changed their phone number.".to_string()
                         }
                     },
                     Announcement::AudioMessageKept => "kept an audio message.".to_string(),
@@ -1533,6 +1537,64 @@ mod tests {
 
         let actual = exporter.format_announcement(&message);
         let expected = "May 17, 2022  5:29:42 PM You removed Other from the conversation.\n\n";
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn can_format_txt_group_removed_other() {
+        // Create exporter
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
+        config.participants.insert(0, Name::fake_name(ME));
+        config.participants.insert(1, Name::fake_name("Other"));
+        config.participants.insert(2, Name::fake_name("Second"));
+        config.real_participants.insert(0, 0);
+        config.real_participants.insert(1, 1);
+        config.real_participants.insert(2, 2);
+
+        let exporter = TXT::new(&config).unwrap();
+
+        let mut message = Config::fake_message();
+        // May 17, 2022  8:29:42 PM
+        message.date = 674526582885055488;
+        message.group_title = Some("Hello world".to_string());
+        message.is_from_me = false;
+        message.handle_id = Some(1);
+        message.item_type = 1;
+        message.group_action_type = 1;
+        message.other_handle = Some(2);
+
+        let actual = exporter.format_announcement(&message);
+        let expected = "May 17, 2022  5:29:42 PM Other removed Second from the conversation.\n\n";
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn can_format_txt_group_changed_number() {
+        // Create exporter
+        let options = Options::fake_options(ExportType::Txt);
+        let mut config = Config::fake_app(options);
+        config.participants.insert(0, Name::fake_name(ME));
+        config.participants.insert(1, Name::fake_name("Other"));
+        config.real_participants.insert(0, 0);
+        config.real_participants.insert(1, 1);
+
+        let exporter = TXT::new(&config).unwrap();
+
+        let mut message = Config::fake_message();
+        // May 17, 2022  8:29:42 PM
+        message.date = 674526582885055488;
+        message.group_title = Some("Hello world".to_string());
+        message.is_from_me = false;
+        message.handle_id = Some(1);
+        message.item_type = 1;
+        message.group_action_type = 0;
+        message.other_handle = Some(1);
+
+        let actual = exporter.format_announcement(&message);
+        let expected = "May 17, 2022  5:29:42 PM Other changed their phone number.\n\n";
 
         assert_eq!(actual, expected);
     }
@@ -2809,7 +2871,7 @@ mod text_effect_tests {
     }
 
     #[test]
-    fn can_format_html_text_styled_overlapping_ranges() {
+    fn can_format_txt_text_styled_overlapping_ranges() {
         // Create exporter
         let options = Options::fake_options(ExportType::Txt);
         let config = Config::fake_app(options);


### PR DESCRIPTION
- Fix #670 and #681
- Support Phone Number Changed group action type 

When someone changes their phone number, iMessage generates a pair of events at the same timestamp: "remove old handle (127)" + "add new handle (349)". `Messages.app` coalesces the pair into a single "changed their phone number" line.
