### PR TITLE
Feat/cs/remove dedupelicate trait

### DIFF
--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -119,11 +119,10 @@ impl ChatToHandle {
         let all_chats = Self::cache(db)?;
 
         // Cache chatroom participants
-        let chatroom_participants = ChatToHandle::cache(db)?;
         let chat_handle_lookup = ChatToHandle::get_chat_lookup_map(db)?;
 
         // Deduplicate chatroom participants
-        let real_chatrooms = ChatToHandle::dedupe(&chatroom_participants, &chat_handle_lookup)?;
+        let real_chatrooms = ChatToHandle::dedupe(&all_chats, &chat_handle_lookup)?;
 
         // Calculate total duplicated chats
         let total_duplicated =
@@ -221,7 +220,7 @@ ORDER BY chat;
     /// use std::collections::HashMap;
     ///
     /// use imessage_database::util::dirs::default_db_path;
-    /// use imessage_database::tables::table::{Cacheable, Deduplicate, get_connection};
+    /// use imessage_database::tables::table::{Cacheable, get_connection};
     /// use imessage_database::tables::chat_handle::ChatToHandle;
     ///
     /// let db_path = default_db_path();

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -9,7 +9,7 @@ use crate::{
     error::table::TableError,
     tables::{
         diagnostic::HandleDiagnostic,
-        table::{Cacheable, Deduplicate, HANDLE, ME, Table},
+        table::{Cacheable, HANDLE, ME, Table},
     },
 };
 
@@ -89,9 +89,7 @@ impl Cacheable for Handle {
 }
 
 // MARK: Dedupe
-impl Deduplicate for Handle {
-    type T = String;
-
+impl Handle {
     /// Given the initial set of duplicated handles, deduplicate them
     ///
     /// This returns a new hashmap that maps the real handle ID to a new deduplicated unique handle ID
@@ -103,7 +101,7 @@ impl Deduplicate for Handle {
     ///
     /// ```
     /// use imessage_database::util::dirs::default_db_path;
-    /// use imessage_database::tables::table::{Cacheable, Deduplicate, get_connection};
+    /// use imessage_database::tables::table::{Cacheable, get_connection};
     /// use imessage_database::tables::handle::Handle;
     ///
     /// let db_path = default_db_path();
@@ -111,25 +109,25 @@ impl Deduplicate for Handle {
     /// let handles = Handle::cache(&conn).unwrap();
     /// let deduped_handles = Handle::dedupe(&handles);
     /// ```
-    fn dedupe(duplicated_data: &HashMap<i32, Self::T>) -> HashMap<i32, i32> {
+    pub fn dedupe(duplicated_data: &HashMap<i32, String>) -> HashMap<i32, i32> {
         let mut deduplicated_participants: HashMap<i32, i32> = HashMap::new();
-        let mut participant_to_unique_participant_id: HashMap<Self::T, i32> = HashMap::new();
+        let mut participant_to_unique_participant_id: HashMap<String, i32> = HashMap::new();
 
         // Build cache of each unique set of participants to a new identifier:
         let mut unique_participant_identifier = 0;
 
         // Iterate over the values in a deterministic order
-        let mut sorted_dupes: Vec<(&i32, &Self::T)> = duplicated_data.iter().collect();
+        let mut sorted_dupes: Vec<(&i32, &String)> = duplicated_data.iter().collect();
         sorted_dupes.sort_by(|(a, _), (b, _)| a.cmp(b));
 
         for (participant_id, participant) in sorted_dupes {
             if let Some(id) = participant_to_unique_participant_id.get(participant) {
-                deduplicated_participants.insert(participant_id.to_owned(), id.to_owned());
+                deduplicated_participants.insert(*participant_id, *id);
             } else {
                 participant_to_unique_participant_id
                     .insert(participant.to_owned(), unique_participant_identifier);
                 deduplicated_participants
-                    .insert(participant_id.to_owned(), unique_participant_identifier);
+                    .insert(*participant_id, unique_participant_identifier);
                 unique_participant_identifier += 1;
             }
         }
@@ -257,7 +255,7 @@ impl Handle {
 // MARK: Tests
 #[cfg(test)]
 mod tests {
-    use crate::tables::{handle::Handle, table::Deduplicate};
+    use crate::tables::handle::Handle;
     use std::collections::{HashMap, HashSet};
 
     #[test]

--- a/imessage-database/src/tables/messages/body.rs
+++ b/imessage-database/src/tables/messages/body.rs
@@ -180,7 +180,7 @@ pub fn parse_body_typedstream<'a>(
 /// Build a table so that `utf16_to_byte[n]` gives the byte offset
 /// that corresponds to the *n*-th UTF-16 code-unit of `s`.
 fn build_utf16_to_byte_map(s: &str) -> Vec<usize> {
-    let mut map = Vec::with_capacity(s.encode_utf16().count() + 1);
+    let mut map = Vec::with_capacity(s.len() + 1);
     let mut byte = 0;
     for ch in s.chars() {
         // how many UTF-16 units does this scalar use (1 or 2)

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -605,9 +605,7 @@ impl Message {
             }
 
             // If neither typedstream nor self.text produced text, fall back to legacy streamtyped
-            if text.is_none()
-                && let Some(body) = self.attributed_body(db)
-            {
+            if text.is_none() {
                 text = Some(streamtyped::parse(body)?);
             }
         }

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -156,14 +156,6 @@ pub trait Cacheable {
     fn cache(db: &Connection) -> Result<HashMap<Self::K, Self::V>, TableError>;
 }
 
-/// Defines behavior for deduplicating data in a table
-pub trait Deduplicate {
-    /// The type of data being deduplicated
-    type T;
-    /// Creates a mapping from duplicated IDs to canonical IDs
-    fn dedupe(duplicated_data: &HashMap<i32, Self::T>) -> HashMap<i32, i32>;
-}
-
 // MARK: Database
 /// Get a connection to the iMessage `SQLite` database
 // # Example:

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -18,7 +18,7 @@ use imessage_database::{
         chat_handle::ChatToHandle,
         handle::Handle,
         messages::Message,
-        table::{ATTACHMENTS_DIR, Cacheable, Deduplicate, ME, ORPHANED, UNKNOWN, get_db_size},
+        table::{ATTACHMENTS_DIR, Cacheable, ME, ORPHANED, UNKNOWN, get_db_size},
     },
     util::{
         dates::{format as format_date, get_local_time, get_offset, readable_diff},


### PR DESCRIPTION
- Remove `Deduplicate` trait; simply call `Table::dedupe()` for relevant tables (signatures vary)
- Stop doing some duplicate work