### PR TITLE
Refactor date handling signature

### DIFF
--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -725,11 +725,11 @@ impl Message {
     pub fn time_until_read(&self, offset: i64) -> Option<String> {
         // Message we received
         if !self.is_from_me && self.date_read != 0 && self.date != 0 {
-            return readable_diff(self.date(offset), self.date_read(offset));
+            return readable_diff(&self.date(offset).ok()?, &self.date_read(offset).ok()?);
         }
         // Message we sent
         else if self.is_from_me && self.date_delivered != 0 && self.date != 0 {
-            return readable_diff(self.date(offset), self.date_delivered(offset));
+            return readable_diff(&self.date(offset).ok()?, &self.date_delivered(offset).ok()?);
         }
         None
     }

--- a/imessage-database/src/util/dates.rs
+++ b/imessage-database/src/util/dates.rs
@@ -76,15 +76,12 @@ pub fn get_local_time(date_stamp: i64, offset: i64) -> Result<DateTime<Local>, M
 /// use chrono::offset::Local;
 /// use imessage_database::util::dates::format;
 ///
-/// let date = format(&Ok(Local::now()));
+/// let date = format(&Local::now());
 /// println!("{date}");
 /// ```
 #[must_use]
-pub fn format(date: &Result<DateTime<Local>, MessageError>) -> String {
-    match date {
-        Ok(d) => DateTime::format(d, "%b %d, %Y %l:%M:%S %p").to_string(),
-        Err(why) => why.to_string(),
-    }
+pub fn format(date: &DateTime<Local>) -> String {
+    DateTime::format(date, "%b %d, %Y %l:%M:%S %p").to_string()
 }
 
 /// Generate a readable diff from two local timestamps.
@@ -95,17 +92,12 @@ pub fn format(date: &Result<DateTime<Local>, MessageError>) -> String {
 /// use chrono::prelude::*;
 /// use imessage_database::util::dates::readable_diff;
 ///
-/// let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-/// let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 15, 13).unwrap());
-/// println!("{}", readable_diff(start, end).unwrap()) // "5 minutes, 2 seconds"
+/// let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+/// let end = Local.with_ymd_and_hms(2020, 5, 20, 9, 15, 13).unwrap();
+/// println!("{}", readable_diff(&start, &end).unwrap()) // "5 minutes, 2 seconds"
 /// ```
 #[must_use]
-pub fn readable_diff(
-    start: Result<DateTime<Local>, MessageError>,
-    end: Result<DateTime<Local>, MessageError>,
-) -> Option<String> {
-    let start = start.ok()?;
-    let end = end.ok()?;
+pub fn readable_diff(start: &DateTime<Local>, end: &DateTime<Local>) -> Option<String> {
 
     // Calculate diff
     let seconds = end.timestamp() - start.timestamp();
@@ -115,7 +107,7 @@ pub fn readable_diff(
         return None;
     }
 
-    let (years, remaining_seconds) = years_and_remainder(&start, &end)
+    let (years, remaining_seconds) = years_and_remainder(start, end)
         .unwrap_or((seconds / SECONDS_PER_YEAR, seconds % SECONDS_PER_YEAR));
 
     // 51 is the length of a diff string that has all components with 2 digits each.
@@ -175,151 +167,142 @@ fn append_component(out_s: &mut String, value: i64, singular: &str, plural: &str
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        error::message::MessageError,
-        util::dates::{TIMESTAMP_FACTOR, format, get_local_time, get_offset, readable_diff},
-    };
+    use crate::util::dates::{TIMESTAMP_FACTOR, format, get_local_time, get_offset, readable_diff};
     use chrono::prelude::*;
 
     #[test]
     fn can_format_date_single_digit() {
-        let date = Local
-            .with_ymd_and_hms(2020, 5, 20, 9, 10, 11)
-            .single()
-            .ok_or(MessageError::InvalidTimestamp(0));
+        let date = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
         assert_eq!(format(&date), "May 20, 2020  9:10:11 AM");
     }
 
     #[test]
     fn can_format_date_double_digit() {
-        let date = Local
-            .with_ymd_and_hms(2020, 5, 20, 10, 10, 11)
-            .single()
-            .ok_or(MessageError::InvalidTimestamp(0));
+        let date = Local.with_ymd_and_hms(2020, 5, 20, 10, 10, 11).unwrap();
         assert_eq!(format(&date), "May 20, 2020 10:10:11 AM");
     }
 
     #[test]
     fn cant_format_diff_backwards() {
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 30).unwrap());
-        assert_eq!(readable_diff(start, end), None);
+        let end = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 30).unwrap();
+        assert_eq!(readable_diff(&start, &end), None);
     }
 
     #[test]
     fn can_format_diff_all_singular() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 21, 10, 11, 12).unwrap());
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 21, 10, 11, 12).unwrap();
         assert_eq!(
-            readable_diff(start, end),
+            readable_diff(&start, &end),
             Some("1 day, 1 hour, 1 minute, 1 second".to_owned())
         );
     }
 
     #[test]
     fn can_format_diff_mixed_singular() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 22, 10, 20, 12).unwrap());
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 22, 10, 20, 12).unwrap();
         assert_eq!(
-            readable_diff(start, end),
+            readable_diff(&start, &end),
             Some("2 days, 1 hour, 10 minutes, 1 second".to_owned())
         );
     }
 
     #[test]
     fn can_format_diff_seconds() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 30).unwrap());
