### PR TITLE
Feat/cs/sql perf

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -151,7 +151,7 @@ On my M1 Max MacBook Pro, approximate performance is as follows:
 
 | `--copy-method` | Messages exported per second |
 |---|---|
-| `disabled` | > 130,000 |
+| `disabled` | > 145,000 |
 | `clone` | ≈ 42,000 |
 | `basic` | ≈ 350 |
 | `full` | ≈ 250 |

--- a/imessage-database/src/util/dates.rs
+++ b/imessage-database/src/util/dates.rs
@@ -5,7 +5,7 @@
 */
 use std::fmt::Write;
 
-use chrono::{DateTime, Datelike, Local, Months, TimeZone, Utc};
+use chrono::{DateTime, Datelike, Local, Months, TimeZone, Timelike, Utc};
 
 use crate::error::message::MessageError;
 
@@ -81,7 +81,29 @@ pub fn get_local_time(date_stamp: i64, offset: i64) -> Result<DateTime<Local>, M
 /// ```
 #[must_use]
 pub fn format(date: &DateTime<Local>) -> String {
-    DateTime::format(date, "%b %d, %Y %l:%M:%S %p").to_string()
+    // Equivalent to `date.format("%b %d, %Y %l:%M:%S %p").to_string()` but
+    // written directly into one pre-sized buffer
+    const MONTHS: [&str; 12] = [
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+    ];
+    let (hour12, meridiem) = match date.hour() {
+        0 => (12, "AM"),
+        12 => (12, "PM"),
+        h if h < 12 => (h, "AM"),
+        h => (h - 12, "PM"),
+    };
+
+    let mut out = String::with_capacity(24);
+    let _ = write!(
+        out,
+        "{} {:02}, {} {hour12:2}:{:02}:{:02} {meridiem}",
+        MONTHS[(date.month() - 1) as usize],
+        date.day(),
+        date.year(),
+        date.minute(),
+        date.second(),
+    );
+    out
 }
 
 /// Generate a readable diff from two local timestamps.

--- a/imessage-database/src/util/dates.rs
+++ b/imessage-database/src/util/dates.rs
@@ -204,6 +204,27 @@ mod tests {
     }
 
     #[test]
+    fn can_format_date_midnight() {
+        // Hour 0 renders as 12 AM (and single-digit minute/second are zero-padded).
+        let date = Local.with_ymd_and_hms(2020, 5, 20, 0, 5, 9).unwrap();
+        assert_eq!(format(&date), "May 20, 2020 12:05:09 AM");
+    }
+
+    #[test]
+    fn can_format_date_noon() {
+        // Hour 12 renders as 12 PM, not 0 PM.
+        let date = Local.with_ymd_and_hms(2020, 5, 20, 12, 0, 0).unwrap();
+        assert_eq!(format(&date), "May 20, 2020 12:00:00 PM");
+    }
+
+    #[test]
+    fn can_format_date_afternoon() {
+        // Hour 15 maps to a space-padded 12-hour `3` (note the double space) PM.
+        let date = Local.with_ymd_and_hms(2020, 5, 20, 15, 4, 5).unwrap();
+        assert_eq!(format(&date), "May 20, 2020  3:04:05 PM");
+    }
+
+    #[test]
     fn cant_format_diff_backwards() {
         let end = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 11).unwrap();
         let start = Local.with_ymd_and_hms(2020, 5, 20, 9, 10, 30).unwrap();

--- a/imessage-exporter/src/exporters/shared/driver.rs
+++ b/imessage-exporter/src/exporters/shared/driver.rs
@@ -18,6 +18,9 @@ use crate::{
     exporters::formatter::{MessageFormatter, RenderContext},
 };
 
+/// Capacity for each chat file's [`BufWriter`].
+const FILE_BUFFER_CAPACITY: usize = 64 * 1024;
+
 /// Shared per-export mutable state held by every concrete `MessageWriter`.
 /// Holds the file cache (one [`BufWriter`] per chatroom), the writer for
 /// messages that don't belong to a chat, and the progress bar. The owning
