### PR TITLE
Feat/cs/export timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aes"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
 dependencies = [
  "cipher",
  "cpubits",
@@ -25,18 +25,18 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "askama"
@@ -125,7 +125,7 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_derive",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -173,15 +173,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.63"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -381,9 +381,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "digest"
@@ -399,9 +396,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "equivalent"
@@ -433,9 +430,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdlimit"
@@ -449,15 +446,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "foldhash"
@@ -477,21 +468,21 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -501,31 +492,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "hashbrown"
@@ -533,7 +513,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -550,12 +530,6 @@ checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
  "hashbrown 0.16.1",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac"
@@ -577,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
@@ -607,12 +581,6 @@ checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "imessage-database"
@@ -652,8 +620,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -680,13 +646,12 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.99"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -697,22 +662,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ab85f84ca42c5ec520e6f3c9966ba1fd62909ce260f8837e248857d2560509"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -733,9 +692,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lzma-rs"
@@ -749,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.1"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "num-conv"
@@ -804,9 +763,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plist"
@@ -828,20 +787,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -908,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -923,9 +872,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -935,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -946,9 +895,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rpassword"
@@ -968,7 +917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
 dependencies = [
  "hashbrown 0.16.1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -998,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -1030,50 +979,44 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -1118,9 +1061,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "sqlite-wasm-rs"
@@ -1142,9 +1085,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1175,11 +1129,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -1190,28 +1144,27 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -1221,15 +1174,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1248,12 +1201,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1266,28 +1213,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
-]
-
-[[package]]
 name = "wasm-bindgen"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1298,9 +1227,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1308,58 +1237,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.122"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1417,7 +1312,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1428,7 +1323,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1539,109 +1434,15 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/imessage-exporter/README.md
+++ b/imessage-exporter/README.md
@@ -125,12 +125,17 @@ The [releases page](https://github.com/ReagentX/imessage-exporter/releases) prov
         Handles from the messages table will be mapped to names in the provided database
         Generally, one of `AddressBook-v22.abcddb` or `AddressBook.sqlitedb`
         
-    --no-progress
+--no-progress
         Disable the on-screen progress bar regardless of context
         By default, the progress bar is shown only when stderr is a terminal,
         so headless invocations (CI, output redirected to a logfile) stay clean automatically.
         Use this flag to suppress the bar even in an interactive terminal.
         
+--use-message-times
+        Stamp transcripts with the earliest and latest message dates in this export
+        Also set each new attachment file's creation time to its message date
+        Creation time is set only on macOS and Windows
+
 -h, --help
         Print help
 -V, --version
@@ -220,6 +225,15 @@ imessage-exporter -f html -t "@"
 ### Contacts
 
 `imessage-exporter` will automatically attempt to resolve handle details (email addresses and phone numbers) against contacts found either in the provided iOS backup or on the local macOS Address Book. Users can optionally pass in a path to an Address Book database, but this should generally not be necessary.
+
+### Message-derived file timestamps
+
+`--use-message-times` sets each transcript file's creation time to the earliest message rendered into it during the current export and its modification time to the latest. Newly written attachment files receive the associated message's modification time regardless of this option; enabling it also sets their creation time to that date. The option is disabled by default because these timestamps describe message content rather than the export operation.
+
+- Transcript files that receive no messages during the current export retain their existing timestamps. Directories also remain unchanged.
+- The exporter can set creation time only on macOS and Windows. On other platforms, this option changes transcript modification times but no attachment timestamps.
+- Re-exporting content can leave the same modification time when the latest rendered message has not changed. Any process that uses only modification time to detect rewritten files can therefore miss the new contents.
+- A stamped transcript file's timestamps no longer record when the current export wrote it.
 
 ### HTML Exports
 

--- a/imessage-exporter/src/app/compatibility/converters/common.rs
+++ b/imessage-exporter/src/app/compatibility/converters/common.rs
@@ -3,15 +3,17 @@
 */
 use std::{
     ffi::OsStr,
-    fs::{File, FileTimes, copy, create_dir_all, metadata, read_dir},
+    fs::{copy, create_dir_all, metadata, read_dir},
     path::Path,
     process::{Command, Stdio},
-    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use imessage_database::tables::messages::Message;
 
-use crate::app::runtime::Config;
+use crate::app::{
+    file_times::{set_file_times, unix_to_system_time},
+    runtime::Config,
+};
 
 /// Run a command, ignoring output. Returns [`None`] if the process cannot be
 /// spawned, cannot be waited on, or exits with a non-zero status.
@@ -105,7 +107,12 @@ pub(crate) fn copy_raw(from: &Path, to: &Path) {
     }
 }
 
-/// Update copied-file timestamps from the message date and source metadata.
+/// Update an attachment output's access and modification times.
+///
+/// Access time comes from `from`. Modification time comes from the message
+/// date, with `from`'s modification time as a fallback. With
+/// `use_message_times` set, creation time matches modification time. Directory
+/// targets and metadata errors leave `to` unchanged.
 pub(crate) fn update_file_metadata(from: &Path, to: &Path, message: &Message, config: &Config) {
     if to.is_dir() {
         return;
@@ -123,37 +130,99 @@ pub(crate) fn update_file_metadata(from: &Path, to: &Path, message: &Message, co
         // The new last access time comes from the metadata of the original file
         let atime = metadata.accessed().ok();
 
+        // Apply both values or leave the destination unchanged.
         if let (Some(atime), Some(mtime)) = (atime, mtime) {
-            // On Unix, `set_times` uses `futimens`, which does not require the file
-            // descriptor to have write access. On Windows, `SetFileTime` requires
-            // `FILE_WRITE_ATTRIBUTES`, so the file must be opened with write access.
-            #[cfg(unix)]
-            let file_result = File::open(to);
-            #[cfg(not(unix))]
-            let file_result = File::options().write(true).open(to);
-            match file_result {
-                Ok(file) => {
-                    let file_times = FileTimes::new().set_accessed(atime).set_modified(mtime);
-                    if let Err(why) = file.set_times(file_times) {
-                        eprintln!("Unable to update {} metadata: {why}", to.display());
-                    }
-                }
-                Err(why) => {
-                    eprintln!("Unable to open {} to update metadata: {why}", to.display());
-                }
-            }
+            // Modification and access time always apply; the option also sets
+            // creation time.
+            let ctime = config.options.use_message_times.then_some(mtime);
+            set_file_times(to, ctime, Some(mtime), Some(atime));
         }
     }
 }
 
-fn unix_to_system_time(secs: i64, nanos: u32) -> Option<SystemTime> {
-    if secs >= 0 {
-        UNIX_EPOCH
-            .checked_add(Duration::from_secs(secs as u64))?
-            .checked_add(Duration::from_nanos(u64::from(nanos)))
-    } else {
-        UNIX_EPOCH
-            .checked_sub(Duration::from_secs(secs.unsigned_abs()))?
-            .checked_add(Duration::from_nanos(u64::from(nanos)))
+// MARK: Tests
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{File, metadata},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    use imessage_database::tables::messages::Message;
+
+    use crate::app::{
+        export_type::ExportType,
+        file_times::{set_file_times, unix_to_system_time},
+        options::Options,
+        runtime::Config,
+        test_dir::unique_test_dir,
+    };
+
+    use super::update_file_metadata;
+
+    /// Whole Unix seconds so assertions cannot trip over a filesystem that
+    /// truncates sub-second precision.
+    const MESSAGE_UNIX_SECS: i64 = 1_500_000_000;
+
+    fn expected_message_time(config: &Config, message: &Message) -> SystemTime {
+        let date = message.date(config.offset).unwrap();
+        unix_to_system_time(date.timestamp(), date.timestamp_subsec_nanos()).unwrap()
+    }
+
+    #[test]
+    fn can_stamp_attachment_with_message_times() {
+        let mut options = Options::fake_options(ExportType::Txt);
+        options.use_message_times = true;
+        let config = Config::fake_app(options);
+
+        let dir = unique_test_dir("attachment-times-on");
+        let from = dir.join("src.bin");
+        let to = dir.join("dest.bin");
+        File::create(&from).unwrap();
+        File::create(&to).unwrap();
+
+        let mut message = Config::fake_message();
+        message.date = MESSAGE_UNIX_SECS - config.offset;
+
+        update_file_metadata(&from, &to, &message, &config);
+
+        let expected = expected_message_time(&config, &message);
+        let metadata = metadata(&to).unwrap();
+        assert_eq!(metadata.modified().unwrap(), expected);
+
+        // Birth time is settable only on macOS and Windows.
+        #[cfg(any(target_vendor = "apple", windows))]
+        assert_eq!(metadata.created().unwrap(), expected);
+    }
+
+    #[test]
+    fn cannot_stamp_attachment_created_without_message_times() {
+        let options = Options::fake_options(ExportType::Txt);
+        assert!(!options.use_message_times);
+        let config = Config::fake_app(options);
+
+        let dir = unique_test_dir("attachment-times-off");
+        let from = dir.join("src.bin");
+        let to = dir.join("dest.bin");
+        File::create(&from).unwrap();
+        File::create(&to).unwrap();
+
+        // A known birthtime distinct from the message date, so a regression
+        // that always writes `ctime = Some(mtime)` cannot stay green.
+        let prior_created = UNIX_EPOCH + Duration::from_secs(1_300_000_000);
+        set_file_times(&to, Some(prior_created), None, None);
+
+        let mut message = Config::fake_message();
+        message.date = MESSAGE_UNIX_SECS - config.offset;
+
+        update_file_metadata(&from, &to, &message, &config);
+
+        let expected = expected_message_time(&config, &message);
+        let metadata = metadata(&to).unwrap();
+        assert_eq!(metadata.modified().unwrap(), expected);
+
+        // Birth time is settable only on macOS and Windows.
+        #[cfg(any(target_vendor = "apple", windows))]
+        assert_eq!(metadata.created().unwrap(), prior_created);
     }
 }

--- a/imessage-exporter/src/app/file_times.rs
+++ b/imessage-exporter/src/app/file_times.rs
@@ -1,0 +1,215 @@
+/*!
+ Apply filesystem timestamps.
+
+ Opening or updating a path reports failures to stderr without propagating
+ them.
+*/
+
+use std::{
+    fs::{File, FileTimes},
+    path::Path,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+/// Apply the supplied timestamps to `path`, leaving the rest untouched.
+///
+/// Call-site details:
+/// - Nothing is fatal. Any failure to open `path` or to write its times prints
+///   to stderr and returns.
+/// - `created` is the birthtime, which only macOS and Windows can set; other
+///   platforms ignore it. POSIX `ctime` is a different field (inode
+///   status-change time) and cannot be set through this interface.
+/// - Directory paths are supported on Unix. They follow the non-fatal error
+///   path on Windows because opening a directory requires backup semantics.
+pub(crate) fn set_file_times(
+    path: &Path,
+    created: Option<SystemTime>,
+    modified: Option<SystemTime>,
+    accessed: Option<SystemTime>,
+) {
+    if created.is_none() && modified.is_none() && accessed.is_none() {
+        return;
+    }
+
+    // On Unix, `set_times` uses `futimens`, which does not require the file
+    // descriptor to have write access. On Windows, `SetFileTime` requires
+    // `FILE_WRITE_ATTRIBUTES`, so the file must be opened with write access.
+    #[cfg(unix)]
+    let file_result = File::open(path);
+    #[cfg(not(unix))]
+    let file_result = File::options().write(true).open(path);
+
+    let file = match file_result {
+        Ok(file) => file,
+        Err(why) => {
+            eprintln!(
+                "Unable to open {} to update metadata: {why}",
+                path.display()
+            );
+            return;
+        }
+    };
+
+    let mut times = FileTimes::new();
+    if let Some(accessed) = accessed {
+        times = times.set_accessed(accessed);
+    }
+    if let Some(modified) = modified {
+        times = times.set_modified(modified);
+    }
+    times = with_created(times, created);
+
+    if let Err(why) = file.set_times(times) {
+        eprintln!("Unable to update {} metadata: {why}", path.display());
+    }
+}
+
+/// Add the birthtime to `times` on the platforms that can set one.
+#[cfg(target_vendor = "apple")]
+fn with_created(times: FileTimes, created: Option<SystemTime>) -> FileTimes {
+    use std::os::darwin::fs::FileTimesExt;
+
+    match created {
+        Some(created) => times.set_created(created),
+        None => times,
+    }
+}
+
+/// Add the birthtime to `times` on the platforms that can set one.
+#[cfg(windows)]
+fn with_created(times: FileTimes, created: Option<SystemTime>) -> FileTimes {
+    use std::os::windows::fs::FileTimesExt;
+
+    match created {
+        Some(created) => times.set_created(created),
+        None => times,
+    }
+}
+
+/// Drop the birthtime: no other platform exposes a settable one.
+#[cfg(not(any(target_vendor = "apple", windows)))]
+fn with_created(times: FileTimes, _created: Option<SystemTime>) -> FileTimes {
+    times
+}
+
+/// Convert Unix seconds plus nanoseconds to a [`SystemTime`].
+///
+/// Negative seconds move before the epoch; nanoseconds remain a positive
+/// offset from that whole-second boundary. Returns [`None`] on overflow.
+pub(crate) fn unix_to_system_time(secs: i64, nanos: u32) -> Option<SystemTime> {
+    if secs >= 0 {
+        UNIX_EPOCH
+            .checked_add(Duration::from_secs(secs as u64))?
+            .checked_add(Duration::from_nanos(u64::from(nanos)))
+    } else {
+        UNIX_EPOCH
+            .checked_sub(Duration::from_secs(secs.unsigned_abs()))?
+            .checked_add(Duration::from_nanos(u64::from(nanos)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::{File, metadata},
+        time::{Duration, SystemTime, UNIX_EPOCH},
+    };
+
+    use crate::app::{
+        file_times::{set_file_times, unix_to_system_time},
+        test_dir::unique_test_dir,
+    };
+
+    /// Whole seconds, so the assertions cannot trip over a filesystem that
+    /// truncates sub-second precision.
+    fn at(secs: u64) -> SystemTime {
+        UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    #[test]
+    fn can_set_modified_time_on_file() {
+        let dir = unique_test_dir("file-times-modified");
+        let path = dir.join("stamped.txt");
+        File::create(&path).unwrap();
+
+        let modified = at(1_000_000_000);
+        set_file_times(&path, None, Some(modified), None);
+
+        assert_eq!(metadata(&path).unwrap().modified().unwrap(), modified);
+    }
+
+    #[test]
+    fn can_set_accessed_time_on_file() {
+        let dir = unique_test_dir("file-times-accessed");
+        let path = dir.join("stamped.txt");
+        File::create(&path).unwrap();
+
+        let accessed = at(1_100_000_000);
+        set_file_times(&path, None, None, Some(accessed));
+
+        assert_eq!(metadata(&path).unwrap().accessed().unwrap(), accessed);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn can_set_times_on_directory() {
+        use std::fs::create_dir;
+
+        let dir = unique_test_dir("file-times-directory");
+        let path = dir.join("subdir");
+        create_dir(&path).unwrap();
+
+        let modified = at(1_200_000_000);
+        set_file_times(&path, None, Some(modified), None);
+
+        assert_eq!(metadata(&path).unwrap().modified().unwrap(), modified);
+    }
+
+    /// Birth time is settable only on macOS and Windows.
+    #[test]
+    #[cfg(any(target_vendor = "apple", windows))]
+    fn can_set_created_time() {
+        let dir = unique_test_dir("file-times-created");
+        let path = dir.join("stamped.txt");
+        File::create(&path).unwrap();
+
+        let created = at(1_300_000_000);
+        let modified = at(1_400_000_000);
+        set_file_times(&path, Some(created), Some(modified), None);
+
+        let metadata = metadata(&path).unwrap();
+        assert_eq!(metadata.created().unwrap(), created);
+        assert_eq!(metadata.modified().unwrap(), modified);
+    }
+
+    #[test]
+    fn missing_path_does_not_panic() {
+        let dir = unique_test_dir("file-times-missing");
+        let path = dir.join("absent.txt");
+
+        set_file_times(&path, Some(at(1)), Some(at(2)), Some(at(3)));
+
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn empty_request_does_not_panic() {
+        let dir = unique_test_dir("file-times-empty");
+        let path = dir.join("stamped.txt");
+        File::create(&path).unwrap();
+
+        set_file_times(&path, None, None, None);
+    }
+
+    #[test]
+    fn unix_to_system_time_handles_negative_seconds() {
+        let expected = UNIX_EPOCH - Duration::from_secs(400_000_000);
+        assert_eq!(unix_to_system_time(-400_000_000, 0), Some(expected));
+    }
+
+    #[test]
+    fn unix_to_system_time_handles_positive_seconds() {
+        let expected = UNIX_EPOCH + Duration::from_secs(1_500_000_000) + Duration::from_nanos(250);
+        assert_eq!(unix_to_system_time(1_500_000_000, 250), Some(expected));
+    }
+}

--- a/imessage-exporter/src/app/mod.rs
+++ b/imessage-exporter/src/app/mod.rs
@@ -4,6 +4,7 @@ pub mod data_source;
 pub mod error;
 pub mod escaping;
 pub mod export_type;
+pub mod file_times;
 pub mod options;
 pub mod progress;
 pub mod runtime;

--- a/imessage-exporter/src/app/options.rs
+++ b/imessage-exporter/src/app/options.rs
@@ -43,6 +43,7 @@ pub const OPTION_CONVERSATION_FILTER: &str = "conversation-filter";
 pub const OPTION_CLEARTEXT_PASSWORD: &str = "cleartext-password";
 pub const OPTION_CUSTOM_CONTACTS_DB_PATH: &str = "contacts-path";
 pub const OPTION_NO_PROGRESS: &str = "no-progress";
+pub const OPTION_USE_MESSAGE_TIMES: &str = "use-message-times";
 
 // Other CLI Text
 pub const SUPPORTED_FILE_TYPES: &str = "txt, html";
@@ -89,6 +90,8 @@ pub struct Options {
     pub contacts_path: Option<PathBuf>,
     /// Whether to show the export progress bar when the terminal supports it.
     pub show_progress: bool,
+    /// Whether to stamp transcript and attachment files with message dates.
+    pub use_message_times: bool,
 }
 
 // Redact the cleartext backup password from debug output.
@@ -115,6 +118,7 @@ impl std::fmt::Debug for Options {
             )
             .field("contacts_path", &self.contacts_path)
             .field("show_progress", &self.show_progress)
+            .field("use_message_times", &self.use_message_times)
             .finish()
     }
 }
@@ -139,6 +143,7 @@ impl Options {
         let cleartext_password: Option<&String> = args.get_one(OPTION_CLEARTEXT_PASSWORD);
         let contacts_path: Option<&String> = args.get_one(OPTION_CUSTOM_CONTACTS_DB_PATH);
         let show_progress = !args.get_flag(OPTION_NO_PROGRESS);
+        let use_message_times = args.get_flag(OPTION_USE_MESSAGE_TIMES);
 
         // Build the export type
         let export_type: Option<ExportType> = match export_file_type {
@@ -162,6 +167,7 @@ impl Options {
                 (use_caller_id, OPTION_USE_CALLER_ID),
                 (conversation_filter.is_some(), OPTION_CONVERSATION_FILTER),
                 (!show_progress, OPTION_NO_PROGRESS),
+                (use_message_times, OPTION_USE_MESSAGE_TIMES),
             ];
             for (set, opt) in format_deps {
                 if set {
@@ -184,6 +190,7 @@ impl Options {
             (custom_name.is_some(), OPTION_CUSTOM_NAME),
             (conversation_filter.is_some(), OPTION_CONVERSATION_FILTER),
             (!show_progress, OPTION_NO_PROGRESS),
+            (use_message_times, OPTION_USE_MESSAGE_TIMES),
         ];
         for (set, opt) in diag_conflicts {
             if diagnostic && set {
@@ -302,6 +309,7 @@ impl Options {
             cleartext_password: cleartext_password.cloned(),
             contacts_path: contacts_path.cloned().map(PathBuf::from),
             show_progress,
+            use_message_times,
         })
     }
 
@@ -506,6 +514,13 @@ fn get_command() -> Command {
                 .action(ArgAction::SetTrue)
                 .display_order(16),
         )
+        .arg(
+            Arg::new(OPTION_USE_MESSAGE_TIMES)
+                .long(OPTION_USE_MESSAGE_TIMES)
+                .help("Stamp transcripts with the earliest and latest message dates in this export\nAlso set each new attachment file's creation time to its message date\nCreation time is set only on macOS and Windows\n")
+                .action(ArgAction::SetTrue)
+                .display_order(17),
+        )
 }
 
 #[cfg(test)]
@@ -533,7 +548,10 @@ impl Options {
             conversation_filter: None,
             cleartext_password: None,
             contacts_path: None,
-            show_progress: true,
+            // The harness leaves stderr as a TTY, so a true default draws `\r`
+            // bars over test output.
+            show_progress: false,
+            use_message_times: false,
         }
     }
 }
@@ -582,6 +600,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -658,6 +677,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -689,6 +709,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -763,6 +784,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -802,6 +824,7 @@ mod arg_tests {
             cleartext_password: Some("password".to_string()),
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -855,6 +878,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -886,6 +910,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -918,6 +943,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -949,6 +975,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -980,6 +1007,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -1050,6 +1078,7 @@ mod arg_tests {
             cleartext_password: None,
             contacts_path: None,
             show_progress: true,
+            use_message_times: false,
         };
 
         assert_eq!(actual, expected);
@@ -1091,6 +1120,43 @@ mod arg_tests {
     #[test]
     fn cant_build_option_diagnostic_flag_with_no_progress() {
         let args = get_command().get_matches_from(["imessage-exporter", "-d", "--no-progress"]);
+        assert!(Options::from_args(&args).is_err());
+    }
+
+    #[test]
+    fn can_build_option_use_message_times() {
+        let args = get_command().get_matches_from([
+            "imessage-exporter",
+            "-f",
+            "txt",
+            "--use-message-times",
+        ]);
+        let actual = Options::from_args(&args).unwrap();
+        assert!(actual.use_message_times);
+    }
+
+    #[test]
+    fn use_message_times_defaults_to_false() {
+        let args = get_command().get_matches_from(["imessage-exporter", "-f", "txt"]);
+        let actual = Options::from_args(&args).unwrap();
+        assert!(!actual.use_message_times);
+    }
+
+    #[test]
+    fn cant_build_option_use_message_times_no_export_type() {
+        let args = get_command().get_matches_from(["imessage-exporter", "--use-message-times"]);
+        let error = Options::from_args(&args).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "Invalid options!\nOption --use-message-times is enabled, which requires --format"
+        );
+    }
+
+    #[test]
+    fn cant_build_option_diagnostic_flag_with_use_message_times() {
+        let args =
+            get_command().get_matches_from(["imessage-exporter", "-d", "--use-message-times"]);
+        // `--use-message-times` requires `--format`, which diagnostics forbids.
         assert!(Options::from_args(&args).is_err());
     }
 }

--- a/imessage-exporter/src/app/test_dir.rs
+++ b/imessage-exporter/src/app/test_dir.rs
@@ -25,6 +25,9 @@ use std::{
 const PREFIX: &str = "imessage-exporter-test-";
 
 /// Sweep entries older than this on first call per process.
+///
+/// Directory names carry creation time because tests may change filesystem
+/// timestamps beneath them.
 const STALE_AFTER: Duration = Duration::from_secs(60 * 60);
 
 /// Build a fresh, uniquely-named directory under [`temp_dir`] and return its
@@ -48,8 +51,23 @@ pub fn unique_test_dir(label: &str) -> PathBuf {
     path
 }
 
-/// Remove leftover [`PREFIX`]-tagged directories whose mtime is older than
-/// [`STALE_AFTER`].
+/// The creation time [`unique_test_dir`] recorded in a directory name, or
+/// [`None`] when the name carries no parseable one.
+///
+/// The name is `{PREFIX}{pid}-{nanos}-{counter}-{label}`, so the second
+/// hyphen-separated field is Unix-epoch nanoseconds at creation. `label` may
+/// itself contain hyphens, which is why the split is bounded.
+fn creation_time_from_name(name: &str) -> Option<SystemTime> {
+    let mut fields = name.strip_prefix(PREFIX)?.splitn(3, '-');
+    fields.next()?;
+    let nanos: u128 = fields.next()?.parse().ok()?;
+    let seconds = u64::try_from(nanos / 1_000_000_000).ok()?;
+    let subsec = u32::try_from(nanos % 1_000_000_000).ok()?;
+    UNIX_EPOCH.checked_add(Duration::new(seconds, subsec))
+}
+
+/// Remove leftover [`PREFIX`]-tagged directories created more than
+/// [`STALE_AFTER`] ago, dating each one from its name.
 fn sweep_stale_test_dirs() {
     let Ok(entries) = read_dir(temp_dir()) else {
         return;
@@ -60,15 +78,12 @@ fn sweep_stale_test_dirs() {
     for entry in entries.flatten() {
         let name = entry.file_name();
         let Some(name) = name.to_str() else { continue };
-        if !name.starts_with(PREFIX) {
+        // Require both the module prefix and its parseable timestamp before
+        // removing an entry from the shared temp directory.
+        let Some(created) = creation_time_from_name(name) else {
             continue;
-        }
-        let stale = entry
-            .metadata()
-            .and_then(|m| m.modified())
-            .map(|m| m < cutoff)
-            .unwrap_or(false);
-        if stale {
+        };
+        if created < cutoff {
             let _ = remove_dir_all(entry.path());
         }
     }
@@ -76,7 +91,70 @@ fn sweep_stale_test_dirs() {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::metadata;
+
     use super::*;
+    use crate::app::file_times::set_file_times;
+
+    /// The timestamp in the name controls age even when mtime predates the
+    /// stale cutoff.
+    #[test]
+    #[cfg(unix)]
+    fn can_keep_backdated_directory_with_recent_name() {
+        let dir = unique_test_dir("sweep-backdated");
+        set_file_times(
+            &dir,
+            None,
+            Some(UNIX_EPOCH + Duration::from_secs(1_000_000_000)),
+            None,
+        );
+        let modified = metadata(&dir).unwrap().modified().unwrap();
+        assert!(
+            modified < SystemTime::now() - STALE_AFTER,
+            "precondition: the directory must look stale by mtime"
+        );
+
+        sweep_stale_test_dirs();
+
+        assert!(
+            dir.is_dir(),
+            "sweep deleted a directory created seconds ago"
+        );
+    }
+
+    /// An epoch-old timestamp in the name is stale even when mtime is recent.
+    #[test]
+    fn can_sweep_directory_with_old_name() {
+        let path = temp_dir().join(format!("{PREFIX}{}-1-0-sweep-old", process::id()));
+        create_dir_all(&path).unwrap();
+
+        sweep_stale_test_dirs();
+
+        assert!(!path.exists(), "sweep kept a directory named as epoch-old");
+    }
+
+    #[test]
+    fn cannot_sweep_directory_without_a_parseable_name() {
+        let path = temp_dir().join(format!("{PREFIX}{}-undatable", process::id()));
+        create_dir_all(&path).unwrap();
+
+        sweep_stale_test_dirs();
+
+        assert!(path.is_dir(), "sweep deleted a directory it cannot date");
+        // Undated entries are deliberately retained, so remove the fixture.
+        remove_dir_all(&path).unwrap();
+    }
+
+    #[test]
+    fn can_read_creation_time_from_name() {
+        let dir = unique_test_dir("name-time");
+        let name = dir.file_name().unwrap().to_str().unwrap();
+        let created = creation_time_from_name(name).expect("name carries a timestamp");
+
+        // The encoded creation time falls within the live window.
+        assert!(created > SystemTime::now() - STALE_AFTER);
+        assert!(creation_time_from_name("unrelated-temp-entry").is_none());
+    }
 
     #[test]
     fn unique_test_dir_is_unique_per_call() {

--- a/imessage-exporter/src/exporters/shared/date_span.rs
+++ b/imessage-exporter/src/exporters/shared/date_span.rs
@@ -1,0 +1,80 @@
+use std::path::Path;
+
+use crate::app::file_times::{set_file_times, unix_to_system_time};
+
+/// A message date as `(unix_seconds, nanoseconds)`.
+///
+/// Lexicographic order on the pair is chronological order: `nanoseconds` is
+/// always a positive offset from `unix_seconds`, on both sides of the epoch.
+pub(crate) type Timestamp = (i64, u32);
+
+/// The earliest and latest message date written into one output file during
+/// the current export.
+#[derive(Clone, Copy)]
+pub(crate) struct DateSpan {
+    earliest: Timestamp,
+    latest: Timestamp,
+}
+
+impl DateSpan {
+    /// Open a span on a single message.
+    pub(crate) fn new(at: Timestamp) -> Self {
+        Self {
+            earliest: at,
+            latest: at,
+        }
+    }
+
+    /// Widen both bounds to cover `at`; callers may supply dates in any order.
+    pub(crate) fn extend(&mut self, at: Timestamp) {
+        if at < self.earliest {
+            self.earliest = at;
+        }
+        if at > self.latest {
+            self.latest = at;
+        }
+    }
+
+    /// Stamp `path` with creation time from the earliest message and
+    /// modification time from the latest. Access time remains unchanged.
+    ///
+    /// [`set_file_times`] reports metadata failures without failing the export.
+    /// A bound that overflows [`SystemTime`](std::time::SystemTime) is omitted.
+    /// Creation time applies only on macOS and Windows.
+    pub(crate) fn apply(&self, path: &Path) {
+        set_file_times(
+            path,
+            unix_to_system_time(self.earliest.0, self.earliest.1),
+            unix_to_system_time(self.latest.0, self.latest.1),
+            None,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DateSpan;
+
+    #[test]
+    fn can_span_out_of_order_dates() {
+        let mut span = DateSpan::new((100, 0));
+        span.extend((300, 0));
+        span.extend((50, 0));
+        span.extend((200, 0));
+
+        assert_eq!(span.earliest, (50, 0));
+        assert_eq!(span.latest, (300, 0));
+    }
+
+    #[test]
+    fn can_span_dates_within_one_second() {
+        // Negative seconds carry a positive nanosecond offset, so the pair
+        // still orders chronologically before the epoch.
+        let mut span = DateSpan::new((-5, 500));
+        span.extend((-5, 900));
+        span.extend((-5, 100));
+
+        assert_eq!(span.earliest, (-5, 100));
+        assert_eq!(span.latest, (-5, 900));
+    }
+}

--- a/imessage-exporter/src/exporters/shared/driver.rs
+++ b/imessage-exporter/src/exporters/shared/driver.rs
@@ -5,6 +5,7 @@ use std::{
     },
     fs::File,
     io::{BufWriter, IsTerminal, Write, stderr},
+    path::PathBuf,
 };
 
 use imessage_database::tables::{
@@ -15,7 +16,10 @@ use rusqlite::Connection;
 
 use crate::{
     app::{error::RuntimeError, progress::ExportProgress, runtime::Config},
-    exporters::formatter::{MessageFormatter, RenderContext},
+    exporters::{
+        formatter::{MessageFormatter, RenderContext},
+        shared::date_span::{DateSpan, Timestamp},
+    },
 };
 
 /// Capacity for each chat file's [`BufWriter`].
@@ -31,10 +35,20 @@ pub struct ExportState {
     pub files: HashMap<String, BufWriter<File>>,
     /// Cache each chat's resolved filename by chat rowid
     pub route: HashMap<i32, String>,
-    /// Destination for messages that don't have a conversation route.
-    pub orphaned: BufWriter<File>,
+    /// Destination for messages that don't have a conversation route. Held in
+    /// an [`Option`] so [`ExportState::finish`] can drop the writer before the
+    /// file is stamped.
+    pub orphaned: Option<BufWriter<File>>,
+    /// Path to the orphaned file, retained for stamping after its writer drops.
+    pub orphaned_path: PathBuf,
     /// Drives the on-screen progress indicator.
     pub pb: ExportProgress,
+    /// Message date span per chat file, keyed like [`Self::files`]. Populated
+    /// only when `use_message_times` is set.
+    spans: HashMap<String, DateSpan>,
+    /// Message date span for the orphaned file. The file opens eagerly, but
+    /// stays unstamped when no message routes to it.
+    orphaned_span: Option<DateSpan>,
 }
 
 impl ExportState {
@@ -42,20 +56,91 @@ impl ExportState {
     /// `config.options.export_path` with the supplied extension, then build
     /// the empty file cache and progress bar.
     pub fn new(config: &Config, extension: &str) -> Result<Self, RuntimeError> {
-        let mut orphaned = config.options.export_path.clone();
-        orphaned.push(ORPHANED);
-        orphaned.set_extension(extension);
-        let file = File::options().append(true).create(true).open(&orphaned)?;
+        let mut orphaned_path = config.options.export_path.clone();
+        orphaned_path.push(ORPHANED);
+        orphaned_path.set_extension(extension);
+        let file = File::options()
+            .append(true)
+            .create(true)
+            .open(&orphaned_path)?;
         // `--no-progress` forces off; otherwise show only when stderr is a TTY
         // so headless invocations (CI, redirects to logfiles) stay clean.
         let pb_enabled = config.options.show_progress && stderr().is_terminal();
         Ok(Self {
             files: HashMap::new(),
             route: HashMap::new(),
-            orphaned: BufWriter::with_capacity(FILE_BUFFER_CAPACITY, file),
+            orphaned: Some(BufWriter::with_capacity(FILE_BUFFER_CAPACITY, file)),
+            orphaned_path,
             pb: ExportProgress::new(pb_enabled),
+            spans: HashMap::new(),
+            orphaned_span: None,
         })
     }
+
+    /// Widen the chat file's span to cover `at`, allocating the key only the
+    /// first time a message lands in that file.
+    fn record_chat(&mut self, filename: &str, at: Timestamp) {
+        match self.spans.get_mut(filename) {
+            Some(span) => span.extend(at),
+            None => {
+                self.spans.insert(filename.to_string(), DateSpan::new(at));
+            }
+        }
+    }
+
+    /// Widen the orphaned file's span to cover `at`.
+    fn record_orphaned(&mut self, at: Timestamp) {
+        match &mut self.orphaned_span {
+            Some(span) => span.extend(at),
+            None => self.orphaned_span = Some(DateSpan::new(at)),
+        }
+    }
+
+    /// Drop every writer, then stamp each file with a recorded date span.
+    ///
+    /// Call-site details:
+    /// - Write and flush footers first so buffered output cannot replace the
+    ///   stamped modification time. Dropping a [`BufWriter`] discards flush
+    ///   errors.
+    /// - Files with no recorded span in the current export are left untouched,
+    ///   including the orphaned file when no message routes to it.
+    /// - Only files are stamped. Their parent directories remain unchanged.
+    /// - No span is ever recorded while `use_message_times` is off, so this
+    ///   stamps nothing in that case.
+    fn finish(&mut self, config: &Config) {
+        self.files.clear();
+        self.orphaned = None;
+
+        for (filename, span) in self.spans.drain() {
+            span.apply(&config.options.export_path.join(filename));
+        }
+        if let Some(span) = self.orphaned_span.take() {
+            span.apply(&self.orphaned_path);
+        }
+    }
+}
+
+/// Convert the message date into a file-span timestamp.
+///
+/// A date that [`Message::date`] cannot convert contributes nothing to the span.
+fn message_timestamp(config: &Config, message: &Message) -> Option<Timestamp> {
+    let date = message.date(config.offset).ok()?;
+    Some((date.timestamp(), date.timestamp_subsec_nanos()))
+}
+
+/// Return the cached orphaned writer, reopening the file for append if absent.
+fn orphaned_writer(state: &mut ExportState) -> Result<&mut BufWriter<File>, RuntimeError> {
+    let writer = match state.orphaned.take() {
+        Some(writer) => writer,
+        None => {
+            let file = File::options()
+                .append(true)
+                .create(true)
+                .open(&state.orphaned_path)?;
+            BufWriter::with_capacity(FILE_BUFFER_CAPACITY, file)
+        }
+    };
+    Ok(state.orphaned.insert(writer))
 }
 
 /// Decode the message's body via [`Message::parse_body`] and apply it.
@@ -106,6 +191,9 @@ pub trait MessageWriter<'a>: MessageFormatter<'a> {
 /// Resolve the `BufWriter` for `message`, creating the chat file (and writing
 /// its header) on first sight. Messages without a conversation route to the
 /// shared orphaned writer.
+///
+/// With `use_message_times` set, this also extends the destination file's date
+/// span. Callers invoke it only for rendered messages.
 pub fn get_or_create_file_for<'a, 'b, W>(
     writer: &'b mut W,
     message: &Message,
@@ -114,6 +202,12 @@ where
     W: MessageWriter<'a>,
 {
     let config = writer.config();
+    // Skip date conversion when the export will not apply the resulting span.
+    let at = config
+        .options
+        .use_message_times
+        .then(|| message_timestamp(config, message))
+        .flatten();
     match config.conversation(message) {
         Some((chatroom, _)) => {
             let chatroom_rowid = chatroom.rowid;
@@ -129,6 +223,9 @@ where
                     name
                 }
             };
+            if let Some(at) = at {
+                state.record_chat(&filename, at);
+            }
             match state.files.entry(filename) {
                 Occupied(entry) => Ok(entry.into_mut()),
                 Vacant(entry) => {
@@ -146,7 +243,13 @@ where
                 }
             }
         }
-        None => Ok(&mut writer.state_mut().orphaned),
+        None => {
+            let state = writer.state_mut();
+            if let Some(at) = at {
+                state.record_orphaned(at);
+            }
+            orphaned_writer(state)
+        }
     }
 }
 
@@ -169,6 +272,12 @@ fn advance_progress(pb: &ExportProgress, current_message: &mut u64) {
 /// after the progress bar only when one or more messages were skipped.
 /// Row-deserialization errors and I/O errors remain fatal.
 ///
+/// With `use_message_times` set, teardown stamps each transcript that received
+/// a message during the current export: creation time from its earliest
+/// rendered message and modification time from its latest. Writers are dropped
+/// first. Directories remain unchanged, and metadata failures do not fail the
+/// export.
+///
 /// [issue #135]: https://github.com/ReagentX/imessage-exporter/issues/135
 pub fn run_export<'a, W>(writer: &mut W) -> Result<(), RuntimeError>
 where
@@ -180,7 +289,7 @@ where
         W::LABEL,
     );
 
-    W::write_file_header(&mut writer.state_mut().orphaned)?;
+    W::write_file_header(orphaned_writer(writer.state_mut())?)?;
 
     let mut current_message_row = -1;
     let mut current_message = 0;
@@ -254,6 +363,7 @@ where
     if let Some(notice) = W::footer_notice() {
         eprintln!("{notice}");
     }
+    let config = writer.config();
     let state = writer.state_mut();
     for file in state.files.values_mut() {
         W::write_file_footer(file)?;
@@ -261,8 +371,160 @@ where
         // rather than letting `BufWriter::Drop` discard them silently.
         file.flush()?;
     }
-    W::write_file_footer(&mut state.orphaned)?;
-    state.orphaned.flush()?;
+    let orphaned = orphaned_writer(state)?;
+    W::write_file_footer(orphaned)?;
+    orphaned.flush()?;
+
+    // Stamp only after every footer write and checked flush succeeds.
+    state.finish(config);
 
     Ok(())
+}
+
+// MARK: Tests
+#[cfg(test)]
+mod tests {
+    use std::{
+        fs::metadata,
+        path::PathBuf,
+        time::{SystemTime, UNIX_EPOCH},
+    };
+
+    use imessage_database::tables::{
+        messages::Message,
+        table::{ORPHANED, Table},
+    };
+
+    use crate::{
+        Config, HTML, Options, TXT, app::export_type::ExportType,
+        exporters::shared::driver::run_export,
+    };
+
+    /// Whole Unix seconds, so no assertion can trip over a filesystem that
+    /// truncates sub-second precision.
+    fn seconds(time: SystemTime) -> i64 {
+        time.duration_since(UNIX_EPOCH)
+            .expect("time is after the Unix epoch")
+            .as_secs() as i64
+    }
+
+    /// Read the fixture's earliest and latest message dates through the same
+    /// conversion path as the exporter.
+    fn expected_span(config: &Config) -> (i64, i64) {
+        let mut statement =
+            Message::stream_rows(config.data_source.db(), &config.options.query_context).unwrap();
+        let dates: Vec<i64> = Message::rows(&mut statement, [])
+            .unwrap()
+            .map(|message| message.unwrap().date(config.offset).unwrap().timestamp())
+            .collect();
+        (
+            *dates.iter().min().expect("fixture has messages"),
+            *dates.iter().max().expect("fixture has messages"),
+        )
+    }
+
+    /// The fixture's `chat` and `chat_message_join` tables are empty, so every
+    /// message routes here.
+    fn orphaned_file(config: &Config, extension: &str) -> PathBuf {
+        config
+            .options
+            .export_path
+            .join(format!("{ORPHANED}.{extension}"))
+    }
+
+    #[test]
+    fn can_stamp_export_with_message_times() {
+        let mut options = Options::fake_options(ExportType::Txt);
+        options.use_message_times = true;
+        let config = Config::fake_app(options);
+
+        let (earliest, latest) = expected_span(&config);
+        assert_ne!(
+            earliest, latest,
+            "fixture must span two distinct dates to catch first-seen/last-seen bugs"
+        );
+
+        let mut exporter = TXT::new(&config).unwrap();
+        run_export(&mut exporter).unwrap();
+
+        let metadata = metadata(orphaned_file(&config, "txt")).unwrap();
+        assert!(metadata.len() > 0, "export wrote no messages");
+        assert_eq!(seconds(metadata.modified().unwrap()), latest);
+
+        // Birth time is settable only on macOS and Windows.
+        #[cfg(any(target_vendor = "apple", windows))]
+        assert_eq!(seconds(metadata.created().unwrap()), earliest);
+    }
+
+    /// HTML writes a footer after the last message; stamping before that write
+    /// would replace the expected modification time.
+    #[test]
+    fn can_stamp_html_export_with_message_times() {
+        let mut options = Options::fake_options(ExportType::Html);
+        options.use_message_times = true;
+        let config = Config::fake_app(options);
+
+        let (earliest, latest) = expected_span(&config);
+        assert_ne!(
+            earliest, latest,
+            "fixture must span two distinct dates to catch first-seen/last-seen bugs"
+        );
+
+        let mut exporter = HTML::new(&config).unwrap();
+        run_export(&mut exporter).unwrap();
+
+        let metadata = metadata(orphaned_file(&config, "html")).unwrap();
+        assert!(metadata.len() > 0, "export wrote no messages");
+        assert_eq!(seconds(metadata.modified().unwrap()), latest);
+
+        // Birth time is settable only on macOS and Windows.
+        #[cfg(any(target_vendor = "apple", windows))]
+        assert_eq!(seconds(metadata.created().unwrap()), earliest);
+    }
+
+    #[test]
+    fn cannot_stamp_export_without_message_times() {
+        let options = Options::fake_options(ExportType::Txt);
+        assert!(!options.use_message_times);
+        let config = Config::fake_app(options);
+
+        let (_, latest) = expected_span(&config);
+        let before = seconds(SystemTime::now());
+
+        let mut exporter = TXT::new(&config).unwrap();
+        run_export(&mut exporter).unwrap();
+
+        let modified = seconds(
+            metadata(orphaned_file(&config, "txt"))
+                .unwrap()
+                .modified()
+                .unwrap(),
+        );
+        assert_ne!(modified, latest);
+        assert!(
+            modified >= before,
+            "unstamped file should keep its wall-clock mtime: {modified} < {before}"
+        );
+    }
+
+    #[test]
+    fn cannot_stamp_file_without_messages() {
+        let mut options = Options::fake_options(ExportType::Txt);
+        options.use_message_times = true;
+        // Exclude every fixture message; the orphaned file is still created.
+        options.query_context.set_start("2100-01-01").unwrap();
+        let config = Config::fake_app(options);
+
+        let before = seconds(SystemTime::now());
+
+        let mut exporter = TXT::new(&config).unwrap();
+        run_export(&mut exporter).unwrap();
+
+        let metadata = metadata(orphaned_file(&config, "txt")).unwrap();
+        assert_eq!(metadata.len(), 0);
+        assert!(
+            seconds(metadata.modified().unwrap()) >= before,
+            "an empty file must keep its real timestamps"
+        );
+    }
 }

--- a/imessage-exporter/src/exporters/shared/mod.rs
+++ b/imessage-exporter/src/exporters/shared/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod announcement;
 pub(crate) mod attachment;
 pub(crate) mod balloon;
+pub(crate) mod date_span;
 pub(crate) mod driver;
 pub(crate) mod edited;
 pub(crate) mod message;


### PR DESCRIPTION
- Implement #785 
  - Each transcript’s creation time is the earliest message written into that file and its modification time is the latest
  - Guarded behind `--use-message-times` (off by default)