### PR TITLE
Feat/cs/fix ffmpeg invocations

### DIFF
--- a/imessage-database/src/tables/messages/body.rs
+++ b/imessage-database/src/tables/messages/body.rs
@@ -170,8 +170,9 @@ pub fn parse_body_typedstream<'a>(
             }
         }
     }
-    // If we have no components, return None
-    (!out_v.is_empty()).then_some(ParseResult {
+    // Return None only when nothing useful was extracted. `Some("")` is a
+    // valid result.
+    (!out_v.is_empty() || message_text.is_some()).then_some(ParseResult {
         components: out_v,
         text: message_text,
     })

--- a/imessage-exporter/src/app/compatibility/converters/sticker.rs
+++ b/imessage-exporter/src/app/compatibility/converters/sticker.rs
@@ -184,15 +184,18 @@ fn convert_heics_with_tmp(
                 .collect();
             frames.sort();
 
-            let mut first_merged: Option<PathBuf> = None;
-            for frame in &frames {
-                let stem = frame.file_stem()?.to_str()?;
-                let index = stem.strip_prefix("frame_")?;
-                let alpha = tmp_path.join(format!("alpha_{index}.png"));
-                if !alpha.exists() {
-                    continue;
-                }
-                let merged = tmp_path.join(format!("merged_{index}.png"));
+            // Pair frames with their alpha masks and assign dense merged
+            // destinations starting at 0000. ffmpeg's `image2` demuxer treats
+            // any gap as end-of-sequence, so renumbering densely is what
+            // prevents silent truncation when an alpha mask is missing.
+            // Starting at 0000 also matches the demuxer's default
+            // `start_number=0`, so the final encode reads the sequence
+            // reliably across ffmpeg builds.
+            let (merge_ops, skipped) = plan_merge_ops(&frames, tmp_path);
+            for frame in &skipped {
+                eprintln!("Skipping {}: no matching alpha mask", frame.display());
+            }
+            for (frame, alpha, merged) in &merge_ops {
                 run_command(
                     video_converter.name(),
                     vec![
@@ -205,11 +208,8 @@ fn convert_heics_with_tmp(
                         merged.to_str()?,
                     ],
                 )?;
-                if first_merged.is_none() {
-                    first_merged = Some(merged);
-                }
             }
-            let first_merged = first_merged?;
+            let first_merged = merge_ops.first()?.2.clone();
 
             // Once we have the transparent frames,
             // we use the first frame to generate a transparency palette
@@ -245,6 +245,39 @@ fn convert_heics_with_tmp(
     }
 }
 
+/// Pair each frame file with its matching alpha mask and assign dense
+/// `merged_NNNN.png` destinations starting at index 0. Frames whose alpha
+/// is missing are returned in `skipped` so the caller can warn about them.
+///
+/// Dense numbering is load-bearing: ffmpeg's `image2` demuxer stops at the
+/// first gap in the input pattern, silently truncating the output. Starting
+/// at 0000 also matches the demuxer's default `start_number=0`.
+fn plan_merge_ops(
+    frames: &[PathBuf],
+    tmp_path: &Path,
+) -> (Vec<(PathBuf, PathBuf, PathBuf)>, Vec<PathBuf>) {
+    let mut ops: Vec<(PathBuf, PathBuf, PathBuf)> = Vec::with_capacity(frames.len());
+    let mut skipped: Vec<PathBuf> = Vec::new();
+    for frame in frames {
+        let index = frame
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .and_then(|s| s.strip_prefix("frame_"));
+        let Some(index) = index else {
+            skipped.push(frame.clone());
+            continue;
+        };
+        let alpha = tmp_path.join(format!("alpha_{index}.png"));
+        if !alpha.exists() {
+            skipped.push(frame.clone());
+            continue;
+        }
+        let merged = tmp_path.join(format!("merged_{:04}.png", ops.len()));
+        ops.push((frame.clone(), alpha, merged));
+    }
+    (ops, skipped)
+}
+
 /// Create a unique scratch directory under the platform temp dir.
 ///
 /// Names include the process ID and a nanosecond timestamp so that
@@ -264,4 +297,128 @@ fn unique_tmp_dir() -> Option<PathBuf> {
         return None;
     }
     Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{File, remove_dir_all},
+        path::{Path, PathBuf},
+    };
+
+    use crate::app::compatibility::converters::sticker::{plan_merge_ops, unique_tmp_dir};
+
+    fn touch(path: &Path) {
+        File::create(path).unwrap();
+    }
+
+    #[test]
+    fn plan_merge_ops_pairs_all_frames_when_alphas_present() {
+        let tmp = unique_tmp_dir().unwrap();
+        let frames = vec![
+            tmp.join("frame_0001.png"),
+            tmp.join("frame_0002.png"),
+            tmp.join("frame_0003.png"),
+        ];
+        for index in ["0001", "0002", "0003"] {
+            touch(&tmp.join(format!("alpha_{index}.png")));
+        }
+
+        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
+        let expected_ops = vec![
+            (
+                frames[0].clone(),
+                tmp.join("alpha_0001.png"),
+                tmp.join("merged_0000.png"),
+            ),
+            (
+                frames[1].clone(),
+                tmp.join("alpha_0002.png"),
+                tmp.join("merged_0001.png"),
+            ),
+            (
+                frames[2].clone(),
+                tmp.join("alpha_0003.png"),
+                tmp.join("merged_0002.png"),
+            ),
+        ];
+        let expected_skipped: Vec<PathBuf> = vec![];
+        assert_eq!(actual_ops, expected_ops);
+        assert_eq!(actual_skipped, expected_skipped);
+
+        let _ = remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn plan_merge_ops_renumbers_densely_around_missing_alpha() {
+        let tmp = unique_tmp_dir().unwrap();
+        let frames = vec![
+            tmp.join("frame_0001.png"),
+            tmp.join("frame_0002.png"),
+            tmp.join("frame_0003.png"),
+        ];
+        // alpha_0002.png deliberately absent
+        touch(&tmp.join("alpha_0001.png"));
+        touch(&tmp.join("alpha_0003.png"));
+
+        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
+        let expected_ops = vec![
+            (
+                frames[0].clone(),
+                tmp.join("alpha_0001.png"),
+                tmp.join("merged_0000.png"),
+            ),
+            (
+                frames[2].clone(),
+                tmp.join("alpha_0003.png"),
+                tmp.join("merged_0001.png"),
+            ),
+        ];
+        let expected_skipped = vec![frames[1].clone()];
+        assert_eq!(actual_ops, expected_ops);
+        assert_eq!(actual_skipped, expected_skipped);
+
+        let _ = remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn plan_merge_ops_handles_zero_indexed_frames() {
+        let tmp = unique_tmp_dir().unwrap();
+        let frames = vec![tmp.join("frame_0000.png"), tmp.join("frame_0001.png")];
+        touch(&tmp.join("alpha_0000.png"));
+        touch(&tmp.join("alpha_0001.png"));
+
+        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
+        let expected_ops = vec![
+            (
+                frames[0].clone(),
+                tmp.join("alpha_0000.png"),
+                tmp.join("merged_0000.png"),
+            ),
+            (
+                frames[1].clone(),
+                tmp.join("alpha_0001.png"),
+                tmp.join("merged_0001.png"),
+            ),
+        ];
+        let expected_skipped: Vec<PathBuf> = vec![];
+        assert_eq!(actual_ops, expected_ops);
+        assert_eq!(actual_skipped, expected_skipped);
+
+        let _ = remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn plan_merge_ops_skips_every_frame_when_no_alphas_exist() {
+        let tmp = unique_tmp_dir().unwrap();
+        let frames = vec![tmp.join("frame_0001.png"), tmp.join("frame_0002.png")];
+
+        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
+        let expected_ops: Vec<(PathBuf, PathBuf, PathBuf)> = vec![];
+        let expected_skipped = frames.clone();
+        assert_eq!(actual_ops, expected_ops);
+        assert_eq!(actual_skipped, expected_skipped);
+
+        let _ = remove_dir_all(&tmp);
+    }
 }

--- a/imessage-exporter/src/app/compatibility/converters/sticker.rs
+++ b/imessage-exporter/src/app/compatibility/converters/sticker.rs
@@ -4,7 +4,7 @@
 
 use std::{
     env::temp_dir,
-    fs::{create_dir_all, read_dir, remove_dir_all},
+    fs::{create_dir_all, remove_dir_all},
     path::{Path, PathBuf},
     process,
     time::{SystemTime, UNIX_EPOCH},
@@ -168,48 +168,31 @@ fn convert_heics_with_tmp(
                 ],
             )?;
 
-            // This step applies the transparency mask to the images.
-            // Discover the actual frame files emitted by ffmpeg rather than
-            // counting-and-indexing, so the loop matches whatever start
-            // number ffmpeg used.
-            let mut frames: Vec<PathBuf> = read_dir(tmp_path)
-                .ok()?
-                .flatten()
-                .map(|entry| entry.path())
-                .filter(|path| {
-                    path.file_name()
-                        .and_then(|name| name.to_str())
-                        .is_some_and(|name| name.starts_with("frame_") && name.ends_with(".png"))
-                })
-                .collect();
-            frames.sort();
+            // Apply the transparency mask to every frame in a single ffmpeg
+            // invocation. The image2 demuxer reads both sequences in lockstep
+            // and `alphamerge` pairs frame N with alpha N, so we avoid the
+            // per-frame process-spawn cost that previously made animated
+            // stickers take several seconds. `-start_number 0` on the output
+            // matches the demuxer's default in the final encode below, so the
+            // sequence reads reliably across ffmpeg builds without needing a
+            // `-start_number` flag on the gif assembly.
+            run_command(
+                video_converter.name(),
+                vec![
+                    "-i",
+                    &format!("{tmp}/frame_%04d.png"),
+                    "-i",
+                    &format!("{tmp}/alpha_%04d.png"),
+                    "-filter_complex",
+                    "[1:v]format=gray,geq=lum='p(X,Y)':a='p(X,Y)'[mask];[0:v][mask]alphamerge",
+                    "-start_number",
+                    "0",
+                    "-y",
+                    &format!("{tmp}/merged_%04d.png"),
+                ],
+            )?;
 
-            // Pair frames with their alpha masks and assign dense merged
-            // destinations starting at 0000. ffmpeg's `image2` demuxer treats
-            // any gap as end-of-sequence, so renumbering densely is what
-            // prevents silent truncation when an alpha mask is missing.
-            // Starting at 0000 also matches the demuxer's default
-            // `start_number=0`, so the final encode reads the sequence
-            // reliably across ffmpeg builds.
-            let (merge_ops, skipped) = plan_merge_ops(&frames, tmp_path);
-            for frame in &skipped {
-                eprintln!("Skipping {}: no matching alpha mask", frame.display());
-            }
-            for (frame, alpha, merged) in &merge_ops {
-                run_command(
-                    video_converter.name(),
-                    vec![
-                        "-i",
-                        frame.to_str()?,
-                        "-i",
-                        alpha.to_str()?,
-                        "-filter_complex",
-                        "[1:v]format=gray,geq=lum='p(X,Y)':a='p(X,Y)'[mask];[0:v][mask]alphamerge",
-                        merged.to_str()?,
-                    ],
-                )?;
-            }
-            let first_merged = merge_ops.first()?.2.clone();
+            let first_merged = tmp_path.join("merged_0000.png");
 
             // Once we have the transparent frames,
             // we use the first frame to generate a transparency palette
@@ -245,39 +228,6 @@ fn convert_heics_with_tmp(
     }
 }
 
-/// Pair each frame file with its matching alpha mask and assign dense
-/// `merged_NNNN.png` destinations starting at index 0. Frames whose alpha
-/// is missing are returned in `skipped` so the caller can warn about them.
-///
-/// Dense numbering is load-bearing: ffmpeg's `image2` demuxer stops at the
-/// first gap in the input pattern, silently truncating the output. Starting
-/// at 0000 also matches the demuxer's default `start_number=0`.
-fn plan_merge_ops(
-    frames: &[PathBuf],
-    tmp_path: &Path,
-) -> (Vec<(PathBuf, PathBuf, PathBuf)>, Vec<PathBuf>) {
-    let mut ops: Vec<(PathBuf, PathBuf, PathBuf)> = Vec::with_capacity(frames.len());
-    let mut skipped: Vec<PathBuf> = Vec::new();
-    for frame in frames {
-        let index = frame
-            .file_stem()
-            .and_then(|s| s.to_str())
-            .and_then(|s| s.strip_prefix("frame_"));
-        let Some(index) = index else {
-            skipped.push(frame.clone());
-            continue;
-        };
-        let alpha = tmp_path.join(format!("alpha_{index}.png"));
-        if !alpha.exists() {
-            skipped.push(frame.clone());
-            continue;
-        }
-        let merged = tmp_path.join(format!("merged_{:04}.png", ops.len()));
-        ops.push((frame.clone(), alpha, merged));
-    }
-    (ops, skipped)
-}
-
 /// Create a unique scratch directory under the platform temp dir.
 ///
 /// Names include the process ID and a nanosecond timestamp so that
@@ -297,128 +247,4 @@ fn unique_tmp_dir() -> Option<PathBuf> {
         return None;
     }
     Some(path)
-}
-
-#[cfg(test)]
-mod tests {
-    use std::{
-        fs::{File, remove_dir_all},
-        path::{Path, PathBuf},
-    };
-
-    use crate::app::compatibility::converters::sticker::{plan_merge_ops, unique_tmp_dir};
-
-    fn touch(path: &Path) {
-        File::create(path).unwrap();
-    }
-
-    #[test]
-    fn plan_merge_ops_pairs_all_frames_when_alphas_present() {
-        let tmp = unique_tmp_dir().unwrap();
-        let frames = vec![
-            tmp.join("frame_0001.png"),
-            tmp.join("frame_0002.png"),
-            tmp.join("frame_0003.png"),
-        ];
-        for index in ["0001", "0002", "0003"] {
-            touch(&tmp.join(format!("alpha_{index}.png")));
-        }
-
-        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
-        let expected_ops = vec![
-            (
-                frames[0].clone(),
-                tmp.join("alpha_0001.png"),
-                tmp.join("merged_0000.png"),
-            ),
-            (
-                frames[1].clone(),
-                tmp.join("alpha_0002.png"),
-                tmp.join("merged_0001.png"),
-            ),
-            (
-                frames[2].clone(),
-                tmp.join("alpha_0003.png"),
-                tmp.join("merged_0002.png"),
-            ),
-        ];
-        let expected_skipped: Vec<PathBuf> = vec![];
-        assert_eq!(actual_ops, expected_ops);
-        assert_eq!(actual_skipped, expected_skipped);
-
-        let _ = remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn plan_merge_ops_renumbers_densely_around_missing_alpha() {
-        let tmp = unique_tmp_dir().unwrap();
-        let frames = vec![
-            tmp.join("frame_0001.png"),
-            tmp.join("frame_0002.png"),
-            tmp.join("frame_0003.png"),
-        ];
-        // alpha_0002.png deliberately absent
-        touch(&tmp.join("alpha_0001.png"));
-        touch(&tmp.join("alpha_0003.png"));
-
-        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
-        let expected_ops = vec![
-            (
-                frames[0].clone(),
-                tmp.join("alpha_0001.png"),
-                tmp.join("merged_0000.png"),
-            ),
-            (
-                frames[2].clone(),
-                tmp.join("alpha_0003.png"),
-                tmp.join("merged_0001.png"),
-            ),
-        ];
-        let expected_skipped = vec![frames[1].clone()];
-        assert_eq!(actual_ops, expected_ops);
-        assert_eq!(actual_skipped, expected_skipped);
-
-        let _ = remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn plan_merge_ops_handles_zero_indexed_frames() {
-        let tmp = unique_tmp_dir().unwrap();
-        let frames = vec![tmp.join("frame_0000.png"), tmp.join("frame_0001.png")];
-        touch(&tmp.join("alpha_0000.png"));
-        touch(&tmp.join("alpha_0001.png"));
-
-        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
-        let expected_ops = vec![
-            (
-                frames[0].clone(),
-                tmp.join("alpha_0000.png"),
-                tmp.join("merged_0000.png"),
-            ),
-            (
-                frames[1].clone(),
-                tmp.join("alpha_0001.png"),
-                tmp.join("merged_0001.png"),
-            ),
-        ];
-        let expected_skipped: Vec<PathBuf> = vec![];
-        assert_eq!(actual_ops, expected_ops);
-        assert_eq!(actual_skipped, expected_skipped);
-
-        let _ = remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn plan_merge_ops_skips_every_frame_when_no_alphas_exist() {
-        let tmp = unique_tmp_dir().unwrap();
-        let frames = vec![tmp.join("frame_0001.png"), tmp.join("frame_0002.png")];
-
-        let (actual_ops, actual_skipped) = plan_merge_ops(&frames, &tmp);
-        let expected_ops: Vec<(PathBuf, PathBuf, PathBuf)> = vec![];
-        let expected_skipped = frames.clone();
-        assert_eq!(actual_ops, expected_ops);
-        assert_eq!(actual_skipped, expected_skipped);
-
-        let _ = remove_dir_all(&tmp);
-    }
 }

--- a/imessage-exporter/src/exporters/shared/attachment.rs
+++ b/imessage-exporter/src/exporters/shared/attachment.rs
@@ -9,8 +9,9 @@ use crate::{
 };
 
 /// Run the per-attachment side effects every exporter needs before it can
-/// emit a reference to a file on disk: toggle the progress bar's "encoding
-/// video" indicator if the attachment will be transcoded, then ask the
+/// emit a reference to a file on disk: surface a busy indicator on the
+/// progress bar for conversions that spawn ffmpeg (video transcoding and
+/// animated-sticker decoding), then ask the
 /// [`AttachmentManager`](crate::app::compatibility::attachment_manager::AttachmentManager)
 /// to copy or convert the file.
 ///
@@ -27,16 +28,33 @@ pub(crate) fn prepare_attachment(
     attachment: &mut Attachment,
     message: &Message,
 ) -> Result<(), AttachmentRender> {
-    let will_encode = matches!(attachment.mime_type(), MediaType::Video(_))
+    // Determine which conversions actually invoke ffmpeg and freeze the bar.
+    // Both video transcoding (any video in Full mode) and animated-sticker
+    // conversion (HEICS in Basic/Full) spawn ffmpeg, so both should surface
+    // the busy indicator.
+    let mode = &config.options.attachment_manager.mode;
+    let is_video_full = matches!(attachment.mime_type(), MediaType::Video(_))
+        && matches!(mode, AttachmentManagerMode::Full);
+    let is_animated_sticker = attachment.is_sticker
         && matches!(
-            config.options.attachment_manager.mode,
-            AttachmentManagerMode::Full
+            attachment.mime_type(),
+            MediaType::Image("heics" | "HEICS" | "heic-sequence")
+        )
+        && matches!(
+            mode,
+            AttachmentManagerMode::Basic | AttachmentManagerMode::Full
         );
 
-    if will_encode {
-        state
-            .pb
-            .set_busy_style("Encoding video, estimates paused...".to_string());
+    let busy_label = if is_animated_sticker {
+        Some("Encoding animated sticker, estimates paused...")
+    } else if is_video_full {
+        Some("Encoding video, estimates paused...")
+    } else {
+        None
+    };
+
+    if let Some(label) = busy_label {
+        state.pb.set_busy_style(label.to_string());
     }
 
     let handle_result = config
@@ -44,7 +62,7 @@ pub(crate) fn prepare_attachment(
         .attachment_manager
         .handle_attachment(message, attachment, config);
 
-    if will_encode {
+    if busy_label.is_some() {
         state.pb.set_default_style();
     }
 


### PR DESCRIPTION
- Fix sticker offset reconstruction
- `ffmpeg` processing warning now fires for animated stickers in addition to videos
- Per-frame `ffmpeg` loop replaced with a single `ffmpeg` invocation that consumes both image sequences and applies `alphamerge` across them