### PR TITLE
Feat/cs/date ref

### DIFF
--- a/imessage-database/build.rs
+++ b/imessage-database/build.rs
@@ -4,9 +4,9 @@ Build script for protobuf-generated modules.
 Build modes:
 
 - Default build (`cargo build -p imessage-database`):
-    validates that generated protobuf Rust files are already present in the repository.
+  validates that generated protobuf Rust files are already present in the repository.
 - Regeneration build (`cargo build -p imessage-database --features proto-regen`):
-    regenerates protobuf Rust files from the `.proto` sources.
+  regenerates protobuf Rust files from the `.proto` sources.
 
 Useful commands:
 

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -662,8 +662,8 @@ impl Message {
     /// This field is stored as a unix timestamp with an epoch of `2001-01-01 00:00:00` in the local time zone
     ///
     /// `offset` can be provided by [`get_offset`](crate::util::dates::get_offset) or manually.
-    pub fn date(&self, offset: &i64) -> Result<DateTime<Local>, MessageError> {
-        get_local_time(&self.date, offset)
+    pub fn date(&self, offset: i64) -> Result<DateTime<Local>, MessageError> {
+        get_local_time(self.date, offset)
     }
 
     /// Calculates the date a message was marked as delivered.
@@ -671,8 +671,8 @@ impl Message {
     /// This field is stored as a unix timestamp with an epoch of `2001-01-01 00:00:00` in the local time zone
     ///
     /// `offset` can be provided by [`get_offset`](crate::util::dates::get_offset) or manually.
-    pub fn date_delivered(&self, offset: &i64) -> Result<DateTime<Local>, MessageError> {
-        get_local_time(&self.date_delivered, offset)
+    pub fn date_delivered(&self, offset: i64) -> Result<DateTime<Local>, MessageError> {
+        get_local_time(self.date_delivered, offset)
     }
 
     /// Calculates the date a message was marked as read.
@@ -680,8 +680,8 @@ impl Message {
     /// This field is stored as a unix timestamp with an epoch of `2001-01-01 00:00:00` in the local time zone
     ///
     /// `offset` can be provided by [`get_offset`](crate::util::dates::get_offset) or manually.
-    pub fn date_read(&self, offset: &i64) -> Result<DateTime<Local>, MessageError> {
-        get_local_time(&self.date_read, offset)
+    pub fn date_read(&self, offset: i64) -> Result<DateTime<Local>, MessageError> {
+        get_local_time(self.date_read, offset)
     }
 
     /// Calculates the date a message was most recently edited.
@@ -689,8 +689,8 @@ impl Message {
     /// This field is stored as a unix timestamp with an epoch of `2001-01-01 00:00:00` in the local time zone
     ///
     /// `offset` can be provided by [`get_offset`](crate::util::dates::get_offset) or manually.
-    pub fn date_edited(&self, offset: &i64) -> Result<DateTime<Local>, MessageError> {
-        get_local_time(&self.date_edited, offset)
+    pub fn date_edited(&self, offset: i64) -> Result<DateTime<Local>, MessageError> {
+        get_local_time(self.date_edited, offset)
     }
 
     /// Gets the time until the message was read. This can happen in two ways:
@@ -707,7 +707,7 @@ impl Message {
     ///
     /// `offset` can be provided by [`get_offset`](crate::util::dates::get_offset) or manually.
     #[must_use]
-    pub fn time_until_read(&self, offset: &i64) -> Option<String> {
+    pub fn time_until_read(&self, offset: i64) -> Option<String> {
         // Message we received
         if !self.is_from_me && self.date_read != 0 && self.date != 0 {
             return readable_diff(self.date(offset), self.date_read(offset));
@@ -774,7 +774,7 @@ impl Message {
         self.associated_message_type == Some(4000)
     }
 
-    /// `true` if the message is a [`Poll`] vote, else `false`
+    /// `true` if the message adds a new option to a [`Poll`], else `false`
     #[must_use]
     pub fn is_poll_update(&self) -> bool {
         matches!(self.variant(), Variant::PollUpdate)

--- a/imessage-database/src/tables/messages/tests/date_tests.rs
+++ b/imessage-database/src/tables/messages/tests/date_tests.rs
@@ -18,7 +18,7 @@ mod tests {
         message.date_read = 674530231992568192;
 
         assert_eq!(
-            message.time_until_read(&offset),
+            message.time_until_read(offset),
             Some("1 hour, 49 seconds".to_string())
         );
     }
@@ -37,14 +37,14 @@ mod tests {
         // May 17, 2022  8:29:42 PM
         message.date_read = 674526582885055488;
 
-        assert_eq!(message.time_until_read(&offset), None);
+        assert_eq!(message.time_until_read(offset), None);
     }
 
     #[test]
     fn can_get_time_until_read_none() {
         let offset = get_offset();
         let m = Message::blank();
-        assert_eq!(m.time_until_read(&offset), None);
+        assert_eq!(m.time_until_read(offset), None);
     }
 
     #[test]
@@ -54,7 +54,7 @@ mod tests {
         // May 17, 2022 8:29:42 PM
         m.date_edited = 674526582885055488;
 
-        let result = m.date_edited(&offset);
+        let result = m.date_edited(offset);
         assert!(result.is_ok());
     }
 
@@ -65,7 +65,7 @@ mod tests {
         // May 17, 2022 8:29:42 PM
         m.date_delivered = 674526582885055488;
 
-        let result = m.date_delivered(&offset);
+        let result = m.date_delivered(offset);
         assert!(result.is_ok());
     }
 }

--- a/imessage-database/src/util/dates.rs
+++ b/imessage-database/src/util/dates.rs
@@ -47,19 +47,19 @@ pub fn get_offset() -> i64 {
 /// use imessage_database::util::dates::{get_local_time, get_offset};
 ///
 /// let current_offset = get_offset();
-/// let local = get_local_time(&674526582885055488, &current_offset).unwrap();
+/// let local = get_local_time(674526582885055488, current_offset).unwrap();
 /// ```
-pub fn get_local_time(date_stamp: &i64, offset: &i64) -> Result<DateTime<Local>, MessageError> {
+pub fn get_local_time(date_stamp: i64, offset: i64) -> Result<DateTime<Local>, MessageError> {
     // Newer databases store timestamps as nanoseconds since 2001-01-01,
     // while older ones store plain seconds since 2001-01-01.
-    let seconds_since_2001 = if *date_stamp >= 1_000_000_000_000 {
+    let seconds_since_2001 = if date_stamp >= 1_000_000_000_000 {
         date_stamp / TIMESTAMP_FACTOR
     } else {
-        *date_stamp
+        date_stamp
     };
 
     let utc_stamp = DateTime::from_timestamp(seconds_since_2001 + offset, 0)
-        .ok_or(MessageError::InvalidTimestamp(*date_stamp))?
+        .ok_or(MessageError::InvalidTimestamp(date_stamp))?
         .naive_utc();
     Ok(Local.from_utc_datetime(&utc_stamp))
 }
@@ -302,7 +302,7 @@ mod tests {
         // Older databases store seconds since 2001-01-01 00:00:00
         let stamp_secs = expected_utc.timestamp() - offset;
 
-        let local = get_local_time(&stamp_secs, &offset).unwrap();
+        let local = get_local_time(stamp_secs, offset).unwrap();
         let expected_local = expected_utc.with_timezone(&Local);
 
         assert_eq!(local, expected_local);
@@ -319,7 +319,7 @@ mod tests {
         // Newer databases store nanoseconds since 2001-01-01 00:00:00
         let stamp_ns = (expected_utc.timestamp() - offset) * TIMESTAMP_FACTOR;
 
-        let local = get_local_time(&stamp_ns, &offset).unwrap();
+        let local = get_local_time(stamp_ns, offset).unwrap();
         let expected_local = expected_utc.with_timezone(&Local);
 
         assert_eq!(local, expected_local);
@@ -334,7 +334,7 @@ mod tests {
 
         let expected_utc = Utc.timestamp_opt(stamp_secs + offset, 0).single().unwrap();
 
-        let local = get_local_time(&stamp_secs, &offset).unwrap();
+        let local = get_local_time(stamp_secs, offset).unwrap();
         let expected_local = expected_utc.with_timezone(&Local);
 
         assert_eq!(local, expected_local);
@@ -354,7 +354,7 @@ mod tests {
             .single()
             .unwrap();
 
-        let local = get_local_time(&stamp_ns, &offset).unwrap();
+        let local = get_local_time(stamp_ns, offset).unwrap();
         let expected_local = expected_utc.with_timezone(&Local);
 
         assert_eq!(local, expected_local);

--- a/imessage-exporter/src/app/compatibility/converters/common.rs
+++ b/imessage-exporter/src/app/compatibility/converters/common.rs
@@ -112,7 +112,7 @@ pub(crate) fn update_file_metadata(from: &Path, to: &Path, message: &Message, co
     // Update file metadata
     if let Ok(metadata) = metadata(from) {
         // The modification time is the message's date, otherwise the original file's modification time
-        let mtime = match message.date(&config.offset) {
+        let mtime = match message.date(config.offset) {
             Ok(date) => unix_to_system_time(date.timestamp(), date.timestamp_subsec_nanos())
                 .or_else(|| metadata.modified().ok()),
             Err(_) => metadata.modified().ok(),

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -886,7 +886,7 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
         if who == ME {
             who = self.config.options.custom_name.as_deref().unwrap_or("You");
         }
-        let timestamp = format(&msg.date(&self.config.offset));
+        let timestamp = format(&msg.date(self.config.offset));
 
         match msg.get_announcement() {
             Some(announcement) => {
@@ -993,8 +993,8 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
                             match previous_timestamp {
                                 None => out_s.push_str(&self.edited_to_html("", &clean_text, last)),
                                 Some(prev_timestamp) => {
-                                    let end = get_local_time(&event.date, &self.config.offset);
-                                    let start = get_local_time(prev_timestamp, &self.config.offset);
+                                    let end = get_local_time(event.date, self.config.offset);
+                                    let start = get_local_time(*prev_timestamp, self.config.offset);
                                     let diff = readable_diff(start, end).unwrap_or_default();
 
                                     out_s.push_str(&self.edited_to_html(
@@ -1021,8 +1021,8 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
                     };
 
                     match readable_diff(
-                        msg.date(&self.config.offset),
-                        msg.date_edited(&self.config.offset),
+                        msg.date(self.config.offset),
+                        msg.date_edited(self.config.offset),
                     ) {
                         Some(diff) => {
                             let _ = write!(
@@ -1544,7 +1544,7 @@ impl<'a> BalloonFormatter<&'a Message> for HTML<'a> {
         if let Some(date_str) = metadata.get("estimatedEndTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(&date_stamp, &0);
+            let date_time = get_local_time(date_stamp, 0);
             let date_string = format(&date_time);
 
             out_s.push_str("<div class=\"app_footer\">");
@@ -1559,7 +1559,7 @@ impl<'a> BalloonFormatter<&'a Message> for HTML<'a> {
         else if let Some(date_str) = metadata.get("triggerTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(&date_stamp, &0);
+            let date_time = get_local_time(date_stamp, 0);
             let date_string = format(&date_time);
 
             out_s.push_str("<div class=\"app_footer\">");
@@ -1574,7 +1574,7 @@ impl<'a> BalloonFormatter<&'a Message> for HTML<'a> {
         else if let Some(date_str) = metadata.get("sendDate") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(&date_stamp, &0);
+            let date_time = get_local_time(date_stamp, 0);
             let date_string = format(&date_time);
 
             out_s.push_str("<div class=\"app_footer\">");

--- a/imessage-exporter/src/exporters/shared.rs
+++ b/imessage-exporter/src/exporters/shared.rs
@@ -40,9 +40,9 @@ pub(super) fn format_expressive(msg: &Message) -> &str {
 /// Returns `(formatted_date, read_receipt)` where `read_receipt` is
 /// empty if there is no read receipt data.
 pub(super) fn message_time(config: &Config, message: &Message) -> (String, String) {
-    let date = format(&message.date(&config.offset));
+    let date = format(&message.date(config.offset));
     let mut read_receipt = String::new();
-    if let Some(time) = message.time_until_read(&config.offset)
+    if let Some(time) = message.time_until_read(config.offset)
         && !time.is_empty()
     {
         let who = if message.is_from_me() {

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -627,7 +627,7 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
             who = self.config.options.custom_name.as_deref().unwrap_or(YOU);
         }
 
-        let timestamp = format(&msg.date(&self.config.offset));
+        let timestamp = format(&msg.date(self.config.offset));
 
         match msg.get_announcement() {
             Some(announcement) => {
@@ -711,14 +711,14 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
                             // Original message get an absolute timestamp
                             None => {
                                 let parsed_timestamp =
-                                    format(&get_local_time(&event.date, &self.config.offset));
+                                    format(&get_local_time(event.date, self.config.offset));
                                 out_s.push_str(&parsed_timestamp);
                                 out_s.push(' ');
                             }
                             // Subsequent edits get a relative timestamp
                             Some(prev_timestamp) => {
-                                let end = get_local_time(&event.date, &self.config.offset);
-                                let start = get_local_time(prev_timestamp, &self.config.offset);
+                                let end = get_local_time(event.date, self.config.offset);
+                                let start = get_local_time(*prev_timestamp, self.config.offset);
                                 if let Some(diff) = readable_diff(start, end) {
                                     out_s.push_str(indent);
                                     out_s.push_str("Edited ");
@@ -745,8 +745,8 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
                     };
 
                     if let Some(diff) = readable_diff(
-                        msg.date(&self.config.offset),
-                        msg.date_edited(&self.config.offset),
+                        msg.date(self.config.offset),
+                        msg.date_edited(self.config.offset),
                     ) {
                         out_s.push_str(who);
                         out_s.push_str(" unsent this message part ");
@@ -1047,7 +1047,7 @@ impl<'a> BalloonFormatter<&'a str> for TXT<'a> {
         if let Some(date_str) = metadata.get("estimatedEndTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(&date_stamp, &0);
+            let date_time = get_local_time(date_stamp, 0);
             let date_string = format(&date_time);
 
             out_s.push_str("\nExpected at ");
@@ -1057,7 +1057,7 @@ impl<'a> BalloonFormatter<&'a str> for TXT<'a> {
         else if let Some(date_str) = metadata.get("triggerTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(&date_stamp, &0);
+            let date_time = get_local_time(date_stamp, 0);
             let date_string = format(&date_time);
 
             out_s.push_str("\nWas expected at ");
@@ -1067,7 +1067,7 @@ impl<'a> BalloonFormatter<&'a str> for TXT<'a> {
         else if let Some(date_str) = metadata.get("sendDate") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(&date_stamp, &0);
+            let date_time = get_local_time(date_stamp, 0);
             let date_string = format(&date_time);
 
             out_s.push_str("\nChecked in at ");


### PR DESCRIPTION
- Pass date offset by value
  - All `Message::date()` methods and `util::get_local_time()` no longer accept references for the offset