### PR TITLE
Feat/cs/remove codegen build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,7 @@ dependencies = [
 
 [[package]]
 name = "crabstep"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fafbe57c349843caca2aa70b4a98bf688123845ac080c324f407f9ecb71873c1"
+version = "0.0.0"
 
 [[package]]
 name = "crc"
@@ -361,18 +359,6 @@ checksum = "e182f7dbc2ef73d9ef67351c5fbbea084729c48362d3ce9dd44c28e32e277fe5"
 dependencies = [
  "libc",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "filetime"
-version = "0.2.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0505cd1b6fa6580283f6bdf70a73fcf4aba1184038c90902b92b3dd0df63ed"
-dependencies = [
- "cfg-if",
- "libc",
- "libredox",
- "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -530,7 +516,6 @@ dependencies = [
  "clap",
  "crabapple",
  "fdlimit",
- "filetime",
  "fs2",
  "imessage-database",
  "rusqlite",
@@ -597,18 +582,6 @@ name = "libc"
 version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
-
-[[package]]
-name = "libredox"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -710,12 +683,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -835,15 +802,6 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
-dependencies = [
- "bitflags",
-]
 
 [[package]]
 name = "regex"
@@ -1364,16 +1322,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1391,31 +1340,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -1425,22 +1357,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1449,22 +1369,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -1473,22 +1381,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -1497,22 +1393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"

--- a/imessage-database/Cargo.toml
+++ b/imessage-database/Cargo.toml
@@ -20,6 +20,8 @@ crabstep = "=0.3.2"
 base64 = "0.22.1"
 jzon = "0.12.5"
 
+[features]
+proto-regen = ["dep:protobuf-codegen"]
+
 [build-dependencies]
-protobuf = "=3.7.2"
-protobuf-codegen = "=3.7.2"
+protobuf-codegen = { version = "=3.7.2", optional = true }

--- a/imessage-database/build.rs
+++ b/imessage-database/build.rs
@@ -1,36 +1,78 @@
-use std::{
-    env,
-    fs::{copy, exists},
-    path::PathBuf,
-};
+/*!
+Build script for protobuf-generated modules.
+
+Build modes:
+
+- Default build (`cargo build -p imessage-database`):
+    validates that generated protobuf Rust files are already present in the repository.
+- Regeneration build (`cargo build -p imessage-database --features proto-regen`):
+    regenerates protobuf Rust files from the `.proto` sources.
+
+Useful commands:
+
+- `cargo check -p imessage-database`
+- `cargo check -p imessage-database --features proto-regen`
+*/
+
+#[cfg(not(feature = "proto-regen"))]
+use std::fs::exists;
+
+#[cfg(feature = "proto-regen")]
+use std::{env, fs::copy, path::PathBuf};
+
+#[cfg(feature = "proto-regen")]
+const HANDWRITING_PROTO_INPUT: &str = "src/message_types/handwriting/handwriting.proto";
+#[cfg(feature = "proto-regen")]
+const HANDWRITING_GENERATED_NAME: &str = "handwriting.rs";
+const HANDWRITING_OUTPUT: &str = "src/message_types/handwriting/handwriting_proto.rs";
+#[cfg(feature = "proto-regen")]
+const DIGITAL_TOUCH_PROTO_INPUT: &str = "src/message_types/digital_touch/digital_touch.proto";
+#[cfg(feature = "proto-regen")]
+const DIGITAL_TOUCH_GENERATED_NAME: &str = "digital_touch.rs";
+const DIGITAL_TOUCH_OUTPUT: &str = "src/message_types/digital_touch/digital_touch_proto.rs";
 
 fn main() {
-    build_proto(
-        "src/message_types/handwriting/handwriting.proto",
-        "handwriting.rs",
-        "src/message_types/handwriting/handwriting_proto.rs",
-    );
-    build_proto(
-        "src/message_types/digital_touch/digital_touch.proto",
-        "digital_touch.rs",
-        "src/message_types/digital_touch/digital_touch_proto.rs",
-    );
+    #[cfg(feature = "proto-regen")]
+    {
+        build_proto(
+            HANDWRITING_PROTO_INPUT,
+            HANDWRITING_GENERATED_NAME,
+            HANDWRITING_OUTPUT,
+        );
+        build_proto(
+            DIGITAL_TOUCH_PROTO_INPUT,
+            DIGITAL_TOUCH_GENERATED_NAME,
+            DIGITAL_TOUCH_OUTPUT,
+        );
+    }
+
+    #[cfg(not(feature = "proto-regen"))]
+    {
+        ensure_generated(HANDWRITING_OUTPUT);
+        ensure_generated(DIGITAL_TOUCH_OUTPUT);
+    }
 }
 
-fn build_proto(input_proto: &str, generated_name: &str, output_rs: &str) {
-    if !exists(output_rs).unwrap() {
-        protobuf_codegen::Codegen::new()
-            .pure()
-            .input(input_proto)
-            .include(".")
-            .cargo_out_dir("p")
-            .run_from_script();
-
-        // Move generated file to correct location
-        let mut generated = PathBuf::from(env::var("OUT_DIR").unwrap());
-        generated.push("p");
-        generated.push(generated_name);
-        println!("{}", generated.to_str().unwrap());
-        copy(generated, output_rs).unwrap();
+#[cfg(not(feature = "proto-regen"))]
+fn ensure_generated(path: &str) {
+    if !exists(path).unwrap_or(false) {
+        panic!(
+            "Missing generated protobuf module `{path}`. Re-generate with `cargo build -p imessage-database --features proto-regen`."
+        );
     }
+}
+
+#[cfg(feature = "proto-regen")]
+fn build_proto(input_proto: &str, generated_name: &str, output_rs: &str) {
+    protobuf_codegen::Codegen::new()
+        .pure()
+        .input(input_proto)
+        .include(".")
+        .cargo_out_dir("p")
+        .run_from_script();
+
+    let mut generated = PathBuf::from(env::var("OUT_DIR").unwrap());
+    generated.push("p");
+    generated.push(generated_name);
+    copy(generated, output_rs).unwrap();
 }

--- a/imessage-exporter/Cargo.toml
+++ b/imessage-exporter/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.0.0"
 
 [dependencies]
 clap = { version = "=4.5.54", features = ["cargo"] }
-filetime = "=0.2.26"
 fdlimit = "=0.3.0"
 fs2 = "=0.4.3"
 imessage-database = { path = "../imessage-database" }

--- a/imessage-exporter/src/app/compatibility/converters/common.rs
+++ b/imessage-exporter/src/app/compatibility/converters/common.rs
@@ -105,6 +105,10 @@ pub(crate) fn copy_raw(from: &Path, to: &Path) {
 
 /// Update the metadata of a copied file, falling back to the original file's metadata if necessary
 pub(crate) fn update_file_metadata(from: &Path, to: &Path, message: &Message, config: &Config) {
+    if to.is_dir() {
+        return;
+    }
+
     // Update file metadata
     if let Ok(metadata) = metadata(from) {
         // The modification time is the message's date, otherwise the the original file's creation time

--- a/imessage-exporter/src/app/compatibility/converters/common.rs
+++ b/imessage-exporter/src/app/compatibility/converters/common.rs
@@ -1,11 +1,11 @@
 /*!
  Defines routines common across all converters.
 */
-use filetime::{FileTime, set_file_times};
 use std::{
-    fs::{copy, create_dir_all, metadata, read_dir},
+    fs::{File, FileTimes, copy, create_dir_all, metadata, read_dir},
     path::Path,
     process::{Command, Stdio},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use imessage_database::tables::messages::Message;
@@ -109,15 +109,38 @@ pub(crate) fn update_file_metadata(from: &Path, to: &Path, message: &Message, co
     if let Ok(metadata) = metadata(from) {
         // The modification time is the message's date, otherwise the the original file's creation time
         let mtime = match message.date(&config.offset) {
-            Ok(date) => FileTime::from_unix_time(date.timestamp(), date.timestamp_subsec_nanos()),
-            Err(_) => FileTime::from_last_modification_time(&metadata),
+            Ok(date) => unix_to_system_time(date.timestamp(), date.timestamp_subsec_nanos())
+                .or_else(|| metadata.modified().ok()),
+            Err(_) => metadata.modified().ok(),
         };
 
         // The new last access time comes from the metadata of the original file
-        let atime = FileTime::from_last_access_time(&metadata);
+        let atime = metadata.accessed().ok();
 
-        if let Err(why) = set_file_times(to, atime, mtime) {
-            eprintln!("Unable to update {} metadata: {why}", to.display());
+        if let (Some(atime), Some(mtime)) = (atime, mtime) {
+            match File::open(to) {
+                Ok(file) => {
+                    let file_times = FileTimes::new().set_accessed(atime).set_modified(mtime);
+                    if let Err(why) = file.set_times(file_times) {
+                        eprintln!("Unable to update {} metadata: {why}", to.display());
+                    }
+                }
+                Err(why) => {
+                    eprintln!("Unable to open {} to update metadata: {why}", to.display());
+                }
+            }
         }
+    }
+}
+
+fn unix_to_system_time(secs: i64, nanos: u32) -> Option<SystemTime> {
+    if secs >= 0 {
+        UNIX_EPOCH
+            .checked_add(Duration::from_secs(secs as u64))?
+            .checked_add(Duration::from_nanos(u64::from(nanos)))
+    } else {
+        UNIX_EPOCH
+            .checked_sub(Duration::from_secs(secs.unsigned_abs()))?
+            .checked_add(Duration::from_nanos(u64::from(nanos)))
     }
 }

--- a/imessage-exporter/src/app/compatibility/converters/common.rs
+++ b/imessage-exporter/src/app/compatibility/converters/common.rs
@@ -2,7 +2,7 @@
  Defines routines common across all converters.
 */
 use std::{
-    fs::{File, FileTimes, copy, create_dir_all, metadata, read_dir},
+    fs::{FileTimes, OpenOptions, copy, create_dir_all, metadata, read_dir},
     path::Path,
     process::{Command, Stdio},
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -118,7 +118,7 @@ pub(crate) fn update_file_metadata(from: &Path, to: &Path, message: &Message, co
         let atime = metadata.accessed().ok();
 
         if let (Some(atime), Some(mtime)) = (atime, mtime) {
-            match File::open(to) {
+            match OpenOptions::new().write(true).open(to) {
                 Ok(file) => {
                     let file_times = FileTimes::new().set_accessed(atime).set_modified(mtime);
                     if let Err(why) = file.set_times(file_times) {

--- a/imessage-exporter/src/app/compatibility/converters/common.rs
+++ b/imessage-exporter/src/app/compatibility/converters/common.rs
@@ -111,7 +111,7 @@ pub(crate) fn update_file_metadata(from: &Path, to: &Path, message: &Message, co
 
     // Update file metadata
     if let Ok(metadata) = metadata(from) {
-        // The modification time is the message's date, otherwise the the original file's creation time
+        // The modification time is the message's date, otherwise the original file's modification time
         let mtime = match message.date(&config.offset) {
             Ok(date) => unix_to_system_time(date.timestamp(), date.timestamp_subsec_nanos())
                 .or_else(|| metadata.modified().ok()),


### PR DESCRIPTION
- Move protobuf codegen crate behind a build flag (-44 crates)
- Use stdlib `FileTimes` instead of `filetime` crate (-1 crate)