### PR TITLE
Feat/cs/polish api

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -12,6 +12,9 @@ This tool targets the current latest public release for Messages.app. It may wor
 - Encrypted or unencrypted local iOS backups
   - Unencrypted backups are resolved normally
   - Encrypted backups are resolved with [crabapple](https://github.com/ReagentX/crabapple)
+- Jailbroken iOS filesystem data
+  - Uses `sms.db`, which follows the same schema as macOS `chat.db`
+  - Resolved as a macOS database with an alternate attachment root
 
 ## Supported Message Features
 

--- a/imessage-database/src/error/attachment.rs
+++ b/imessage-database/src/error/attachment.rs
@@ -14,6 +14,8 @@ pub enum AttachmentError {
     Unreadable(String, Error),
 }
 
+impl std::error::Error for AttachmentError {}
+
 impl Display for AttachmentError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {

--- a/imessage-database/src/error/handwriting.rs
+++ b/imessage-database/src/error/handwriting.rs
@@ -27,6 +27,8 @@ pub enum HandwritingError {
     ResizeError(std::num::TryFromIntError),
 }
 
+impl std::error::Error for HandwritingError {}
+
 impl Display for HandwritingError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {

--- a/imessage-database/src/error/message.rs
+++ b/imessage-database/src/error/message.rs
@@ -49,6 +49,8 @@ impl Display for MessageError {
     }
 }
 
+impl std::error::Error for MessageError {}
+
 impl From<StreamTypedError> for MessageError {
     fn from(err: StreamTypedError) -> Self {
         MessageError::StreamTypedParseError(err)

--- a/imessage-database/src/error/plist.rs
+++ b/imessage-database/src/error/plist.rs
@@ -77,6 +77,8 @@ impl Display for PlistParseError {
     }
 }
 
+impl std::error::Error for PlistParseError {}
+
 impl From<TypedStreamError> for PlistParseError {
     fn from(error: TypedStreamError) -> Self {
         PlistParseError::TypedStreamError(error)

--- a/imessage-database/src/error/query_context.rs
+++ b/imessage-database/src/error/query_context.rs
@@ -11,6 +11,8 @@ pub enum QueryContextError {
     InvalidDate(String),
 }
 
+impl std::error::Error for QueryContextError {}
+
 impl Display for QueryContextError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {

--- a/imessage-database/src/error/streamtyped.rs
+++ b/imessage-database/src/error/streamtyped.rs
@@ -17,6 +17,8 @@ pub enum StreamTypedError {
     InvalidTimestamp,
 }
 
+impl std::error::Error for StreamTypedError {}
+
 impl Display for StreamTypedError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {

--- a/imessage-database/src/error/table.rs
+++ b/imessage-database/src/error/table.rs
@@ -31,38 +31,47 @@ pub enum TableConnectError {
     NotBackupRoot,
 }
 
+impl Display for TableConnectError {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
+        match self {
+            TableConnectError::Permissions(why) => write!(
+                fmt,
+                "Unable to read from chat database: {why}\nEnsure full disk access is enabled for your terminal emulator in System Settings > Privacy & Security > Full Disk Access"
+            ),
+            TableConnectError::NotAFile(path) => {
+                write!(
+                    fmt,
+                    "Specified path `{}` is not a valid SQLite database file!",
+                    path.to_string_lossy()
+                )
+            }
+            TableConnectError::DoesNotExist(path) => {
+                write!(
+                    fmt,
+                    "Database file `{}` does not exist at the specified path!",
+                    path.to_string_lossy()
+                )
+            }
+            TableConnectError::NotBackupRoot => write!(
+                fmt,
+                "The path provided points to a database inside of an iOS backup, not the root of the backup."
+            ),
+        }
+    }
+}
+
 impl Display for TableError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {
-            TableError::CannotConnect(why) => match why {
-                TableConnectError::Permissions(why) => write!(
-                    fmt,
-                    "Unable to read from chat database: {why}\nEnsure full disk access is enabled for your terminal emulator in System Settings > Privacy & Security > Full Disk Access"
-                ),
-                TableConnectError::NotAFile(path) => {
-                    write!(
-                        fmt,
-                        "Specified path `{}` is not a valid SQLite database file!",
-                        path.to_string_lossy()
-                    )
-                }
-                TableConnectError::DoesNotExist(path) => {
-                    write!(
-                        fmt,
-                        "Database file `{}` does not exist at the specified path!",
-                        path.to_string_lossy()
-                    )
-                }
-                TableConnectError::NotBackupRoot => write!(
-                    fmt,
-                    "The path provided points to a database inside of an iOS backup, not the root of the backup."
-                ),
-            },
+            TableError::CannotConnect(why) => write!(fmt, "{why}"),
             TableError::CannotRead(why) => write!(fmt, "Cannot read from filesystem: {why}"),
             TableError::QueryError(error) => write!(fmt, "Failed to query table: {error}"),
         }
     }
 }
+
+impl std::error::Error for TableError {}
+impl std::error::Error for TableConnectError {}
 
 impl From<std::io::Error> for TableError {
     fn from(err: std::io::Error) -> Self {

--- a/imessage-database/src/error/typedstream.rs
+++ b/imessage-database/src/error/typedstream.rs
@@ -26,6 +26,8 @@ pub enum TypedStreamError {
     InvalidPointer(usize),
 }
 
+impl std::error::Error for TypedStreamError {}
+
 impl Display for TypedStreamError {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result {
         match self {

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -137,12 +137,6 @@ impl Table for Attachment {
         Ok(db.prepare_cached(&format!("SELECT * from {ATTACHMENT}"))?)
     }
 
-    fn extract(attachment: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-        match attachment {
-            Ok(Ok(attachment)) => Ok(attachment),
-            Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-        }
-    }
 }
 
 // MARK: Impl

--- a/imessage-database/src/tables/chat.rs
+++ b/imessage-database/src/tables/chat.rs
@@ -5,7 +5,7 @@
 use std::collections::HashMap;
 
 use plist::Value;
-use rusqlite::{CachedStatement, Connection, Error, Result, Row};
+use rusqlite::{CachedStatement, Connection, Result, Row};
 
 use crate::{
     error::{plist::PlistParseError, table::TableError},
@@ -82,12 +82,6 @@ impl Table for Chat {
         Ok(db.prepare_cached(&format!("SELECT * from {CHAT}"))?)
     }
 
-    fn extract(chat: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-        match chat {
-            Ok(Ok(chat)) => Ok(chat),
-            Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-        }
-    }
 }
 
 // MARK: Cache

--- a/imessage-database/src/tables/chat.rs
+++ b/imessage-database/src/tables/chat.rs
@@ -25,15 +25,15 @@ use crate::{
 #[derive(Debug, PartialEq, Eq)]
 pub struct Properties {
     /// Whether the chat has read receipts enabled
-    read_receipts_enabled: bool,
+    pub read_receipts_enabled: bool,
     /// The most recent message in the chat
-    last_message_guid: Option<String>,
+    pub last_message_guid: Option<String>,
     /// Whether the chat was forced to use SMS/RCS instead of iMessage
-    forced_sms: bool,
+    pub forced_sms: bool,
     /// GUID of the group photo, if it exists in the attachments table
-    group_photo_guid: Option<String>,
+    pub group_photo_guid: Option<String>,
     /// Whether the chat has a custom background image
-    has_chat_background: bool,
+    pub has_chat_background: bool,
 }
 
 impl Properties {

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -9,7 +9,7 @@ use crate::{
     tables::table::{CHAT_HANDLE_JOIN, CHAT_MESSAGE_JOIN, Cacheable, Diagnostic, Table},
     util::output::{done_processing, processing},
 };
-use rusqlite::{CachedStatement, Connection, Error, Result, Row};
+use rusqlite::{CachedStatement, Connection, Result, Row};
 
 // MARK: Struct
 /// Represents a single row in the `chat_handle_join` table.
@@ -30,12 +30,6 @@ impl Table for ChatToHandle {
         Ok(db.prepare_cached(&format!("SELECT * FROM {CHAT_HANDLE_JOIN}"))?)
     }
 
-    fn extract(chat_to_handle: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-        match chat_to_handle {
-            Ok(Ok(chat_to_handle)) => Ok(chat_to_handle),
-            Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-        }
-    }
 }
 
 // MARK: Cache

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -2,7 +2,7 @@
  This module represents common (but not all) columns in the `handle` table.
 */
 
-use rusqlite::{CachedStatement, Connection, Error, Result, Row};
+use rusqlite::{CachedStatement, Connection, Result, Row};
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use crate::{
@@ -37,12 +37,6 @@ impl Table for Handle {
         Ok(db.prepare_cached(&format!("SELECT * from {HANDLE}"))?)
     }
 
-    fn extract(handle: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-        match handle {
-            Ok(Ok(handle)) => Ok(handle),
-            Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-        }
-    }
 }
 
 // MARK: Cache
@@ -258,7 +252,7 @@ impl Handle {
                 let (person_centric_id, rowid, _) = contact;
                 let data_to_insert = match person_to_id.get_mut(person_centric_id) {
                     Some(person) => person.iter().cloned().collect::<Vec<String>>().join(" "),
-                    None => panic!("Attempted to resolve contact with no person_centric_id!"),
+                    None => continue,
                 };
                 row_to_id.insert(rowid.to_owned(), data_to_insert);
             }

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -8,6 +8,7 @@
  ## Example
  ```no_run
  use imessage_database::{
+     error::table::TableError,
      tables::{
          messages::Message,
          table::{get_connection, Diagnostic, Table},
@@ -16,7 +17,14 @@
  };
 
  // Your custom error type
- struct ProgramError;
+ #[derive(Debug)]
+ struct ProgramError(TableError);
+
+ impl From<TableError> for ProgramError {
+     fn from(err: TableError) -> Self {
+         Self(err)
+     }
+ }
 
  // Get the default database path and connect to it
  let db_path = default_db_path();
@@ -1369,16 +1377,12 @@ impl Message {
     /// }
     ///```
     pub fn from_guid(guid: &str, db: &Connection) -> Result<Self, TableError> {
-        // If the database has `chat_recoverable_message_join`, we can restore some deleted messages.
-        // If database has `thread_originator_guid`, we can parse replies, otherwise default to 0
-        let filters = format!("WHERE m.guid = \"{guid}\"");
-
         let mut statement = db
-            .prepare(&ios_16_newer_query(Some(&filters)))
-            .or_else(|_| db.prepare(&ios_14_15_query(Some(&filters))))
-            .or_else(|_| db.prepare(&ios_13_older_query(Some(&filters))))?;
+            .prepare_cached(&ios_16_newer_query(Some("WHERE m.guid = ?1")))
+            .or_else(|_| db.prepare_cached(&ios_14_15_query(Some("WHERE m.guid = ?1"))))
+            .or_else(|_| db.prepare_cached(&ios_13_older_query(Some("WHERE m.guid = ?1"))))?;
 
-        Message::extract(statement.query_row([], |row| Ok(Message::from_row(row))))
+        Message::extract(statement.query_row([guid], |row| Ok(Message::from_row(row))))
     }
 }
 

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -132,7 +132,7 @@ use std::{
 use chrono::{DateTime, offset::Local};
 use crabstep::TypedStreamDeserializer;
 use plist::Value;
-use rusqlite::{CachedStatement, Connection, Error, Result, Row};
+use rusqlite::{CachedStatement, Connection, Result, Row};
 
 use crate::{
     error::{message::MessageError, table::TableError},
@@ -256,12 +256,6 @@ impl Table for Message {
             .or_else(|_| db.prepare_cached(&ios_13_older_query(None)))?)
     }
 
-    fn extract(message: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-        match message {
-            Ok(Ok(message)) => Ok(message),
-            Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-        }
-    }
 }
 
 // MARK: Diagnostic

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -46,7 +46,12 @@ pub trait Table: Sized {
     fn get(db: &'_ Connection) -> Result<CachedStatement<'_>, TableError>;
 
     /// Map a `rusqlite::Result<Self>` into our `TableError`
-    fn extract(item: Result<Result<Self, Error>, Error>) -> Result<Self, TableError>;
+    fn extract(item: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
+        match item {
+            Ok(Ok(row)) => Ok(row),
+            Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
+        }
+    }
 
     /// Process all rows from the table using a callback.
     /// This is the most memory-efficient approach for large tables.
@@ -273,7 +278,7 @@ pub const ATTACHMENTS_DIR: &str = "attachments";
 
 #[cfg(test)]
 mod tests {
-    use rusqlite::{CachedStatement, Connection, Error, Result, Row};
+    use rusqlite::{CachedStatement, Connection, Result, Row};
 
     use crate::error::table::TableError;
 
@@ -288,13 +293,6 @@ mod tests {
 
         fn get(db: &'_ Connection) -> Result<CachedStatement<'_>, TableError> {
             Ok(db.prepare_cached("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3")?)
-        }
-
-        fn extract(item: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-            match item {
-                Ok(Ok(row)) => Ok(row),
-                Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-            }
         }
     }
 
@@ -339,13 +337,6 @@ mod tests {
 
             fn get(_db: &'_ Connection) -> Result<CachedStatement<'_>, TableError> {
                 Err(TableError::CannotRead(std::io::Error::other("boom")))
-            }
-
-            fn extract(item: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-                match item {
-                    Ok(Ok(row)) => Ok(row),
-                    Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-                }
             }
         }
 

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -27,7 +27,7 @@
  }).unwrap();
  ```
 
- Note: you can substitute `TableError` with your own error type if you want to handle errors differently. See the [`Table::stream`] method for more details.
+ Note: you can substitute `TableError` with your own error type if it implements `From<TableError>`. See the [`Table::stream`] method for more details.
 */
 
 use std::{collections::HashMap, fs::metadata, path::Path};
@@ -80,8 +80,9 @@ pub trait Table: Sized {
     ///     Ok::<(), TableError>(())
     /// }).unwrap();
     /// ```
-    fn stream<F, E>(db: &Connection, callback: F) -> Result<(), TableError>
+    fn stream<F, E>(db: &Connection, callback: F) -> Result<(), E>
     where
+        E: From<TableError>,
         F: FnMut(Result<Self, TableError>) -> Result<(), E>,
     {
         stream_table_callback::<Self, F, E>(db, callback)
@@ -121,17 +122,21 @@ pub trait Table: Sized {
     }
 }
 
-fn stream_table_callback<T, F, E>(db: &Connection, mut callback: F) -> Result<(), TableError>
+fn stream_table_callback<T, F, E>(db: &Connection, mut callback: F) -> Result<(), E>
 where
     T: Table + Sized,
+    E: From<TableError>,
     F: FnMut(Result<T, TableError>) -> Result<(), E>,
 {
-    let mut stmt = T::get(db)?;
-    let rows = stmt.query_map([], |row| Ok(T::from_row(row)))?;
+    let mut stmt = T::get(db).map_err(E::from)?;
+    let rows = stmt
+        .query_map([], |row| Ok(T::from_row(row)))
+        .map_err(TableError::from)
+        .map_err(E::from)?;
 
     for row_result in rows {
         let item_result = T::extract(row_result);
-        let _ = callback(item_result);
+        callback(item_result)?;
     }
     Ok(())
 }
@@ -265,3 +270,91 @@ pub const ORPHANED: &str = "orphaned";
 pub const FITNESS_RECEIVER: &str = "$(kIMTranscriptPluginBreadcrumbTextReceiverIdentifier)";
 /// Name for attachments directory in exports
 pub const ATTACHMENTS_DIR: &str = "attachments";
+
+#[cfg(test)]
+mod tests {
+    use rusqlite::{CachedStatement, Connection, Error, Result, Row};
+
+    use crate::error::table::TableError;
+
+    use super::Table;
+
+    struct TestRow(i64);
+
+    impl Table for TestRow {
+        fn from_row(row: &Row) -> Result<Self> {
+            Ok(Self(row.get(0)?))
+        }
+
+        fn get(db: &'_ Connection) -> Result<CachedStatement<'_>, TableError> {
+            Ok(db.prepare_cached("SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3")?)
+        }
+
+        fn extract(item: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
+            match item {
+                Ok(Ok(row)) => Ok(row),
+                Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    enum StreamError {
+        Table(TableError),
+        Stop,
+    }
+
+    impl From<TableError> for StreamError {
+        fn from(err: TableError) -> Self {
+            Self::Table(err)
+        }
+    }
+
+    #[test]
+    fn stream_propagates_callback_errors() {
+        let db = Connection::open_in_memory().unwrap();
+        let mut seen = vec![];
+
+        let result = TestRow::stream(&db, |row| {
+            let row = row.map_err(StreamError::from)?;
+            seen.push(row.0);
+            if row.0 == 2 {
+                return Err(StreamError::Stop);
+            }
+            Ok(())
+        });
+
+        assert!(matches!(result, Err(StreamError::Stop)));
+        assert_eq!(seen, vec![1, 2]);
+    }
+
+    #[test]
+    fn stream_converts_setup_errors() {
+        struct BrokenTable;
+
+        impl Table for BrokenTable {
+            fn from_row(_row: &Row) -> Result<Self> {
+                Ok(Self)
+            }
+
+            fn get(_db: &'_ Connection) -> Result<CachedStatement<'_>, TableError> {
+                Err(TableError::CannotRead(std::io::Error::other("boom")))
+            }
+
+            fn extract(item: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
+                match item {
+                    Ok(Ok(row)) => Ok(row),
+                    Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
+                }
+            }
+        }
+
+        let db = Connection::open_in_memory().unwrap();
+        let result = BrokenTable::stream(&db, |_| Ok::<(), StreamError>(()));
+
+        assert!(matches!(
+            result,
+            Err(StreamError::Table(TableError::CannotRead(_)))
+        ));
+    }
+}


### PR DESCRIPTION
- Propagate streaming errors from `Table::stream()` and `Table::stream_table_callback()` to the caller
- Expose chat `Property` metadata fields
- Cache query used inside of `from_guid()` for performance and safety
- Implement `std::error::Error` for all error types
- Move `Table::extract()` to default implementation