### PR TITLE
Feat/cs/unify errors

### DIFF
--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -163,11 +163,8 @@ impl Attachment {
                     ))
                 })?;
 
-            let iter = statement.query_map([msg.rowid], |row| Ok(Attachment::from_row(row)))?;
-
-            for attachment in iter {
-                let m = Attachment::extract(attachment)?;
-                out_l.push(m);
+            for attachment in Attachment::rows(&mut statement, [msg.rowid])? {
+                out_l.push(attachment?);
             }
         }
         Ok(out_l)

--- a/imessage-database/src/tables/chat.rs
+++ b/imessage-database/src/tables/chat.rs
@@ -108,10 +108,8 @@ impl Cacheable for Chat {
 
         let mut statement = Chat::get(db)?;
 
-        let chats = statement.query_map([], |row| Ok(Chat::from_row(row)))?;
-
-        for chat in chats {
-            let result = Chat::extract(chat)?;
+        for chat in Chat::rows(&mut statement, [])? {
+            let result = chat?;
             map.insert(result.rowid, result);
         }
         Ok(map)

--- a/imessage-database/src/tables/chat_handle.rs
+++ b/imessage-database/src/tables/chat_handle.rs
@@ -56,10 +56,8 @@ impl Cacheable for ChatToHandle {
         let mut cache: HashMap<i32, BTreeSet<i32>> = HashMap::new();
 
         let mut rows = ChatToHandle::get(db)?;
-        let mappings = rows.query_map([], |row| Ok(ChatToHandle::from_row(row)))?;
-
-        for mapping in mappings {
-            let joiner = ChatToHandle::extract(mapping)?;
+        for mapping in ChatToHandle::rows(&mut rows, [])? {
+            let joiner = mapping?;
             if let Some(handles) = cache.get_mut(&joiner.chat_id) {
                 handles.insert(joiner.handle_id);
             } else {

--- a/imessage-database/src/tables/handle.rs
+++ b/imessage-database/src/tables/handle.rs
@@ -67,12 +67,9 @@ impl Cacheable for Handle {
         // Create query
         let mut statement = Handle::get(db)?;
 
-        // Execute query to build the Handles
-        let handles = statement.query_map([], |row| Ok(Handle::from_row(row)))?;
-
         // Iterate over the handles and update the map
-        for handle in handles {
-            let contact = Handle::extract(handle)?;
+        for handle in Handle::rows(&mut statement, [])? {
+            let contact = handle?;
             map.insert(contact.rowid, contact.id);
         }
 

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -101,7 +101,7 @@
  let db_path = default_db_path();
  let db = get_connection(&db_path).unwrap();
 
- let mut statement = db.prepare("
+ let mut statement = db.prepare_cached("
  SELECT
      *,
      c.chat_id,
@@ -117,9 +117,9 @@
      m.date;
  ").unwrap();
 
- let messages = statement.query_map([], |row| Ok(Message::from_row(row))).unwrap();
-
- messages.for_each(|msg| println!("{:#?}", Message::extract(msg)));
+ for message in Message::rows(&mut statement, []).unwrap() {
+     println!("{:#?}", message);
+ }
  ```
 */
 
@@ -429,12 +429,9 @@ impl Cacheable for Message {
         )));
 
         if let Ok(mut statement) = statement {
-            // Execute query to build the message tapback map
-            let messages = statement.query_map([], |row| Ok(Message::from_row(row)))?;
-
             // Iterate over the messages and update the map
-            for message in messages {
-                let message = Self::extract(message)?;
+            for message in Self::rows(&mut statement, [])? {
+                let message = message?;
                 if message.is_tapback()
                     && let Some((idx, tapback_target_guid)) = message.clean_associated_guid()
                 {
@@ -1072,9 +1069,9 @@ impl Message {
     ///
     /// let mut statement = Message::stream_rows(&conn, &context).unwrap();
     ///
-    /// let messages = statement.query_map([], |row| Ok(Message::from_row(row))).unwrap();
-    ///
-    /// messages.for_each(|msg| println!("{:#?}", Message::extract(msg)));
+    /// for message in Message::rows(&mut statement, []).unwrap() {
+    ///     println!("{:#?}", message);
+    /// }
     /// ```
     pub fn stream_rows<'a>(
         db: &'a Connection,
@@ -1142,11 +1139,8 @@ impl Message {
                 .prepare_cached(&ios_16_newer_query(Some(filters)))
                 .or_else(|_| db.prepare_cached(&ios_14_15_query(Some(filters))))?;
 
-            let iter =
-                statement.query_map([self.guid.as_str()], |row| Ok(Message::from_row(row)))?;
-
-            for message in iter {
-                let m = Message::extract(message)?;
+            for message in Message::rows(&mut statement, [self.guid.as_str()])? {
+                let m = message?;
                 let idx = m.get_reply_index();
                 match out_h.get_mut(&idx) {
                     Some(body_part) => body_part.push(m),
@@ -1175,12 +1169,8 @@ impl Message {
                 .prepare_cached(&ios_16_newer_query(Some(filters)))
                 .or_else(|_| db.prepare_cached(&ios_14_15_query(Some(filters))))?;
 
-            let iter =
-                statement.query_map([self.guid.as_str()], |row| Ok(Message::from_row(row)))?;
-
-            for message in iter {
-                let m = Message::extract(message)?;
-                out_v.push(m);
+            for message in Message::rows(&mut statement, [self.guid.as_str()])? {
+                out_v.push(message?);
             }
         }
 
@@ -1473,7 +1463,7 @@ impl Message {
             .or_else(|_| db.prepare_cached(&ios_14_15_query(Some("WHERE m.guid = ?1"))))
             .or_else(|_| db.prepare_cached(&ios_13_older_query(Some("WHERE m.guid = ?1"))))?;
 
-        Message::extract(statement.query_row([guid], |row| Ok(Message::from_row(row))))
+        Message::row(&mut statement, [guid])
     }
 }
 

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -84,7 +84,7 @@ pub trait Table: Sized {
     ///
     /// Use this for full-table scans where the callback style fits. For
     /// custom statements (filters, joins, bound parameters), prepare the
-    /// statement yourself and iterate via [`Table::rows`] — see the
+    /// statement yourself and iterate via [`Table::rows`]. See the
     /// [`message`](crate::tables::messages::message) module docs for an
     /// example.
     ///

--- a/imessage-database/src/tables/table.rs
+++ b/imessage-database/src/tables/table.rs
@@ -32,33 +32,61 @@
 
 use std::{collections::HashMap, fs::metadata, path::Path};
 
-use rusqlite::{CachedStatement, Connection, Error, OpenFlags, Result, Row, blob::Blob};
+use rusqlite::{
+    CachedStatement, Connection, Error, OpenFlags, Params, Result, Row, Statement, blob::Blob,
+};
 
 use crate::error::table::{TableConnectError, TableError};
 
 // MARK: Traits
 /// Defines behavior for SQL Table data
 pub trait Table: Sized {
-    /// Deserialize a single row into Self, returning a [`rusqlite::Result`]
+    /// Deserialize a single row into `Self`. Returns [`rusqlite::Result`]
+    /// for direct use inside `rusqlite::query_map` / `query_row`
+    /// callbacks. For high-level iteration, prefer [`Table::rows`] or
+    /// [`Table::row`].
     fn from_row(row: &Row) -> Result<Self>;
 
     /// Prepare SELECT * statement
     fn get(db: &'_ Connection) -> Result<CachedStatement<'_>, TableError>;
 
-    /// Map a `rusqlite::Result<Self>` into our `TableError`
-    fn extract(item: Result<Result<Self, Error>, Error>) -> Result<Self, TableError> {
-        match item {
-            Ok(Ok(row)) => Ok(row),
-            Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
-        }
+    /// Iterate over rows produced by `stmt`, deserializing each via
+    /// [`from_row`](Self::from_row). Errors at row-fetch or row-deserialize
+    /// time are surfaced uniformly as [`TableError`]. Accepts both
+    /// [`rusqlite::Statement`] and [`rusqlite::CachedStatement`] (the
+    /// latter via deref coercion).
+    ///
+    /// Use this when the caller owns a custom prepared statement (with
+    /// filters, joins, or bound parameters). For a full-table scan against
+    /// the default `SELECT *` with a callback API, see [`Table::stream`].
+    fn rows<'stmt, P: Params>(
+        stmt: &'stmt mut Statement<'_>,
+        params: P,
+    ) -> Result<impl Iterator<Item = Result<Self, TableError>> + 'stmt, TableError>
+    where
+        Self: 'stmt,
+    {
+        let mapped = stmt.query_map(params, |row| Ok(Self::from_row(row)))?;
+        Ok(mapped.map(flatten_row))
     }
 
-    /// Process all rows from the table using a callback.
-    /// This is the most memory-efficient approach for large tables.
+    /// Fetch exactly one row from `stmt`. Returns
+    /// [`TableError::QueryError`] if the row is missing or fails to
+    /// deserialize. Accepts both [`rusqlite::Statement`] and
+    /// [`rusqlite::CachedStatement`] (the latter via deref coercion).
+    fn row<P: Params>(stmt: &mut Statement<'_>, params: P) -> Result<Self, TableError> {
+        flatten_row(stmt.query_row(params, |row| Ok(Self::from_row(row))))
+    }
+
+    /// Process every row from the table's default `SELECT *` query using a
+    /// callback. Builds and discards the prepared statement internally, so
+    /// the caller never sees it.
     ///
-    /// Uses the default `Table` implementation to prepare the statement and query the rows.
-    ///
-    /// To execute custom queries, see the [`message`](crate::tables::messages::message) module docs for examples.
+    /// Use this for full-table scans where the callback style fits. For
+    /// custom statements (filters, joins, bound parameters), prepare the
+    /// statement yourself and iterate via [`Table::rows`] — see the
+    /// [`message`](crate::tables::messages::message) module docs for an
+    /// example.
     ///
     /// # Example
     ///
@@ -127,6 +155,17 @@ pub trait Table: Sized {
     }
 }
 
+/// Flatten the doubly-nested result produced by `rusqlite::query_map` /
+/// `query_row` callbacks into a single [`TableError`]. The outer layer
+/// represents row-fetch failures, the inner layer represents row-deserialize
+/// failures from [`Table::from_row`].
+fn flatten_row<T>(item: Result<Result<T, Error>, Error>) -> Result<T, TableError> {
+    match item {
+        Ok(Ok(row)) => Ok(row),
+        Err(why) | Ok(Err(why)) => Err(TableError::QueryError(why)),
+    }
+}
+
 fn stream_table_callback<T, F, E>(db: &Connection, mut callback: F) -> Result<(), E>
 where
     T: Table + Sized,
@@ -134,14 +173,8 @@ where
     F: FnMut(Result<T, TableError>) -> Result<(), E>,
 {
     let mut stmt = T::get(db).map_err(E::from)?;
-    let rows = stmt
-        .query_map([], |row| Ok(T::from_row(row)))
-        .map_err(TableError::from)
-        .map_err(E::from)?;
-
-    for row_result in rows {
-        let item_result = T::extract(row_result);
-        callback(item_result)?;
+    for row_result in T::rows(&mut stmt, []).map_err(E::from)? {
+        callback(row_result)?;
     }
     Ok(())
 }

--- a/imessage-exporter/src/app/error.rs
+++ b/imessage-exporter/src/app/error.rs
@@ -1,14 +1,18 @@
 /*!
- Errors that can happen during the application's runtime.
+ Errors surfaced anywhere from CLI startup through per-message formatting.
 */
 
 use std::{
+    error::Error,
     fmt::{Display, Formatter, Result},
     io::Error as IoError,
 };
 
 use crabapple::error::BackupError;
-use imessage_database::{error::table::TableError, util::size::format_file_size};
+use imessage_database::{
+    error::{message::MessageError, table::TableError},
+    util::size::format_file_size,
+};
 
 use crate::app::options::OPTION_BYPASS_FREE_SPACE_CHECK;
 
@@ -18,6 +22,7 @@ pub enum RuntimeError {
     InvalidOptions(String),
     DiskError(IoError),
     DatabaseError(TableError),
+    MessageError(MessageError),
     BackupError(BackupError),
     NotEnoughAvailableSpace(u64, u64),
     FileNameError,
@@ -29,6 +34,7 @@ impl Display for RuntimeError {
             RuntimeError::InvalidOptions(why) => write!(fmt, "Invalid options!\n{why}"),
             RuntimeError::DiskError(why) => write!(fmt, "{why}"),
             RuntimeError::DatabaseError(why) => write!(fmt, "{why}"),
+            RuntimeError::MessageError(why) => write!(fmt, "{why}"),
             RuntimeError::NotEnoughAvailableSpace(estimated_bytes, available_bytes) => {
                 write!(
                     fmt,
@@ -43,9 +49,29 @@ impl Display for RuntimeError {
     }
 }
 
+impl Error for RuntimeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            RuntimeError::DiskError(why) => Some(why),
+            RuntimeError::DatabaseError(why) => Some(why),
+            RuntimeError::MessageError(why) => Some(why),
+            RuntimeError::BackupError(why) => Some(why),
+            RuntimeError::InvalidOptions(_)
+            | RuntimeError::NotEnoughAvailableSpace(_, _)
+            | RuntimeError::FileNameError => None,
+        }
+    }
+}
+
 impl From<TableError> for RuntimeError {
     fn from(err: TableError) -> Self {
         RuntimeError::DatabaseError(err)
+    }
+}
+
+impl From<MessageError> for RuntimeError {
+    fn from(err: MessageError) -> Self {
+        RuntimeError::MessageError(err)
     }
 }
 

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -33,7 +33,7 @@ use crate::{
         data_source::DataSource, error::RuntimeError, export_type::ExportType, options::Options,
         sanitizers::sanitize_filename,
     },
-    exporters::{formatter::ATTACHMENT_NO_FILENAME, shared::driver::run_export},
+    exporters::shared::driver::run_export,
 };
 
 // Maximum length for filenames
@@ -120,7 +120,7 @@ impl Config {
                 .unwrap_or_else(|| {
                     attachment
                         .filename()
-                        .unwrap_or(ATTACHMENT_NO_FILENAME)
+                        .unwrap_or("Attachment missing name metadata!")
                         .to_string()
                 }),
         }

--- a/imessage-exporter/src/exporters/formatter.rs
+++ b/imessage-exporter/src/exporters/formatter.rs
@@ -1,7 +1,6 @@
 use std::borrow::Cow;
 
 use imessage_database::{
-    error::{message::MessageError, table::TableError},
     message_types::{
         app::AppMessage,
         app_store::AppStoreMessage,
@@ -24,9 +23,7 @@ use imessage_database::{
     },
 };
 
-use crate::app::runtime::Config;
-
-pub(crate) const ATTACHMENT_NO_FILENAME: &str = "Attachment missing name metadata!";
+use crate::app::{error::RuntimeError, runtime::Config};
 
 /// Where a message sits in the rendered conversation hierarchy. Each exporter
 /// applies its own decoration for [`Reply`](Self::Reply) (e.g. line prefixing,
@@ -43,18 +40,31 @@ pub(crate) enum RenderContext {
     Reply,
 }
 
+/// Outcome of [`MessageFormatter::format_attachment`]; each variant routes
+/// to a different [`PartBodyBuilder`] hook.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum AttachmentRender {
+    /// Attachment was located and processed into an embed-ready string.
+    Embedded(String),
+    /// Attachment is present in the message but has no filename metadata.
+    /// Caller renders via [`PartBodyBuilder::body_attachment_missing`].
+    MissingFilename,
+    /// Attachment manager couldn't process the file, but its filename is
+    /// known. Caller renders via [`PartBodyBuilder::body_attachment_error`].
+    NamedFile(String),
+}
+
 // MARK: Message
 /// Defines behavior for formatting message instances to the desired output format
 pub(crate) trait MessageFormatter<'a> {
-    /// Format an attachment, possibly by reading the disk. On failure,
-    /// returns the attachment filename (or [`ATTACHMENT_NO_FILENAME`] when
-    /// missing) so the caller can render a missing-attachment notice.
+    /// Format an attachment, possibly by reading the disk. The returned
+    /// [`AttachmentRender`] tells the caller which body hook to invoke.
     fn format_attachment(
         &self,
         attachment: &'a mut Attachment,
         msg: &'a Message,
         metadata: &AttachmentMeta,
-    ) -> Result<String, String>;
+    ) -> AttachmentRender;
     /// Format a sticker, possibly by reading the disk
     fn format_sticker(&self, attachment: &'a mut Attachment, msg: &'a Message) -> String;
     /// Format an app message by parsing some of its fields
@@ -62,9 +72,9 @@ pub(crate) trait MessageFormatter<'a> {
         &self,
         msg: &'a Message,
         attachments: &mut Vec<Attachment>,
-    ) -> Result<String, MessageError>;
+    ) -> Result<String, RuntimeError>;
     /// Format a tapback (displayed under a message)
-    fn format_tapback(&self, msg: &Message) -> Result<String, TableError>;
+    fn format_tapback(&self, msg: &Message) -> Result<String, RuntimeError>;
     /// Render an announcement message directly into `out`. Permits reuse of
     /// the same buffer that [`format_message_into`](Self::format_message_into)
     /// uses, so the per-message hot path doesn't allocate per call.
@@ -90,7 +100,7 @@ pub(crate) trait MessageFormatter<'a> {
         message: &Message,
         context: RenderContext,
         out: &mut String,
-    ) -> Result<(), TableError>;
+    ) -> Result<(), RuntimeError>;
 }
 
 // MARK: Balloon
@@ -164,8 +174,10 @@ pub(crate) trait PartBodyBuilder {
     fn body_sticker(&self, content: String) -> Self::Body;
     /// App message content
     fn body_app(&self, content: String) -> Self::Body;
-    /// App message that failed to export due to an error
-    fn body_app_error(&self, message: &Message, why: MessageError) -> Self::Body;
+    /// App message that failed to export due to an error. `why` is the
+    /// already-rendered error message; implementations are responsible for
+    /// any format-specific escaping.
+    fn body_app_error(&self, message: &Message, why: String) -> Self::Body;
     /// Retracted message content
     fn body_retracted(&self, content: String) -> Self::Body;
     /// Escape raw user text for this format. Implementations decide what

--- a/imessage-exporter/src/exporters/html/balloons.rs
+++ b/imessage-exporter/src/exporters/html/balloons.rs
@@ -167,8 +167,9 @@ impl BalloonFormatter for HTML<'_> {
                 let rendered =
                     match self.format_attachment(attachment, msg, &AttachmentMeta::default()) {
                         AttachmentRender::Embedded(html) => html,
-                        AttachmentRender::MissingFilename => String::new(),
-                        AttachmentRender::NamedFile(name) => name,
+                        AttachmentRender::MissingFilename | AttachmentRender::NamedFile(_) => {
+                            String::new()
+                        }
                     };
                 Html::trust(rendered)
             })

--- a/imessage-exporter/src/exporters/html/balloons.rs
+++ b/imessage-exporter/src/exporters/html/balloons.rs
@@ -1,14 +1,8 @@
 use imessage_database::{
     message_types::{
-        app::AppMessage,
-        app_store::AppStoreMessage,
-        collaboration::CollaborationMessage,
-        digital_touch::DigitalTouch,
-        handwriting::HandwrittenMessage,
-        music::MusicMessage,
-        placemark::PlacemarkMessage,
-        polls::Poll,
-        url::URLMessage,
+        app::AppMessage, app_store::AppStoreMessage, collaboration::CollaborationMessage,
+        digital_touch::DigitalTouch, handwriting::HandwrittenMessage, music::MusicMessage,
+        placemark::PlacemarkMessage, polls::Poll, url::URLMessage,
     },
     tables::{
         attachment::Attachment,
@@ -17,7 +11,7 @@ use imessage_database::{
 };
 
 use crate::exporters::{
-    formatter::{BalloonFormatter, MessageFormatter},
+    formatter::{AttachmentRender, BalloonFormatter, MessageFormatter},
     html::{
         HTML,
         safe::Html,
@@ -170,10 +164,13 @@ impl BalloonFormatter for HTML<'_> {
     ) -> String {
         let attachment_html = if balloon.image.is_none() {
             attachments.get_mut(0).map(|attachment| {
-                Html::trust(
-                    self.format_attachment(attachment, msg, &AttachmentMeta::default())
-                        .unwrap_or_default(),
-                )
+                let rendered =
+                    match self.format_attachment(attachment, msg, &AttachmentMeta::default()) {
+                        AttachmentRender::Embedded(html) => html,
+                        AttachmentRender::MissingFilename => String::new(),
+                        AttachmentRender::NamedFile(name) => name,
+                    };
+                Html::trust(rendered)
             })
         } else {
             None

--- a/imessage-exporter/src/exporters/html/mod.rs
+++ b/imessage-exporter/src/exporters/html/mod.rs
@@ -12,8 +12,7 @@ use crate::{
     app::{error::RuntimeError, runtime::Config, sanitizers::sanitize_html},
     exporters::{
         formatter::{
-            ATTACHMENT_NO_FILENAME, MessageFormatter, PartBodyBuilder, RenderContext,
-            TextEffectFormatter,
+            AttachmentRender, MessageFormatter, PartBodyBuilder, RenderContext, TextEffectFormatter,
         },
         shared::{
             announcement::{AnnouncementBody, resolve_announcement},
@@ -32,7 +31,6 @@ use crate::{
 };
 
 use imessage_database::{
-    error::{message::MessageError, table::TableError},
     message_types::{edited::EditedMessage, text_effects::TextEffect, variants::Announcement},
     tables::{
         attachment::{Attachment, MediaType},
@@ -108,8 +106,8 @@ impl<'a> MessageWriter<'a> for HTML<'a> {
     }
 
     fn write_file_footer(file: &mut BufWriter<File>) -> Result<(), RuntimeError> {
-        file.write_all(FOOTER.as_bytes())
-            .map_err(RuntimeError::DiskError)
+        file.write_all(FOOTER.as_bytes())?;
+        Ok(())
     }
 
     fn footer_notice() -> Option<&'static str> {
@@ -124,8 +122,10 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
         attachment: &'a mut Attachment,
         message: &Message,
         metadata: &AttachmentMeta,
-    ) -> Result<String, String> {
-        prepare_attachment(self.config, &self.state, attachment, message)?;
+    ) -> AttachmentRender {
+        if let Err(render) = prepare_attachment(self.config, &self.state, attachment, message) {
+            return render;
+        }
 
         let embed_path = self.config.message_attachment_path(attachment);
 
@@ -141,18 +141,26 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
                 },
                 None => AttachmentVariant::Audio { media_type },
             },
-            MediaType::Text(_) | MediaType::Application(_) => AttachmentVariant::Download {
-                filename: attachment.filename().ok_or(ATTACHMENT_NO_FILENAME)?,
-                file_size: attachment.file_size(),
-            },
+            MediaType::Text(_) | MediaType::Application(_) => {
+                let Some(filename) = attachment.filename() else {
+                    return AttachmentRender::MissingFilename;
+                };
+                AttachmentVariant::Download {
+                    filename,
+                    file_size: attachment.file_size(),
+                }
+            }
             MediaType::Unknown => {
                 if attachment
                     .copied_path
                     .as_ref()
                     .is_some_and(|path| path.is_dir())
                 {
+                    let Some(filename) = attachment.filename() else {
+                        return AttachmentRender::MissingFilename;
+                    };
                     AttachmentVariant::UnknownFolder {
-                        filename: attachment.filename().ok_or(ATTACHMENT_NO_FILENAME)?,
+                        filename,
                         file_size: attachment.file_size(),
                     }
                 } else {
@@ -164,7 +172,7 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
             MediaType::Other(media_type) => AttachmentVariant::Other { media_type },
         };
 
-        Ok(render_template(&AttachmentVM {
+        AttachmentRender::Embedded(render_template(&AttachmentVM {
             lazy: !self.config.options.no_lazy,
             embed_path,
             variant,
@@ -174,8 +182,9 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
     fn format_sticker(&self, sticker: &'a mut Attachment, message: &Message) -> String {
         let mut sticker_embed =
             match self.format_attachment(sticker, message, &AttachmentMeta::default()) {
-                Ok(html) => html,
-                Err(embed) => return embed,
+                AttachmentRender::Embedded(html) => html,
+                AttachmentRender::MissingFilename => return String::new(),
+                AttachmentRender::NamedFile(name) => return name,
             };
 
         if let Some(kind) = sticker.get_sticker_decoration(
@@ -195,11 +204,16 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
         &self,
         message: &'a Message,
         attachments: &mut Vec<Attachment>,
-    ) -> Result<String, MessageError> {
-        dispatch_app_balloon(self, message, attachments, self.config)
+    ) -> Result<String, RuntimeError> {
+        Ok(dispatch_app_balloon(
+            self,
+            message,
+            attachments,
+            self.config,
+        )?)
     }
 
-    fn format_tapback(&self, msg: &Message) -> Result<String, TableError> {
+    fn format_tapback(&self, msg: &Message) -> Result<String, RuntimeError> {
         let Some(kind) = resolve_tapback(msg, self.config, |sticker| {
             Html::trust(self.format_sticker(sticker, msg))
         })?
@@ -328,7 +342,7 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
         message: &Message,
         context: RenderContext,
         out: &mut String,
-    ) -> Result<(), TableError> {
+    ) -> Result<(), RuntimeError> {
         let is_reply = matches!(context, RenderContext::Reply);
         let mut ctx = MessageContext::resolve(message, self.config.data_source.db())?;
         let mut attachment_index: usize = 0;
@@ -454,7 +468,7 @@ impl PartBodyBuilder for HTML<'_> {
         }
     }
 
-    fn body_app_error(&self, message: &Message, why: MessageError) -> Self::Body {
+    fn body_app_error(&self, message: &Message, why: String) -> Self::Body {
         PartBody::AppError {
             html: Html::trust(
                 sanitize_html(&format!(
@@ -488,13 +502,13 @@ impl HTML<'_> {
     }
 
     fn write_headers(file: &mut BufWriter<File>) -> Result<(), RuntimeError> {
-        file.write_all(HEADER.as_bytes())
-            .and_then(|()| file.write_all(b"<style>\n"))
-            .and_then(|()| file.write_all(STYLE.as_bytes()))
-            .and_then(|()| file.write_all(b"\n</style>"))
-            .and_then(|()| file.write_all(b"<link rel=\"stylesheet\" href=\"style.css\">"))
-            .and_then(|()| file.write_all(b"\n</head>\n<body>\n"))
-            .map_err(RuntimeError::DiskError)
+        file.write_all(HEADER.as_bytes())?;
+        file.write_all(b"<style>\n")?;
+        file.write_all(STYLE.as_bytes())?;
+        file.write_all(b"\n</style>")?;
+        file.write_all(b"<link rel=\"stylesheet\" href=\"style.css\">")?;
+        file.write_all(b"\n</head>\n<body>\n")?;
+        Ok(())
     }
 
     fn apply_active_attributes<'a>(
@@ -535,7 +549,7 @@ mod tests {
             compatibility::attachment_manager::AttachmentManagerMode, contacts::Name,
             export_type::ExportType,
         },
-        exporters::formatter::{MessageFormatter, RenderContext},
+        exporters::formatter::{AttachmentRender, MessageFormatter, RenderContext},
     };
 
     use imessage_database::{
@@ -1725,11 +1739,13 @@ mod tests {
 
         let mut attachment = Config::fake_attachment();
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let actual =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, "<img src=\"a/b/c/d.jpg\" loading=\"lazy\">");
+        assert_eq!(
+            actual,
+            AttachmentRender::Embedded("<img src=\"a/b/c/d.jpg\" loading=\"lazy\">".to_string())
+        );
     }
 
     #[test]
@@ -1748,7 +1764,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1769,7 +1785,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1784,9 +1800,11 @@ mod tests {
 
         let mut attachment = Config::fake_attachment();
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let AttachmentRender::Embedded(actual) =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default())
+        else {
+            panic!("expected AttachmentRender::Embedded");
+        };
 
         assert!(actual.ends_with("33/33c81da8ae3194fc5a0ea993ef6ffe0b048baedb\">"));
     }
@@ -1807,7 +1825,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1828,7 +1846,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1850,9 +1868,8 @@ mod tests {
         attachment.transfer_name = Some("test_data".to_string());
         attachment.copied_path = Some(folder_path);
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let actual =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
         let abs_path = current_dir()
             .unwrap()
@@ -1864,7 +1881,7 @@ mod tests {
             abs_path.display()
         );
 
-        assert_eq!(actual, expected);
+        assert_eq!(actual, AttachmentRender::Embedded(expected));
     }
 
     #[test]
@@ -1882,13 +1899,14 @@ mod tests {
         attachment.filename = Some("notes.txt".to_string());
         attachment.transfer_name = Some("notes.txt".to_string());
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let actual =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
         assert_eq!(
             actual,
-            "<a href=\"notes.txt\">Click to download notes.txt (100.00 B)</a>"
+            AttachmentRender::Embedded(
+                "<a href=\"notes.txt\">Click to download notes.txt (100.00 B)</a>".to_string()
+            )
         );
     }
 
@@ -1907,13 +1925,14 @@ mod tests {
         attachment.filename = Some("doc.pdf".to_string());
         attachment.transfer_name = Some("doc.pdf".to_string());
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let actual =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
         assert_eq!(
             actual,
-            "<a href=\"doc.pdf\">Click to download doc.pdf (100.00 B)</a>"
+            AttachmentRender::Embedded(
+                "<a href=\"doc.pdf\">Click to download doc.pdf (100.00 B)</a>".to_string()
+            )
         );
     }
 
@@ -1931,13 +1950,14 @@ mod tests {
         attachment.mime_type = Some("model/gltf-binary".to_string());
         attachment.filename = Some("scene.glb".to_string());
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let actual =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
         assert_eq!(
             actual,
-            "<p>Unable to embed model/gltf-binary attachments: scene.glb</p>"
+            AttachmentRender::Embedded(
+                "<p>Unable to embed model/gltf-binary attachments: scene.glb</p>".to_string()
+            )
         );
     }
 
@@ -1956,13 +1976,15 @@ mod tests {
         attachment.transfer_name = Some("test_data".to_string());
         attachment.copied_path = Some(PathBuf::from(folder_path));
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let actual =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
         assert_eq!(
             actual,
-            "<p>Unknown attachment type: Fake</p>\n<a href=\"Fake\">Download (100.00 B)</a>"
+            AttachmentRender::Embedded(
+                "<p>Unknown attachment type: Fake</p>\n<a href=\"Fake\">Download (100.00 B)</a>"
+                    .to_string()
+            )
         );
     }
 
@@ -2101,13 +2123,13 @@ mod tests {
             ..Default::default()
         };
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &meta)
-            .unwrap();
+        let actual = exporter.format_attachment(&mut attachment, &message, &meta);
 
         assert_eq!(
             actual,
-            "<div>\n    <audio controls src=\"Audio Message.caf\" type=\"x-caf; codecs=opus\"> </audio>\n</div>\n<hr>\n<span class=\"transcription\">Transcription: Test</span>"
+            AttachmentRender::Embedded(
+                "<div>\n    <audio controls src=\"Audio Message.caf\" type=\"x-caf; codecs=opus\"> </audio>\n</div>\n<hr>\n<span class=\"transcription\">Transcription: Test</span>".to_string()
+            )
         );
     }
 

--- a/imessage-exporter/src/exporters/html/mod.rs
+++ b/imessage-exporter/src/exporters/html/mod.rs
@@ -184,7 +184,7 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
             match self.format_attachment(sticker, message, &AttachmentMeta::default()) {
                 AttachmentRender::Embedded(html) => html,
                 AttachmentRender::MissingFilename => return String::new(),
-                AttachmentRender::NamedFile(name) => return name,
+                AttachmentRender::NamedFile(name) => return sanitize_html(&name).into_owned(),
             };
 
         if let Some(kind) = sticker.get_sticker_decoration(

--- a/imessage-exporter/src/exporters/html/view_model.rs
+++ b/imessage-exporter/src/exporters/html/view_model.rs
@@ -188,7 +188,7 @@ pub(super) struct PollOptionVM<'a> {
 pub(super) struct AttachmentVM<'a> {
     pub lazy: bool,
     /// Path the template emits in `src=` / `href=` attributes. Shared by every
-    /// variant — the only piece each variant needs in addition is the bits
+    /// variant: the only piece each variant needs in addition is the bits
     /// specific to its presentation (media type, filename, etc.).
     pub embed_path: String,
     pub variant: AttachmentVariant<'a>,

--- a/imessage-exporter/src/exporters/shared/attachment.rs
+++ b/imessage-exporter/src/exporters/shared/attachment.rs
@@ -5,19 +5,20 @@ use imessage_database::tables::{
 
 use crate::{
     app::{compatibility::attachment_manager::AttachmentManagerMode, runtime::Config},
-    exporters::{formatter::ATTACHMENT_NO_FILENAME, shared::driver::ExportState},
+    exporters::{formatter::AttachmentRender, shared::driver::ExportState},
 };
 
 /// Run the per-attachment side effects every exporter needs before it can
 /// emit a reference to a file on disk: toggle the progress bar's "encoding
 /// video" indicator if the attachment will be transcoded, then ask the
 /// [`AttachmentManager`](crate::app::compatibility::attachment_manager::AttachmentManager)
-/// to copy or convert the file. Returns the filename (or
-/// [`ATTACHMENT_NO_FILENAME`] when missing) on failure so the caller can
-/// render a missing-attachment notice without re-deriving the source.
+/// to copy or convert the file.
 ///
-/// The filename check fires regardless of `handle_attachment`'s result:
-/// when `AttachmentManagerMode::Disabled` is in effect, `handle_attachment`
+/// Returns `Ok(())` when the attachment has a filename and
+/// `handle_attachment` succeeded; otherwise returns the
+/// [`AttachmentRender`] fallback the caller should propagate. The filename
+/// check fires regardless of `handle_attachment`'s result: when
+/// `AttachmentManagerMode::Disabled` is in effect, `handle_attachment`
 /// returns `Some(())` without touching `filename`, but the caller still
 /// can't render anything useful downstream without one.
 pub(crate) fn prepare_attachment(
@@ -25,7 +26,7 @@ pub(crate) fn prepare_attachment(
     state: &ExportState,
     attachment: &mut Attachment,
     message: &Message,
-) -> Result<(), String> {
+) -> Result<(), AttachmentRender> {
     let will_encode = matches!(attachment.mime_type(), MediaType::Video(_))
         && matches!(
             config.options.attachment_manager.mode,
@@ -48,8 +49,10 @@ pub(crate) fn prepare_attachment(
     }
 
     let Some(filename) = attachment.filename() else {
-        return Err(ATTACHMENT_NO_FILENAME.to_string());
+        return Err(AttachmentRender::MissingFilename);
     };
-    handle_result.ok_or_else(|| filename.to_string())?;
+    if handle_result.is_none() {
+        return Err(AttachmentRender::NamedFile(filename.to_string()));
+    }
     Ok(())
 }

--- a/imessage-exporter/src/exporters/shared/balloon.rs
+++ b/imessage-exporter/src/exporters/shared/balloon.rs
@@ -114,8 +114,9 @@ pub fn dispatch_app_balloon<F: BalloonFormatter>(
 
 // MARK: Check In
 
-/// Build the footer line that accompanies a Check In balloon — the
-/// `"<verb> at <local time>"` phrase derived from the balloon's first
+/// Build the footer line that accompanies a Check In balloon.
+///
+/// The `"<verb> at <local time>"` phrase derived from the balloon's first
 /// [`CheckInKind`] entry. Returns `None` when the balloon has no decodable
 /// check-in metadata, so callers can omit the footer entirely.
 pub fn resolve_check_in_footer(balloon: &AppMessage) -> Option<String> {

--- a/imessage-exporter/src/exporters/shared/driver.rs
+++ b/imessage-exporter/src/exporters/shared/driver.rs
@@ -7,12 +7,9 @@ use std::{
     io::{BufWriter, Write},
 };
 
-use imessage_database::{
-    error::table::TableError,
-    tables::{
-        messages::Message,
-        table::{ORPHANED, Table},
-    },
+use imessage_database::tables::{
+    messages::Message,
+    table::{ORPHANED, Table},
 };
 use rusqlite::Connection;
 
@@ -164,9 +161,7 @@ where
         writer.config().data_source.db(),
         &writer.config().options.query_context,
     )?;
-    let messages = statement
-        .query_map([], |row| Ok(Message::from_row(row)))
-        .map_err(|err| RuntimeError::DatabaseError(TableError::QueryError(err)))?;
+    let messages = statement.query_map([], |row| Ok(Message::from_row(row)))?;
 
     // Reused across iterations so each message doesn't allocate a fresh
     // output buffer. Capacity grows naturally to fit the largest message
@@ -189,16 +184,14 @@ where
             msg_buf.clear();
             writer.format_announcement(&msg, &mut msg_buf);
             let file = get_or_create_file_for(writer, &msg)?;
-            file.write_all(msg_buf.as_bytes())
-                .map_err(RuntimeError::DiskError)?;
+            file.write_all(msg_buf.as_bytes())?;
         }
         // Message tapbacks and poll votes are rendered in context, so no need to render them separately
         else if !msg.is_tapback() && !msg.is_poll_vote() && !msg.is_poll_update() {
             msg_buf.clear();
             writer.format_message_into(&msg, RenderContext::TopLevel, &mut msg_buf)?;
             let file = get_or_create_file_for(writer, &msg)?;
-            file.write_all(msg_buf.as_bytes())
-                .map_err(RuntimeError::DiskError)?;
+            file.write_all(msg_buf.as_bytes())?;
         }
         current_message += 1;
         if current_message % 99 == 0 {

--- a/imessage-exporter/src/exporters/shared/driver.rs
+++ b/imessage-exporter/src/exporters/shared/driver.rs
@@ -161,14 +161,13 @@ where
         writer.config().data_source.db(),
         &writer.config().options.query_context,
     )?;
-    let messages = statement.query_map([], |row| Ok(Message::from_row(row)))?;
 
     // Reused across iterations so each message doesn't allocate a fresh
     // output buffer. Capacity grows naturally to fit the largest message
     // and `clear()` retains it.
     let mut msg_buf = String::with_capacity(W::BUFFER_CAPACITY);
-    for message in messages {
-        let mut msg = Message::extract(message)?;
+    for message in Message::rows(&mut statement, [])? {
+        let mut msg = message?;
 
         // Early escape if we try and render the same message GUID twice
         // See https://github.com/ReagentX/imessage-exporter/issues/135

--- a/imessage-exporter/src/exporters/shared/part.rs
+++ b/imessage-exporter/src/exporters/shared/part.rs
@@ -4,7 +4,7 @@ use imessage_database::tables::{
 };
 
 use crate::exporters::{
-    formatter::{MessageFormatter, PartBodyBuilder},
+    formatter::{AttachmentRender, MessageFormatter, PartBodyBuilder},
     shared::balloon::rewrite_fitness_receiver,
 };
 
@@ -71,15 +71,16 @@ where
                 return formatter.body_sticker(content);
             }
             let body = match formatter.format_attachment(attachment, message, metadata) {
-                Ok(content) => formatter.body_attachment(content),
-                Err(error) => formatter.body_attachment_error(&error),
+                AttachmentRender::Embedded(content) => formatter.body_attachment(content),
+                AttachmentRender::MissingFilename => formatter.body_attachment_missing(),
+                AttachmentRender::NamedFile(name) => formatter.body_attachment_error(&name),
             };
             *attachment_index += 1;
             body
         }
         BubbleComponent::App => match formatter.format_app(message, attachments) {
             Ok(content) => formatter.body_app(content),
-            Err(why) => formatter.body_app_error(message, why),
+            Err(why) => formatter.body_app_error(message, why.to_string()),
         },
         BubbleComponent::Retracted => match &message.edited_parts {
             Some(edited_parts) => match formatter.format_edited(message, edited_parts, idx) {

--- a/imessage-exporter/src/exporters/shared/reply.rs
+++ b/imessage-exporter/src/exporters/shared/reply.rs
@@ -1,8 +1,11 @@
-use imessage_database::{error::table::TableError, tables::messages::Message};
+use imessage_database::tables::messages::Message;
 
-use crate::exporters::{
-    formatter::{MessageFormatter, PartBodyBuilder, RenderContext},
-    shared::driver::apply_body,
+use crate::{
+    app::error::RuntimeError,
+    exporters::{
+        formatter::{MessageFormatter, PartBodyBuilder, RenderContext},
+        shared::driver::apply_body,
+    },
 };
 
 /// One reply, as fed to the format's `replies` template. `body` is already a
@@ -25,7 +28,7 @@ pub(crate) fn build_tapbacks<'a, F, T>(
     message: &'a Message,
     idx: usize,
     wrap: impl Fn(String) -> T,
-) -> Result<Option<Vec<T>>, TableError>
+) -> Result<Option<Vec<T>>, RuntimeError>
 where
     F: MessageFormatter<'a> + PartBodyBuilder,
 {
@@ -62,7 +65,7 @@ pub(crate) fn build_replies<'a, F, S>(
     replies: Option<&'a mut Vec<Message>>,
     buffer_capacity: usize,
     wrap_body: impl Fn(String) -> S,
-) -> Result<Option<Vec<ReplyEntry<S>>>, TableError>
+) -> Result<Option<Vec<ReplyEntry<S>>>, RuntimeError>
 where
     F: MessageFormatter<'a> + PartBodyBuilder,
 {

--- a/imessage-exporter/src/exporters/txt/mod.rs
+++ b/imessage-exporter/src/exporters/txt/mod.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io::BufWriter};
 use crate::{
     app::{error::RuntimeError, runtime::Config},
     exporters::{
-        formatter::{MessageFormatter, PartBodyBuilder, RenderContext},
+        formatter::{AttachmentRender, MessageFormatter, PartBodyBuilder, RenderContext},
         shared::{
             announcement::{AnnouncementBody, resolve_announcement},
             attachment::prepare_attachment,
@@ -21,7 +21,6 @@ use crate::{
 };
 
 use imessage_database::{
-    error::{message::MessageError, table::TableError},
     message_types::{edited::EditedMessage, sticker::StickerDecoration},
     tables::{
         attachment::Attachment,
@@ -98,10 +97,12 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
         attachment: &'a mut Attachment,
         message: &Message,
         metadata: &AttachmentMeta,
-    ) -> Result<String, String> {
-        prepare_attachment(self.config, &self.state, attachment, message)?;
+    ) -> AttachmentRender {
+        if let Err(render) = prepare_attachment(self.config, &self.state, attachment, message) {
+            return render;
+        }
 
-        Ok(render_template(&AttachmentVM {
+        AttachmentRender::Embedded(render_template(&AttachmentVM {
             embed_path: self.config.message_attachment_path(attachment),
             transcription: metadata.transcription.as_deref(),
         }))
@@ -115,8 +116,9 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
         );
         let (path, has_source) =
             match self.format_attachment(sticker, message, &AttachmentMeta::default()) {
-                Ok(p) => (p, true),
-                Err(e) => (e, false),
+                AttachmentRender::Embedded(p) => (p, true),
+                AttachmentRender::MissingFilename => (String::new(), false),
+                AttachmentRender::NamedFile(name) => (name, false),
             };
 
         let decoration = if has_source {
@@ -152,11 +154,16 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
         &self,
         message: &'a Message,
         attachments: &mut Vec<Attachment>,
-    ) -> Result<String, MessageError> {
-        dispatch_app_balloon(self, message, attachments, self.config)
+    ) -> Result<String, RuntimeError> {
+        Ok(dispatch_app_balloon(
+            self,
+            message,
+            attachments,
+            self.config,
+        )?)
     }
 
-    fn format_tapback(&self, msg: &Message) -> Result<String, TableError> {
+    fn format_tapback(&self, msg: &Message) -> Result<String, RuntimeError> {
         let Some(kind) = resolve_tapback(msg, self.config, |sticker| {
             self.format_sticker(sticker, msg)
         })?
@@ -234,7 +241,7 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
         message: &Message,
         context: RenderContext,
         out: &mut String,
-    ) -> Result<(), TableError> {
+    ) -> Result<(), RuntimeError> {
         let mut ctx = MessageContext::resolve(message, self.config.data_source.db())?;
         let mut attachment_index: usize = 0;
 
@@ -344,7 +351,7 @@ impl PartBodyBuilder for TXT<'_> {
         PartBody::Line { text: content }
     }
 
-    fn body_app_error(&self, _message: &Message, why: MessageError) -> Self::Body {
+    fn body_app_error(&self, _message: &Message, why: String) -> Self::Body {
         PartBody::Line {
             text: format!("Unable to format app message: {why}"),
         }
@@ -402,7 +409,7 @@ mod tests {
             compatibility::attachment_manager::AttachmentManagerMode, contacts::Name,
             export_type::ExportType,
         },
-        exporters::formatter::{MessageFormatter, RenderContext},
+        exporters::formatter::{AttachmentRender, MessageFormatter, RenderContext},
     };
     use imessage_database::{
         message_types::text_effects::TextEffect,
@@ -1344,11 +1351,13 @@ mod tests {
 
         let mut attachment = Config::fake_attachment();
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let actual =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, "a/b/c/d.jpg");
+        assert_eq!(
+            actual,
+            AttachmentRender::Embedded("a/b/c/d.jpg".to_string())
+        );
     }
 
     #[test]
@@ -1367,7 +1376,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1388,7 +1397,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1403,9 +1412,11 @@ mod tests {
 
         let mut attachment = Config::fake_attachment();
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &AttachmentMeta::default())
-            .unwrap();
+        let AttachmentRender::Embedded(actual) =
+            exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default())
+        else {
+            panic!("expected AttachmentRender::Embedded");
+        };
 
         assert!(actual.ends_with("33/33c81da8ae3194fc5a0ea993ef6ffe0b048baedb"));
     }
@@ -1428,7 +1439,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1451,7 +1462,7 @@ mod tests {
         let actual =
             exporter.format_attachment(&mut attachment, &message, &AttachmentMeta::default());
 
-        assert_eq!(actual, Err("Attachment missing name metadata!".to_string()));
+        assert_eq!(actual, AttachmentRender::MissingFilename);
     }
 
     #[test]
@@ -1598,11 +1609,12 @@ mod tests {
             ..Default::default()
         };
 
-        let actual = exporter
-            .format_attachment(&mut attachment, &message, &meta)
-            .unwrap();
+        let actual = exporter.format_attachment(&mut attachment, &message, &meta);
 
-        assert_eq!(actual, "Audio Message.caf\nTranscription: Test");
+        assert_eq!(
+            actual,
+            AttachmentRender::Embedded("Audio Message.caf\nTranscription: Test".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
- API Changes
  - Breaking
    - Remove `Table::extract`. Use `Table::rows` or `Table::row` instead.
    <p><details><summary>Migration details (click to expand)</summary></p>
    <ul>
    <li>Multi-row iteration:</li>
    </ul>
    <pre><code class="rust">  // Before
      let rows = stmt.query_map(params, |row| Ok(Message::from_row(row)))?;
      for row in rows {
          let msg = Message::extract(row)?;
          // ...
      }

      // After
      for msg in Message::rows(&amp;mut stmt, params)? {
          let msg = msg?;
          // ...
      }
    </code></pre>
    <ul>
    <li>Single-row fetch:</li>
    </ul>
    <pre><code class="rust">  // Before
      let msg = Message::extract(stmt.query_row(params, |row| Ok(Message::from_row(row))))?;

      // After
      let msg = Message::row(&amp;mut stmt, params)?;
    </code></pre>

    <p></details></p>
- Ergonomic
  - Unify the exporter's `MessageFormatter` trait under a single `RuntimeError` return type
    - `format_app`, `format_tapback`, and `format_message_into` all return `Result<_, RuntimeError>`
    - `RuntimeError` gains a `MessageError` variant + `From<MessageError>` impl so `?` composes end-to-end
    - `RuntimeError` now implements `std::error::Error` with `source()`
    - Every `.map_err(...)` wrapper site in the exporter crate eliminated