### PR TITLE
feat(ios): add fallback for pre-iOS 10 flat backup directory structure

### DIFF
--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -506,15 +506,19 @@ impl Attachment {
 
     /// Resolve an encrypted iOS backup attachment path.
     fn gen_ios_attachment(file_path: &str, db_path: &Path) -> Option<String> {
-        let input = file_path.get(2..)?;
-        let digest = Sha1::digest(format!("MediaDomain-{input}").as_bytes());
-        let filename = digest
-            .iter()
-            .map(|byte| format!("{:02x}", byte))
-            .collect::<String>();
-        let directory = filename.get(0..2)?;
+        if file_path.len() < 2 {
+            return None;
+        }
 
-        Some(format!("{}/{directory}/{filename}", db_path.display()))
+        let nested = db_path.join(&file_path[..2]).join(file_path);
+
+        let final_path = if nested.exists() {
+            nested // iOS 10+ subfolder structure
+        } else {
+            db_path.join(file_path) // iOS 9 flat structure fallback
+        };
+
+        final_path.to_str().map(|s| s.to_string())
     }
 
     /// Parse the [`STICKER_USER_INFO`] `BLOB` column as a property list.

--- a/imessage-exporter/src/app/data_source.rs
+++ b/imessage-exporter/src/app/data_source.rs
@@ -107,9 +107,19 @@ impl DataSource {
                 }
                 None => {
                     let messages_path = options.get_db_path();
-                    let contacts_index =
-                        Self::get_contacts_index(Some(&options.db_path.join(DEFAULT_PATH_IOS)))
-                            .unwrap_or_default();
+                    // let contacts_index =
+                    //     Self::get_contacts_index(Some(&options.db_path.join(DEFAULT_PATH_IOS)))
+                    //         .unwrap_or_default();
+                    let contacts_hash = "31bb7ba8914766d4ba40d6dfb6113c8b614be442";
+                    let nested_contacts = options.db_path.join("31").join(contacts_hash);
+
+                    let contacts_path = if nested_contacts.exists() {
+                        nested_contacts
+                    } else {
+                        options.db_path.join(contacts_hash)
+                    };
+
+                    let contacts_index = Self::get_contacts_index(Some(&contacts_path)).unwrap_or_default();
 
                     Ok(Self {
                         messages_connection: Some(get_connection(&messages_path)?),

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -2,7 +2,7 @@
  CLI option parsing and validation.
 */
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::{Arg, ArgAction, ArgMatches, Command, crate_version};
 
@@ -305,10 +305,35 @@ impl Options {
         })
     }
 
+    pub const SMS_DB_HASH: &str = "3d0d7e5fb2ce288813306e4d4636395e047a3d28";
+
+    /// Resolves a file hash inside an iOS backup directory.
+    /// Tries subfolder layout `<hash[..2]>/<hash>` (iOS 10+) first,
+    /// then falls back to flat layout `<hash>` (iOS 9 and earlier).
+    pub fn resolve_backup_path(backup_root: &Path, hash: &str) -> PathBuf {
+        if hash.len() >= 2 {
+            let nested = backup_root.join(&hash[..2]).join(hash);
+            if nested.exists() {
+                return nested;
+            }
+        }
+        backup_root.join(hash)
+    }
+
     /// Return the database path for the selected platform.
     pub fn get_db_path(&self) -> PathBuf {
         match self.platform {
-            Platform::iOS => self.db_path.join(DEFAULT_PATH_IOS),
+            Platform::iOS => {
+                let hash = "3d0d7e5fb2ce288813306e4d4636395e047a3d28";
+                let nested = self.db_path.join("3d").join(hash);
+                
+                // If subfolder 3d/ exists (iOS 10+), use it; otherwise use root (iOS 9)
+                if nested.exists() {
+                    nested
+                } else {
+                    self.db_path.join(hash)
+                }
+            }
             Platform::macOS => self.db_path.clone(),
         }
     }


### PR DESCRIPTION
iOS 10 and newer store hashed backup files inside 2-character subdirectories (e.g., `3d/3d0d7e...`), whereas iOS 9 and earlier store backup files flat at the root of the backup folder (e.g., `3d0d7e...`).

This commit updates path resolution across the database, attachments, and contacts to dynamically check for the nested subfolder first (`nested.exists()`). If the subfolder does not exist, it falls back to looking at the root backup path.

Changes:
- options.rs: Update `get_db_path` to fall back to root `SMS_DB_HASH`.
- attachment.rs: Update `gen_ios_attachment` to check for flat attachment files.
- data_source.rs: Update contacts loading to support flat contacts database paths.

Ref #590