-        assert_eq!(readable_diff(start, end), Some("19 seconds".to_owned()));
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 30).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some("19 seconds".to_owned()));
     }
 
     #[test]
     fn can_format_diff_minutes() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 15, 11).unwrap());
-        assert_eq!(readable_diff(start, end), Some("5 minutes".to_owned()));
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 20, 9, 15, 11).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some("5 minutes".to_owned()));
     }
 
     #[test]
     fn can_format_diff_hours() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 12, 10, 11).unwrap());
-        assert_eq!(readable_diff(start, end), Some("3 hours".to_owned()));
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 20, 12, 10, 11).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some("3 hours".to_owned()));
     }
 
     #[test]
     fn can_format_diff_days() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 30, 9, 10, 11).unwrap());
-        assert_eq!(readable_diff(start, end), Some("10 days".to_owned()));
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 30, 9, 10, 11).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some("10 days".to_owned()));
     }
 
     #[test]
     fn can_format_diff_minutes_seconds() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 15, 30).unwrap());
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 20, 9, 15, 30).unwrap();
         assert_eq!(
-            readable_diff(start, end),
+            readable_diff(&start, &end),
             Some("5 minutes, 19 seconds".to_owned())
         );
     }
 
     #[test]
     fn can_format_diff_days_minutes() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 22, 9, 30, 11).unwrap());
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 22, 9, 30, 11).unwrap();
         assert_eq!(
-            readable_diff(start, end),
+            readable_diff(&start, &end),
             Some("2 days, 20 minutes".to_owned())
         );
     }
 
     #[test]
     fn can_format_diff_month() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 7, 20, 9, 10, 11).unwrap());
-        assert_eq!(readable_diff(start, end), Some("61 days".to_owned()));
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 7, 20, 9, 10, 11).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some("61 days".to_owned()));
     }
 
     #[test]
     fn can_format_diff_single_year() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2021, 5, 20, 9, 10, 11).unwrap());
-        assert_eq!(readable_diff(start, end), Some("1 year".to_owned()));
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2021, 5, 20, 9, 10, 11).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some("1 year".to_owned()));
     }
 
     #[test]
     fn can_format_diff_years_days() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2022, 7, 20, 9, 10, 11).unwrap());
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2022, 7, 20, 9, 10, 11).unwrap();
         assert_eq!(
-            readable_diff(start, end),
+            readable_diff(&start, &end),
             Some("2 years, 61 days".to_owned())
         );
     }
 
     #[test]
     fn can_format_diff_leap_day_anniversary_as_year() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 2, 29, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2021, 2, 28, 9, 10, 11).unwrap());
