### PR TITLE
Feat/cs/add trait imps

### DIFF
--- a/imessage-database/src/message_types/sticker.rs
+++ b/imessage-database/src/message_types/sticker.rs
@@ -53,8 +53,7 @@ impl StickerSource {
 }
 
 /// Represents different types of [sticker effects](https://www.macrumors.com/how-to/add-effects-to-stickers-in-messages/) that can be applied to sticker iMessage balloons.
-#[derive(Debug, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Debug, PartialEq, Eq, Default)]
 pub enum StickerEffect {
     /// Sticker sent with no effect
     #[default]
@@ -97,17 +96,16 @@ impl Display for StickerEffect {
     }
 }
 
-
 /// Parse the sticker effect type from the EXIF data of a HEIC blob
 #[must_use]
-pub fn get_sticker_effect(mut heic_data: Vec<u8>) -> StickerEffect {
+pub fn get_sticker_effect(mut heic_data: &[u8]) -> StickerEffect {
     // Find the start index and drain
     for idx in 0..heic_data.len() {
         if idx + STICKER_EFFECT_PREFIX.len() < heic_data.len() {
             let part = &heic_data[idx..idx + STICKER_EFFECT_PREFIX.len()];
             if part == STICKER_EFFECT_PREFIX {
                 // Remove the start pattern from the blob
-                heic_data.drain(..idx + STICKER_EFFECT_PREFIX.len());
+                heic_data = &heic_data[idx + STICKER_EFFECT_PREFIX.len()..];
                 break;
             }
         } else {
@@ -124,11 +122,11 @@ pub fn get_sticker_effect(mut heic_data: Vec<u8>) -> StickerEffect {
 
         if part == STICKER_EFFECT_SUFFIX {
             // Remove the end pattern from the string
-            heic_data.truncate(idx);
+            heic_data = &heic_data[..idx];
             break;
         }
     }
-    StickerEffect::from_exif(&String::from_utf8_lossy(&heic_data))
+    StickerEffect::from_exif(&String::from_utf8_lossy(heic_data))
 }
 
 #[cfg(test)]
@@ -149,7 +147,7 @@ mod tests {
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
 
-        let effect = get_sticker_effect(bytes);
+        let effect = get_sticker_effect(&bytes);
 
         assert_eq!(effect, StickerEffect::Normal);
     }
@@ -164,7 +162,7 @@ mod tests {
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
 
-        let effect = get_sticker_effect(bytes);
+        let effect = get_sticker_effect(&bytes);
 
         assert_eq!(effect, StickerEffect::Outline);
     }
@@ -179,7 +177,7 @@ mod tests {
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
 
-        let effect = get_sticker_effect(bytes);
+        let effect = get_sticker_effect(&bytes);
 
         assert_eq!(effect, StickerEffect::Comic);
     }
@@ -194,7 +192,7 @@ mod tests {
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
 
-        let effect = get_sticker_effect(bytes);
+        let effect = get_sticker_effect(&bytes);
 
         assert_eq!(effect, StickerEffect::Puffy);
     }
@@ -209,7 +207,7 @@ mod tests {
         let mut bytes = vec![];
         file.read_to_end(&mut bytes).unwrap();
 
-        let effect = get_sticker_effect(bytes);
+        let effect = get_sticker_effect(&bytes);
 
         assert_eq!(effect, StickerEffect::Shiny);
     }

--- a/imessage-database/src/message_types/variants.rs
+++ b/imessage-database/src/message_types/variants.rs
@@ -43,7 +43,7 @@ use crate::{
 /// - 3 is the text of the message
 ///
 /// In this example, a Like on `p:2/` is a like on the third image.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Tapback<'a> {
     /// Heart
     Loved,
@@ -79,7 +79,7 @@ impl Display for Tapback<'_> {
 ///
 /// Messages sent via an app's iMessage integration will send in a special balloon instead of a normal
 /// text balloon. This represents the different variants of message balloon.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum CustomBalloon<'a> {
     /// Generic third party [applications](crate::message_types::app)
     Application(&'a str),
@@ -107,7 +107,7 @@ pub enum CustomBalloon<'a> {
 ///
 /// Apple sometimes overloads `com.apple.messages.URLBalloonProvider` with
 /// other types of messages; this enum represents those variants.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum URLOverride<'a> {
     /// [`URL`](crate::message_types::url) previews
     Normal(URLMessage<'a>),
@@ -125,7 +125,7 @@ pub enum URLOverride<'a> {
 ///
 /// Announcements are messages sent to a thread for actions that are not balloons, i.e.
 /// updating the name of the group or changing the group photo
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Announcement<'a> {
     /// All parts of the message were unsent
     FullyUnsent,
@@ -140,7 +140,7 @@ pub enum Announcement<'a> {
 /// Tapback Action Container
 ///
 /// Tapbacks can either be added or removed; this enum represents those states
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum TapbackAction {
     /// Tapback was added to the message
     Added,
@@ -152,7 +152,7 @@ pub enum TapbackAction {
 ///
 /// Messages can exist as one of many different variants, this encapsulates
 /// all of the possibilities.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Variant<'a> {
     /// An iMessage with a standard text body that may include attachments
     Normal,

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -248,7 +248,7 @@ impl Attachment {
 
         // Try to parse the HEIC data
         if let Some(data) = self.as_bytes(platform, db_path, custom_attachment_root)? {
-            return Ok(Some(get_sticker_effect(data)));
+            return Ok(Some(get_sticker_effect(&data)));
         }
 
         // Default if the attachment is a sticker and cannot be parsed/read

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -15,6 +15,7 @@ use rusqlite::{CachedStatement, Connection, Result, Row};
 
 // MARK: Struct
 /// Represents a single row in the `chat_handle_join` table.
+#[derive(Debug)]
 pub struct ChatToHandle {
     chat_id: i32,
     handle_id: i32,

--- a/imessage-database/src/tables/messages/body.rs
+++ b/imessage-database/src/tables/messages/body.rs
@@ -39,12 +39,14 @@ const APP_CHAR: char = '\u{FFFD}';
 const REPLACEMENT_CHARS: [char; 2] = [ATTACHMENT_CHAR, APP_CHAR];
 
 /// Indicates the outcome of parsing an attributed range: either an optional text effect or a style change.
+#[derive(Debug, PartialEq)]
 pub enum RangeResult {
     Effect(Option<TextEffect>),
     Style(Style),
 }
 
 /// The result of parsing a message body, containing its components and optional plain text.
+#[derive(Debug, PartialEq)]
 pub struct ParseResult {
     pub components: Vec<BubbleComponent>,
     pub text: Option<String>,

--- a/imessage-database/src/tables/messages/models.rs
+++ b/imessage-database/src/tables/messages/models.rs
@@ -32,7 +32,7 @@ pub enum BubbleComponent {
 
 // MARK: Service
 /// Defines different types of [services](https://support.apple.com/en-us/104972) we can receive messages from.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Service<'a> {
     /// An iMessage
     #[allow(non_camel_case_types)]
@@ -178,7 +178,7 @@ impl AttachmentMeta {
 
 // MARK: GroupAction
 /// Represents different types of group message actions that can occur in a chat system
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum GroupAction<'a> {
     /// A new participant has been added to the group
     ParticipantAdded(i32),

--- a/imessage-database/src/tables/messages/query_parts.rs
+++ b/imessage-database/src/tables/messages/query_parts.rs
@@ -13,7 +13,7 @@ use crate::tables::{
 };
 
 // MARK: Queries
-/// macOS Ventura+ and i0S 16+ schema, interpolated with required columns for performance
+/// macOS Ventura+ and iOS 16+ schema, interpolated with required columns for performance
 static IOS_16_NEWER_HEAD: LazyLock<String> = LazyLock::new(|| {
     format!("
 SELECT
@@ -65,7 +65,7 @@ ORDER BY
 ";
 
 // MARK: Functions
-/// Generate a SQL Query compatible with the macOS Ventura+ and i0S 16+ schema
+/// Generate a SQL Query compatible with the macOS Ventura+ and iOS 16+ schema
 pub(crate) fn ios_16_newer_query(filters: Option<&str>) -> String {
     format!(
         "{}{}{}",


### PR DESCRIPTION
- `get_sticker_effect()` accepts `&[u8]]` instead of `Vec<u8>`
- Add missing trait derivations to many common types