@@ -49,7 +52,7 @@ impl ExportState {
         Ok(Self {
             files: HashMap::new(),
             route: HashMap::new(),
-            orphaned: BufWriter::new(file),
+            orphaned: BufWriter::with_capacity(FILE_BUFFER_CAPACITY, file),
             pb: ExportProgress::new(pb_enabled),
         })
     }
@@ -135,7 +138,7 @@ where
                     // This can happen if multiple chats use the same group name.
                     let file_exists = path.exists();
                     let file = File::options().append(true).create(true).open(&path)?;
-                    let mut buf = BufWriter::new(file);
+                    let mut buf = BufWriter::with_capacity(FILE_BUFFER_CAPACITY, file);
                     if !file_exists {
                         W::write_file_header(&mut buf)?;
                     }

--- a/imessage-exporter/src/exporters/shared/driver.rs
+++ b/imessage-exporter/src/exporters/shared/driver.rs
@@ -204,6 +204,13 @@ where
         }
         current_message_row = msg.rowid;
 
+        // Tapbacks, poll votes, and poll updates are rendered in context by
+        // their parent messages, never at the top level, so we can skip them here
+        if !msg.is_edited() && (msg.is_tapback() || msg.is_poll_vote() || msg.is_poll_update()) {
+            current_message += 1;
+            continue;
+        }
+
         apply_body(&mut msg, writer.config().data_source.db());
 
         if msg.is_announcement() {

--- a/imessage-exporter/src/exporters/shared/driver.rs
+++ b/imessage-exporter/src/exporters/shared/driver.rs
@@ -26,6 +26,8 @@ use crate::{
 pub struct ExportState {
     /// One open [`BufWriter`] per resolved chat filename.
     pub files: HashMap<String, BufWriter<File>>,
+    /// Cache each chat's resolved filename by chat rowid
+    pub route: HashMap<i32, String>,
     /// Destination for messages that don't have a conversation route.
     pub orphaned: BufWriter<File>,
     /// Drives the on-screen progress indicator.
@@ -46,6 +48,7 @@ impl ExportState {
         let pb_enabled = config.options.show_progress && stderr().is_terminal();
         Ok(Self {
             files: HashMap::new(),
+            route: HashMap::new(),
             orphaned: BufWriter::new(file),
             pb: ExportProgress::new(pb_enabled),
         })
@@ -110,8 +113,19 @@ where
     let config = writer.config();
     match config.conversation(message) {
         Some((chatroom, _)) => {
-            let filename = config.filename(chatroom);
+            let chatroom_rowid = chatroom.rowid;
             let state = writer.state_mut();
+            // Reuse the chat's filename if we've already resolved it; otherwise
+            // compute it once and memoize. `config`/`chatroom` are `&'a` and
+            // independent of the `state` borrow.
+            let filename = match state.route.get(&chatroom_rowid) {
+                Some(name) => name.clone(),
+                None => {
+                    let name = config.filename(chatroom);
+                    state.route.insert(chatroom_rowid, name.clone());
+                    name
+                }
+            };
             match state.files.entry(filename) {
                 Occupied(entry) => Ok(entry.into_mut()),
                 Vacant(entry) => {


### PR DESCRIPTION
- Cache chat resolved filenames.
- Optimize date formatting with a pre-sized buffer.
- Increase the output buffer capacity.
- Skip parsing immediately-discarded messages.

# Performance increases

| Commit | Change | HTML msg/s | HTML Δ | TXT msg/s | TXT Δ |
|---|---|---:|---:|---:|---:|
| `f27ec38` | `develop` baseline (pre-allocation work) | 117,374 | — | 131,400 | — |
| `b893075` | Cache chat resolved filenames | 120,005 | +2.2% | 137,191 | +4.4% |
| `88a23e3` | Optimize date formatting by using a pre-sized buffer | 122,183 | +1.8% | 139,966 | +2.0% |
| `5f803b9` | Increase base bufwriter capacity | 129,963 | +6.4% | 142,177 | +1.6% |
| `48efb7b` | Skip immediately discarded tapbacks / poll votes / poll updates | 132,197 | +1.7% | 145,414 | +2.3% |
| Total | Overall improvement vs baseline | 132,197 | +12.6% | 145,414 | +10.7% |