-        assert_eq!(readable_diff(start, end), Some("1 year".to_owned()));
+        let start = Local.with_ymd_and_hms(2020, 2, 29, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2021, 2, 28, 9, 10, 11).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some("1 year".to_owned()));
     }
 
     #[test]
     fn can_format_diff_all() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 22, 14, 32, 45).unwrap());
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 22, 14, 32, 45).unwrap();
         assert_eq!(
-            readable_diff(start, end),
+            readable_diff(&start, &end),
             Some("2 days, 5 hours, 22 minutes, 34 seconds".to_owned())
         );
     }
 
     #[test]
     fn can_format_no_diff() {
-        let start = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        let end = Ok(Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap());
-        assert_eq!(readable_diff(start, end), Some(String::new()));
+        let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        let end = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
+        assert_eq!(readable_diff(&start, &end), Some(String::new()));
     }
 
     #[test]

--- a/imessage-database/src/util/query_context.rs
+++ b/imessage-database/src/util/query_context.rs
@@ -169,7 +169,7 @@ mod use_tests {
         .naive_utc();
         let local = Local.from_utc_datetime(&from_timestamp);
 
-        assert_eq!(format(&Ok(local)), "Jan 01, 2020 12:00:00 AM");
+        assert_eq!(format(&local), "Jan 01, 2020 12:00:00 AM");
         assert!(context.start.is_some());
         assert!(context.end.is_none());
         assert!(context.has_filters());
@@ -186,7 +186,7 @@ mod use_tests {
                 .naive_utc();
         let local = Local.from_utc_datetime(&from_timestamp);
 
-        assert_eq!(format(&Ok(local)), "Jan 01, 2020 12:00:00 AM");
+        assert_eq!(format(&local), "Jan 01, 2020 12:00:00 AM");
         assert!(context.start.is_none());
         assert!(context.end.is_some());
         assert!(context.has_filters());
@@ -212,8 +212,8 @@ mod use_tests {
                 .naive_utc();
         let local_end = Local.from_utc_datetime(&from_timestamp);
 
-        assert_eq!(format(&Ok(local_start)), "Jan 01, 2020 12:00:00 AM");
-        assert_eq!(format(&Ok(local_end)), "Feb 02, 2020 12:00:00 AM");
+        assert_eq!(format(&local_start), "Jan 01, 2020 12:00:00 AM");
+        assert_eq!(format(&local_end), "Feb 02, 2020 12:00:00 AM");
         assert!(context.start.is_some());
         assert!(context.end.is_some());
         assert!(context.has_filters());

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -441,16 +441,18 @@ impl Config {
         if let (Some(first), Some(last)) = (
             message_diag.first_message_date,
             message_diag.last_message_date,
-        ) {
+        )
+            && let (Ok(first_date), Ok(last_date)) = (
+                get_local_time(first, self.offset),
+                get_local_time(last, self.offset),
+            )
+        {
             println!(
                 "    Date range: {} to {}\n                {}",
-                format_date(&get_local_time(first, self.offset)),
-                format_date(&get_local_time(last, self.offset)),
-                readable_diff(
-                    get_local_time(first, self.offset),
-                    get_local_time(last, self.offset)
-                )
-                .unwrap_or_else(|| "N/A".to_string()),
+                format_date(&first_date),
+                format_date(&last_date),
+                readable_diff(&first_date, &last_date)
+                    .unwrap_or_else(|| "N/A".to_string()),
             );
         }
 

--- a/imessage-exporter/src/exporters/html.rs
+++ b/imessage-exporter/src/exporters/html.rs
@@ -886,7 +886,10 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
         if who == ME {
             who = self.config.options.custom_name.as_deref().unwrap_or("You");
         }
-        let timestamp = format(&msg.date(self.config.offset));
+        let timestamp = match msg.date(self.config.offset) {
+            Ok(d) => format(&d),
+            Err(why) => why.to_string(),
+        };
 
         match msg.get_announcement() {
             Some(announcement) => {
@@ -993,9 +996,14 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
                             match previous_timestamp {
                                 None => out_s.push_str(&self.edited_to_html("", &clean_text, last)),
                                 Some(prev_timestamp) => {
-                                    let end = get_local_time(event.date, self.config.offset);
-                                    let start = get_local_time(*prev_timestamp, self.config.offset);
-                                    let diff = readable_diff(start, end).unwrap_or_default();
+                                    let diff = if let (Ok(start), Ok(end)) = (
+                                        get_local_time(*prev_timestamp, self.config.offset),
+                                        get_local_time(event.date, self.config.offset),
+                                    ) {
+                                        readable_diff(&start, &end).unwrap_or_default()
+                                    } else {
+                                        String::new()
+                                    };
 
                                     out_s.push_str(&self.edited_to_html(
                                         &format!("Edited {diff} later"),
@@ -1020,10 +1028,7 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
                             .who(msg.handle_id, msg.is_from_me(), &msg.destination_caller_id)
                     };
 
-                    match readable_diff(
-                        msg.date(self.config.offset),
-                        msg.date_edited(self.config.offset),
-                    ) {
+                    match msg.date(self.config.offset).ok().zip(msg.date_edited(self.config.offset).ok()).and_then(|(s, e)| readable_diff(&s, &e)) {
                         Some(diff) => {
                             let _ = write!(
                                 out_s,
@@ -1544,46 +1549,49 @@ impl<'a> BalloonFormatter<&'a Message> for HTML<'a> {
         if let Some(date_str) = metadata.get("estimatedEndTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(date_stamp, 0);
-            let date_string = format(&date_time);
+            if let Ok(date_time) = get_local_time(date_stamp, 0) {
+                let date_string = format(&date_time);
 
-            out_s.push_str("<div class=\"app_footer\">");
+                out_s.push_str("<div class=\"app_footer\">");
 
-            out_s.push_str("<div class=\"caption\">Expected around ");
-            out_s.push_str(&date_string);
-            out_s.push_str("</div>");
+                out_s.push_str("<div class=\"caption\">Expected around ");
+                out_s.push_str(&date_string);
+                out_s.push_str("</div>");
 
-            out_s.push_str("</div>");
+                out_s.push_str("</div>");
+            }
         }
         // Expired check-in
         else if let Some(date_str) = metadata.get("triggerTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(date_stamp, 0);
-            let date_string = format(&date_time);
+            if let Ok(date_time) = get_local_time(date_stamp, 0) {
+                let date_string = format(&date_time);
 
-            out_s.push_str("<div class=\"app_footer\">");
+                out_s.push_str("<div class=\"app_footer\">");
 
-            out_s.push_str("<div class=\"caption\">Was expected around ");
-            out_s.push_str(&date_string);
-            out_s.push_str("</div>");
+                out_s.push_str("<div class=\"caption\">Was expected around ");
+                out_s.push_str(&date_string);
+                out_s.push_str("</div>");
 
-            out_s.push_str("</div>");
+                out_s.push_str("</div>");
+            }
         }
         // Accepted check-in
         else if let Some(date_str) = metadata.get("sendDate") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(date_stamp, 0);
-            let date_string = format(&date_time);
+            if let Ok(date_time) = get_local_time(date_stamp, 0) {
+                let date_string = format(&date_time);
 
-            out_s.push_str("<div class=\"app_footer\">");
+                out_s.push_str("<div class=\"app_footer\">");
 
-            out_s.push_str("<div class=\"caption\">Checked in at ");
-            out_s.push_str(&date_string);
-            out_s.push_str("</div>");
+                out_s.push_str("<div class=\"caption\">Checked in at ");
+                out_s.push_str(&date_string);
+                out_s.push_str("</div>");
 
-            out_s.push_str("</div>");
+                out_s.push_str("</div>");
+            }
         }
 
         out_s

--- a/imessage-exporter/src/exporters/shared.rs
+++ b/imessage-exporter/src/exporters/shared.rs
@@ -40,7 +40,10 @@ pub(super) fn format_expressive(msg: &Message) -> &str {
 /// Returns `(formatted_date, read_receipt)` where `read_receipt` is
 /// empty if there is no read receipt data.
 pub(super) fn message_time(config: &Config, message: &Message) -> (String, String) {
-    let date = format(&message.date(config.offset));
+    let date = match message.date(config.offset) {
+        Ok(d) => format(&d),
+        Err(why) => why.to_string(),
+    };
     let mut read_receipt = String::new();
     if let Some(time) = message.time_until_read(config.offset)
         && !time.is_empty()

--- a/imessage-exporter/src/exporters/txt.rs
+++ b/imessage-exporter/src/exporters/txt.rs
@@ -627,7 +627,10 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
             who = self.config.options.custom_name.as_deref().unwrap_or(YOU);
         }
 
-        let timestamp = format(&msg.date(self.config.offset));
+        let timestamp = match msg.date(self.config.offset) {
+            Ok(d) => format(&d),
+            Err(why) => why.to_string(),
+        };
 
         match msg.get_announcement() {
             Some(announcement) => {
@@ -710,16 +713,21 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
                         match previous_timestamp {
                             // Original message get an absolute timestamp
                             None => {
-                                let parsed_timestamp =
-                                    format(&get_local_time(event.date, self.config.offset));
+                                let parsed_timestamp = match get_local_time(event.date, self.config.offset) {
+                                    Ok(d) => format(&d),
+                                    Err(why) => why.to_string(),
+                                };
                                 out_s.push_str(&parsed_timestamp);
                                 out_s.push(' ');
                             }
                             // Subsequent edits get a relative timestamp
                             Some(prev_timestamp) => {
-                                let end = get_local_time(event.date, self.config.offset);
-                                let start = get_local_time(*prev_timestamp, self.config.offset);
-                                if let Some(diff) = readable_diff(start, end) {
+                                if let (Ok(start), Ok(end)) = (
+                                    get_local_time(*prev_timestamp, self.config.offset),
+                                    get_local_time(event.date, self.config.offset),
+                                )
+                                    && let Some(diff) = readable_diff(&start, &end)
+                                {
                                     out_s.push_str(indent);
                                     out_s.push_str("Edited ");
                                     out_s.push_str(&diff);
@@ -744,10 +752,7 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
                         "They"
                     };
 
-                    if let Some(diff) = readable_diff(
-                        msg.date(self.config.offset),
-                        msg.date_edited(self.config.offset),
-                    ) {
+                    if let Some(diff) = msg.date(self.config.offset).ok().zip(msg.date_edited(self.config.offset).ok()).and_then(|(s, e)| readable_diff(&s, &e)) {
                         out_s.push_str(who);
                         out_s.push_str(" unsent this message part ");
                         out_s.push_str(&diff);
@@ -1047,31 +1052,34 @@ impl<'a> BalloonFormatter<&'a str> for TXT<'a> {
         if let Some(date_str) = metadata.get("estimatedEndTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(date_stamp, 0);
-            let date_string = format(&date_time);
+            if let Ok(date_time) = get_local_time(date_stamp, 0) {
+                let date_string = format(&date_time);
 
-            out_s.push_str("\nExpected at ");
-            out_s.push_str(&date_string);
+                out_s.push_str("\nExpected at ");
+                out_s.push_str(&date_string);
+            }
         }
         // Expired check-in
         else if let Some(date_str) = metadata.get("triggerTime") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(date_stamp, 0);
-            let date_string = format(&date_time);
+            if let Ok(date_time) = get_local_time(date_stamp, 0) {
+                let date_string = format(&date_time);
 
-            out_s.push_str("\nWas expected at ");
-            out_s.push_str(&date_string);
+                out_s.push_str("\nWas expected at ");
+                out_s.push_str(&date_string);
+            }
         }
         // Accepted check-in
         else if let Some(date_str) = metadata.get("sendDate") {
             // Parse the estimated end time from the message's query string
             let date_stamp = date_str.parse::<f64>().unwrap_or(0.) as i64 * TIMESTAMP_FACTOR;
-            let date_time = get_local_time(date_stamp, 0);
-            let date_string = format(&date_time);
+            if let Ok(date_time) = get_local_time(date_stamp, 0) {
+                let date_string = format(&date_time);
 
-            out_s.push_str("\nChecked in at ");
-            out_s.push_str(&date_string);
+                out_s.push_str("\nChecked in at ");
+                out_s.push_str(&date_string);
+            }
         }
 
         out_s


### PR DESCRIPTION
- `date::format()` and `date::readable_diff()` now receive `&DateTime<Local>`,  instead of `Result<DateTime<Local>, MessageError>`