### PR TITLE
Feat/cs/database capabilities

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -30,7 +30,7 @@ Thread diagnostic data:
 Global diagnostic data:
     Total database size: 339.88 MB
     Handles with resolved names: 231/452 (51%)
-    Schema Capabilities
+    Schema capabilities:
         Recoverable deleted messages: Detected
         Reply threads: Detected
         Tapbacks and poll votes: Detected
@@ -132,23 +132,23 @@ The total size of the database file on the disk.
 
 The number of handles in the database that were successfully matched to contact names from the contacts index, out of the total number of handles found. This is followed by the match ratio as a percentage.
 
-## Schema Capabilities
+### Schema capabilities
 
 `imessage-database` probes the database schema once and builds its queries from what the schema actually supports, so databases missing optional features still read correctly. This section shows which optional features the reader detected.
 
-### Recoverable deleted messages
+#### Recoverable deleted messages
 
 Whether the `chat_recoverable_message_join` table exists. When present, messages deleted within the last 30 days can be read and filtered.
 
-### Reply threads
+#### Reply threads
 
 Whether the `message.thread_originator_guid` column exists. When present, replies can be grouped under the messages they respond to.
 
-### Tapbacks and poll votes
+#### Tapbacks and poll votes
 
 Whether the `message.associated_message_guid` column exists. When present, tapbacks and poll votes can be resolved to the messages they target.
 
-### Message filter categories
+#### Message filter categories
 
 Whether the `message.filter_action` and `message.filter_sub_action` columns exist. When present, the filter category each message was received under is read alongside the row.
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -13,7 +13,7 @@ Message diagnostic data:
     Total messages: 183453
     Messages not associated with a chat: 43210
     Messages belonging to more than one chat: 36
-    Recoverable deleted messages: 1
+    Recoverable messages: 1
     Date range: Sep 20, 2019  1:53:14 PM to Mar 09, 2026  5:03:14 PM
                 6 years, 170 days, 4 hours, 58 minutes, 24 seconds
 Attachment diagnostic data:
@@ -30,6 +30,11 @@ Thread diagnostic data:
 Global diagnostic data:
     Total database size: 339.88 MB
     Handles with resolved names: 231/452 (51%)
+    Schema Capabilities
+        Recoverable deleted messages: Detected
+        Reply threads: Detected
+        Tapbacks and poll votes: Detected
+        Message filter categories: Detected
 
 Environment Diagnostics
 
@@ -67,7 +72,7 @@ If a message exists in the `messages` table but does not have an entry in the `c
 
 If a message exists in the `messages` table and maps to multiple chats in `chat_message_join`, the message will exist in all of those chats when exported.
 
-## Recoverable deleted messages
+## Recoverable messages
 
 The number of messages that were marked as deleted from conversations but are recoverable and will be rendered in-line in exports.
 
@@ -126,6 +131,26 @@ The total size of the database file on the disk.
 ### Handles with resolved names
 
 The number of handles in the database that were successfully matched to contact names from the contacts index, out of the total number of handles found. This is followed by the match ratio as a percentage.
+
+## Schema Capabilities
+
+`imessage-database` probes the database schema once and builds its queries from what the schema actually supports, so databases missing optional features still read correctly. This section shows which optional features the reader detected.
+
+### Recoverable deleted messages
+
+Whether the `chat_recoverable_message_join` table exists. When present, messages deleted within the last 30 days can be read and filtered.
+
+### Reply threads
+
+Whether the `message.thread_originator_guid` column exists. When present, replies can be grouped under the messages they respond to.
+
+### Tapbacks and poll votes
+
+Whether the `message.associated_message_guid` column exists. When present, tapbacks and poll votes can be resolved to the messages they target.
+
+### Message filter categories
+
+Whether the `message.filter_action` and `message.filter_sub_action` columns exist. When present, the filter category each message was received under is read alongside the row.
 
 ## Detected converters
 

--- a/imessage-database/src/lib.rs
+++ b/imessage-database/src/lib.rs
@@ -5,4 +5,6 @@
 pub mod error;
 pub mod message_types;
 pub mod tables;
+#[cfg(test)]
+mod test_support;
 pub mod util;

--- a/imessage-database/src/message_types/digital_touch/models.rs
+++ b/imessage-database/src/message_types/digital_touch/models.rs
@@ -194,7 +194,9 @@ impl Color {
     /// Decode a packed buffer of consecutive RGBA colors.
     #[must_use]
     pub fn decode_all(buf: &[u8]) -> Vec<Color> {
-        buf.chunks_exact(4)
+        buf.as_chunks::<4>()
+            .0
+            .iter()
             .map(|c| Color {
                 r: c[0],
                 g: c[1],
@@ -221,7 +223,9 @@ impl Color {
 /// Decode a packed buffer of little-endian `u16` values (delays, rotations).
 #[must_use]
 pub fn decode_u16s(buf: &[u8]) -> Vec<u16> {
-    buf.chunks_exact(2)
+    buf.as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| u16::from_le_bytes([c[0], c[1]]))
         .collect()
 }
@@ -233,7 +237,9 @@ pub fn decode_u16s(buf: &[u8]) -> Vec<u16> {
 /// arrays disagree on how many events it contains.
 pub fn decode_points<T>(raw: &[u8], extras: Vec<T>) -> Result<Vec<Point<T>>, DigitalTouchError> {
     let coords: Vec<(u16, u16)> = raw
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|c| {
             (
                 u16::from_le_bytes([c[0], c[1]]),
@@ -286,7 +292,9 @@ pub fn decode_strokes(raw: &[u8], count: usize) -> Result<Vec<Vec<(u16, u16)>>, 
 
         strokes.push(
             raw[idx..end]
-                .chunks_exact(4)
+                .as_chunks::<4>()
+                .0
+                .iter()
                 .map(|c| {
                     (
                         u16::from_le_bytes([c[0], c[1]]),

--- a/imessage-database/src/tables/attachment.rs
+++ b/imessage-database/src/tables/attachment.rs
@@ -17,6 +17,7 @@ use crate::{
     error::{attachment::AttachmentError, table::TableError},
     message_types::sticker::{StickerDecoration, StickerEffect, StickerSource, get_sticker_effect},
     tables::{
+        capabilities::Capabilities,
         diagnostic::AttachmentDiagnostic,
         messages::Message,
         table::{
@@ -46,7 +47,19 @@ pub const DEFAULT_SMS_ROOT: &str = "~/Library/SMS";
 pub const DEFAULT_ATTACHMENT_ROOT: &str = "~/Library/Messages/Attachments";
 /// Default macOS sticker cache root.
 pub const DEFAULT_STICKER_CACHE_ROOT: &str = "~/Library/Messages/StickerCache";
-const COLS: &str = "a.rowid, a.guid, a.filename, a.uti, a.mime_type, a.transfer_name, a.total_bytes, a.is_sticker, a.hide_attachment, a.emoji_image_short_description";
+/// Recognized `attachment` columns in canonical projection order.
+pub(crate) const ATTACHMENT_COLUMNS: [&str; 10] = [
+    "rowid",
+    "guid",
+    "filename",
+    "uti",
+    "mime_type",
+    "transfer_name",
+    "total_bytes",
+    "is_sticker",
+    "hide_attachment",
+    "emoji_image_short_description",
+];
 
 // MARK: MediaType
 /// Represents the [MIME type](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_Types) of a message's attachment data
@@ -200,28 +213,28 @@ impl Attachment {
     /// [`attributed_body()`](crate::tables::messages::message::Message::attributed_body).
     /// Callers pairing body ranges to rows should match on the file-transfer GUID
     /// rather than relying on position.
-    pub fn from_message(db: &Connection, msg: &Message) -> Result<Vec<Attachment>, TableError> {
+    pub fn from_message(
+        db: &Connection,
+        msg: &Message,
+        capabilities: &Capabilities,
+    ) -> Result<Vec<Attachment>, TableError> {
         let mut out_l = vec![];
         if msg.has_attachments() {
-            let mut statement = db
-                .prepare_cached(&format!(
-                    "
-                        SELECT {COLS}
-                        FROM message_attachment_join j 
-                        LEFT JOIN {ATTACHMENT} a ON j.attachment_id = a.ROWID
-                        WHERE j.message_id = ?1
-                    ",
-                ))
-                .or_else(|_| {
-                    db.prepare_cached(&format!(
-                        "
-                            SELECT *
-                            FROM message_attachment_join j 
-                            LEFT JOIN {ATTACHMENT} a ON j.attachment_id = a.ROWID
-                            WHERE j.message_id = ?1
-                        ",
-                    ))
-                })?;
+            let projection = capabilities
+                .attachment_columns()
+                .iter()
+                .map(|column| format!("a.{column}"))
+                .collect::<Vec<String>>()
+                .join(", ");
+
+            let mut statement = db.prepare_cached(&format!(
+                "
+                    SELECT {projection}
+                    FROM {MESSAGE_ATTACHMENT_JOIN} j
+                    LEFT JOIN {ATTACHMENT} a ON j.attachment_id = a.ROWID
+                    WHERE j.message_id = ?1
+                ",
+            ))?;
 
             for attachment in Attachment::rows(&mut statement, [msg.rowid])? {
                 out_l.push(attachment?);

--- a/imessage-database/src/tables/capabilities.rs
+++ b/imessage-database/src/tables/capabilities.rs
@@ -1,0 +1,180 @@
+/*!
+ Capability detection for Messages databases.
+
+Schemas vary independently of OS release: even on a single macOS build, two
+machines can carry different `message` columns. [`Capabilities::determine`]
+probes the live schema once; query composition then includes exactly what the
+database supports.
+*/
+
+use rusqlite::Connection;
+
+use crate::{
+    error::table::TableError,
+    tables::{
+        attachment::ATTACHMENT_COLUMNS,
+        diagnostic::{column_names, table_exists},
+        messages::columns::MESSAGE_COLUMNS,
+        table::{ATTACHMENT, MESSAGE, RECENTLY_DELETED},
+    },
+};
+
+/// Features of a Messages database schema, probed from the live database.
+///
+/// Each flag guards the SQL constructs that reference its column or table:
+/// when a flag is `false`, composed queries substitute a neutral placeholder
+/// so deserialization behaves uniformly across schemas.
+#[derive(Clone, Debug)]
+pub struct Capabilities {
+    /// Recognized `message` columns this schema declares, in canonical
+    /// ([`MESSAGE_COLUMNS`]) order.
+    message_columns: Vec<&'static str>,
+    /// Recognized `attachment` columns this schema declares, in canonical
+    /// ([`ATTACHMENT_COLUMNS`]) order.
+    attachment_columns: Vec<&'static str>,
+    /// Both `filter_action` and `filter_sub_action` exist on `message`.
+    ///
+    /// The pair is one feature: queries project either both real columns or
+    /// two `NULL` placeholders. A schema carrying only one of the pair reads
+    /// `None` for both, keeping [`FilterAction`](crate::tables::messages::models::FilterAction)
+    /// parsing off partial data.
+    pub filter_actions: bool,
+    /// The `chat_recoverable_message_join` table exists, so recently deleted
+    /// messages can be identified and filtered.
+    pub recoverable_messages: bool,
+    /// `thread_originator_guid` exists on `message`, so replies can be counted
+    /// and grouped.
+    pub replies: bool,
+    /// `associated_message_guid` exists on `message`, so tapbacks and poll
+    /// votes can be resolved.
+    pub associated_message_guids: bool,
+}
+
+impl Capabilities {
+    /// Probe the schema of the supplied database.
+    pub fn determine(db: &Connection) -> Result<Self, TableError> {
+        let message_names = column_names(db, MESSAGE)?;
+        let attachment_names = column_names(db, ATTACHMENT)?;
+
+        Ok(Self {
+            message_columns: MESSAGE_COLUMNS
+                .into_iter()
+                .filter(|column| message_names.contains(*column))
+                .collect(),
+            attachment_columns: ATTACHMENT_COLUMNS
+                .into_iter()
+                .filter(|column| attachment_names.contains(*column))
+                .collect(),
+            filter_actions: message_names.contains("filter_action")
+                && message_names.contains("filter_sub_action"),
+            recoverable_messages: table_exists(db, RECENTLY_DELETED)?,
+            replies: message_names.contains("thread_originator_guid"),
+            associated_message_guids: message_names.contains("associated_message_guid"),
+        })
+    }
+
+    /// Return a copy with the row-enrichment features disabled:
+    /// `recoverable_messages`, `replies`, and `filter_actions`.
+    ///
+    /// Narrow scans that only need the base projection (e.g. the tapback
+    /// cache) use this to skip correlated subqueries and joins those
+    /// features would add.
+    #[must_use]
+    pub fn without_derived_features(&self) -> Self {
+        Self {
+            recoverable_messages: false,
+            replies: false,
+            filter_actions: false,
+            ..self.clone()
+        }
+    }
+
+    /// Recognized `message` columns this schema declares, in canonical order.
+    pub fn message_columns(&self) -> &[&'static str] {
+        &self.message_columns
+    }
+
+    /// Recognized `attachment` columns this schema declares, in canonical order.
+    pub fn attachment_columns(&self) -> &[&'static str] {
+        &self.attachment_columns
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Capabilities;
+    use crate::test_support::schema_db;
+
+    #[test]
+    fn detects_present_features() {
+        let db = schema_db(true, true, true);
+        let capabilities = Capabilities::determine(&db).unwrap();
+
+        assert!(capabilities.filter_actions);
+        assert!(capabilities.recoverable_messages);
+        assert!(capabilities.replies);
+        assert!(capabilities.associated_message_guids);
+
+        // Every recognized column joins the projection.
+        assert_eq!(capabilities.message_columns().len(), 26);
+    }
+
+    #[test]
+    fn detects_absent_features() {
+        let db = schema_db(false, false, false);
+        let capabilities = Capabilities::determine(&db).unwrap();
+
+        assert!(!capabilities.filter_actions);
+        assert!(!capabilities.recoverable_messages);
+        assert!(!capabilities.replies);
+        // The reply columns leave the projection with their capability.
+        assert!(
+            !capabilities
+                .message_columns()
+                .contains(&"thread_originator_guid")
+        );
+    }
+
+    #[test]
+    fn pre_tapback_schema_probes_no_associated_guids() {
+        let db = schema_db(false, false, false);
+        db.execute_batch("ALTER TABLE message DROP COLUMN associated_message_guid")
+            .unwrap();
+
+        assert!(
+            !Capabilities::determine(&db)
+                .unwrap()
+                .associated_message_guids
+        );
+    }
+
+    #[test]
+    fn attachment_columns_track_the_schema() {
+        // The pre-emoji `attachment` layout declares every recognized column
+        // except `emoji_image_short_description`.
+        let db = schema_db(false, false, false);
+        db.execute_batch(
+            "CREATE TABLE attachment (
+                ROWID INTEGER PRIMARY KEY,
+                guid TEXT,
+                filename TEXT,
+                uti TEXT,
+                mime_type TEXT,
+                transfer_name TEXT,
+                total_bytes INTEGER,
+                is_sticker INTEGER,
+                hide_attachment INTEGER
+            );",
+        )
+        .unwrap();
+
+        let capabilities = Capabilities::determine(&db).unwrap();
+
+        assert_eq!(capabilities.attachment_columns().len(), 9);
+        assert!(
+            !capabilities
+                .attachment_columns()
+                .contains(&"emoji_image_short_description")
+        );
+    }
+}

--- a/imessage-database/src/tables/diagnostic.rs
+++ b/imessage-database/src/tables/diagnostic.rs
@@ -6,6 +6,8 @@ use rusqlite::Connection;
 
 use crate::error::table::TableError;
 
+use std::collections::HashSet;
+
 pub(crate) fn count_query(db: &Connection, sql: &str) -> Result<usize, TableError> {
     let count = db.prepare(sql)?.query_row([], |row| row.get::<_, i64>(0))?;
 
@@ -48,6 +50,27 @@ pub(crate) fn column_exists(
     }
 
     Ok(false)
+}
+
+/// Collect the declared column names of `table_name`, lowercased for
+/// case-insensitive membership checks.
+///
+/// A missing table yields an empty set rather than an error, so callers can
+/// treat "table absent" and "no recognized columns" uniformly.
+pub(crate) fn column_names(
+    db: &Connection,
+    table_name: &str,
+) -> Result<HashSet<String>, TableError> {
+    let mut statement = db.prepare(&format!(
+        "PRAGMA table_info({})",
+        quote_sqlite_identifier(table_name)
+    ))?;
+    let columns = statement.query_map([], |row| row.get::<_, String>(1))?;
+    let mut names = HashSet::new();
+    for name in columns {
+        names.insert(name?.to_ascii_lowercase());
+    }
+    Ok(names)
 }
 
 fn quote_sqlite_identifier(identifier: &str) -> String {

--- a/imessage-database/src/tables/messages/columns.rs
+++ b/imessage-database/src/tables/messages/columns.rs
@@ -1,13 +1,13 @@
 /*!
  Column layout resolution and row decoding for the `message` table.
 
- [`Message`] reads 32 columns whose ordinals differ per schema: the explicit
- query heads project them directly, while the `m.*` heads append derived
- columns after every `message` column. Decoding each field by name repeats a
- scan of the result set for every field of every row.
- [`MessageColumns`] resolves that mapping once per statement so rows decode by
- ordinal, and [`Message::from_row_named`] is the fallback for layouts it
- rejects.
+ [`Message`] reads 32 columns whose ordinals differ per schema: the composed
+ query projects the recognized columns contiguously, while custom queries
+ (such as `m.*` projections) may append derived columns after every `message`
+ column. Decoding each field by name repeats a scan of the result set for
+ every field of every row. [`MessageColumns`] resolves that mapping once per
+ statement so rows decode by ordinal, and [`Message::from_row_named`] is the
+ fallback for layouts it rejects.
 */
 
 use rusqlite::{Result, Row, Statement, types::FromSql};
@@ -15,11 +15,39 @@ use rusqlite::{Result, Row, Statement, types::FromSql};
 use crate::tables::messages::Message;
 
 // MARK: Columns
-/// Source columns shared by the iOS 16+ and iOS 27+ explicit query heads.
-/// Filter columns remain schema-specific: each head appends real or `NULL`
-/// values. Deserialization resolves names before reading ordinals, so runtime
-/// behavior does not depend on this order.
-pub(crate) const COMMON_COLS: &str = "m.rowid, m.guid, m.text, m.service, m.handle_id, m.destination_caller_id, m.subject, m.date, m.date_read, m.date_delivered, m.is_from_me, m.is_read, m.item_type, m.other_handle, m.share_status, m.share_direction, m.group_title, m.group_action_type, m.associated_message_guid, m.associated_message_type, m.balloon_bundle_id, m.expressive_send_style_id, m.thread_originator_guid, m.thread_originator_part, m.date_edited, m.associated_message_emoji";
+/// Recognized `message` source columns in canonical projection order.
+///
+/// [`Capabilities`](crate::tables::capabilities::Capabilities) probes these
+/// names against the live schema; query composition projects exactly the
+/// subset that exists, qualified with `m.`.
+pub(crate) const MESSAGE_COLUMNS: [&str; 26] = [
+    "rowid",
+    "guid",
+    "text",
+    "service",
+    "handle_id",
+    "destination_caller_id",
+    "subject",
+    "date",
+    "date_read",
+    "date_delivered",
+    "is_from_me",
+    "is_read",
+    "item_type",
+    "other_handle",
+    "share_status",
+    "share_direction",
+    "group_title",
+    "group_action_type",
+    "associated_message_guid",
+    "associated_message_type",
+    "balloon_bundle_id",
+    "expressive_send_style_id",
+    "thread_originator_guid",
+    "thread_originator_part",
+    "date_edited",
+    "associated_message_emoji",
+];
 
 /// Size of the stack buffer used to case-fold column names. The two longest
 /// recognized names, `associated_message_emoji` and
@@ -328,14 +356,14 @@ mod tests {
 
     use super::{LONGEST_COL, Message, MessageColumns};
     use crate::tables::{
-        messages::query_parts::{
-            ios_13_older_query, ios_14_15_query, ios_16_newer_query, ios_27_newer_query,
-        },
+        capabilities::Capabilities,
+        messages::query_parts::message_query,
         table::{Table, get_connection},
     };
 
-    /// A `message` schema whose column order differs from [`super::COMMON_COLS`]. Its
-    /// `m.*` result exercises name resolution rather than projection order.
+    /// A `message` schema whose column order differs from
+    /// [`super::MESSAGE_COLUMNS`]. Its `m.*` result exercises name resolution
+    /// rather than projection order.
     const SCRAMBLED_SCHEMA: &str = "
         CREATE TABLE message (
             associated_message_emoji TEXT,
@@ -406,6 +434,12 @@ mod tests {
         let db = Connection::open_in_memory().unwrap();
         db.execute_batch(SCRAMBLED_SCHEMA).unwrap();
         db
+    }
+
+    /// Prepare the composed message query for `db`'s probed schema.
+    fn prepared(db: &Connection) -> Statement<'_> {
+        let capabilities = Capabilities::determine(db).unwrap();
+        db.prepare(&message_query(&capabilities, None)).unwrap()
     }
 
     /// Every [`MessageColumns`] field paired with its column name and resolved
@@ -566,9 +600,8 @@ mod tests {
     fn every_column_name_fits_the_fold_buffer() {
         // A name longer than the buffer is skipped before the match, so it
         // would silently never resolve.
-        let columns =
-            MessageColumns::resolve(&ventura_db().prepare(&ios_16_newer_query(None)).unwrap())
-                .unwrap();
+        let db = ventura_db();
+        let columns = MessageColumns::resolve(&prepared(&db)).unwrap();
         for (name, _) in slots(&columns) {
             assert!(name.len() <= LONGEST_COL, "`{name}` exceeds LONGEST_COL");
         }
@@ -576,38 +609,45 @@ mod tests {
 
     #[test]
     fn slots_cover_every_resolved_field() {
-        let columns =
-            MessageColumns::resolve(&ventura_db().prepare(&ios_16_newer_query(None)).unwrap())
-                .unwrap();
+        let db = ventura_db();
+        let columns = MessageColumns::resolve(&prepared(&db)).unwrap();
         assert_eq!(slots(&columns).len(), MessageColumns::FIELDS);
     }
 
     #[test]
-    fn resolve_matches_rusqlite_for_explicit_head() {
+    fn resolve_matches_rusqlite_for_composed_head() {
         let db = ventura_db();
-        assert_resolve_matches_rusqlite(&db.prepare(&ios_16_newer_query(None)).unwrap());
+        assert_resolve_matches_rusqlite(&prepared(&db));
+
+        let scrambled = scrambled_db();
+        assert_resolve_matches_rusqlite(&prepared(&scrambled));
     }
 
     #[test]
-    fn resolve_matches_rusqlite_for_wildcard_heads() {
+    fn resolve_matches_rusqlite_for_wildcard_projection() {
+        // Custom queries may project `m.*`; resolution must still work when
+        // derived columns follow every `message` column.
         let db = ventura_db();
-        assert_resolve_matches_rusqlite(&db.prepare(&ios_14_15_query(None)).unwrap());
-        assert_resolve_matches_rusqlite(&db.prepare(&ios_13_older_query(None)).unwrap());
-    }
-
-    #[test]
-    fn resolve_matches_rusqlite_for_filter_heads() {
-        let db = scrambled_db();
-        assert_resolve_matches_rusqlite(&db.prepare(&ios_27_newer_query(None)).unwrap());
-        assert_resolve_matches_rusqlite(&db.prepare(&ios_13_older_query(None)).unwrap());
+        let stmt = db
+            .prepare(
+                "
+                SELECT m.*, c.chat_id,
+                    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
+                    0 as num_replies
+                FROM message as m
+                LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
+                ",
+            )
+            .unwrap();
+        assert_resolve_matches_rusqlite(&stmt);
     }
 
     fn assert_exact_explicit_projection(stmt: &Statement<'_>) {
         let columns = MessageColumns::resolve(stmt).unwrap();
 
-        // Exact count catches drift between the explicit projection and the
-        // mapped fields. Ordinal equality constrains `COMMON_COLS`, not
-        // deserialization.
+        // Exact count catches drift between the composed projection and the
+        // mapped fields. Ordinal equality constrains the composer's column
+        // order, not deserialization.
         assert_eq!(stmt.column_count(), slots(&columns).len());
         for (idx, (name, resolved)) in slots(&columns).into_iter().enumerate() {
             assert_eq!(resolved, Some(idx), "`{name}` is not at ordinal {idx}");
@@ -615,18 +655,18 @@ mod tests {
     }
 
     #[test]
-    fn explicit_heads_select_exactly_what_message_reads() {
+    fn composed_head_selects_exactly_what_message_reads() {
         let ventura = ventura_db();
-        assert_exact_explicit_projection(&ventura.prepare(&ios_16_newer_query(None)).unwrap());
+        assert_exact_explicit_projection(&prepared(&ventura));
 
         let scrambled = scrambled_db();
-        assert_exact_explicit_projection(&scrambled.prepare(&ios_27_newer_query(None)).unwrap());
+        assert_exact_explicit_projection(&prepared(&scrambled));
     }
 
     #[test]
     fn source_qualified_head_has_one_chat_id() {
         let db = ventura_db();
-        let stmt = db.prepare(&ios_14_15_query(None)).unwrap();
+        let stmt = prepared(&db);
 
         let matches: Vec<usize> = stmt
             .column_names()
@@ -647,22 +687,20 @@ mod tests {
         // declared name even where the head writes `rowid`, so a
         // case-sensitive match would fail to resolve a required column.
         let db = ventura_db();
-        let stmt = db.prepare(&ios_16_newer_query(None)).unwrap();
+        let stmt = prepared(&db);
         assert_eq!(stmt.column_name(0).unwrap(), "ROWID");
         assert_eq!(MessageColumns::resolve(&stmt).unwrap().rowid, 0);
     }
 
     #[test]
-    fn paths_agree_for_every_query_head() {
+    fn paths_agree_for_composed_query() {
         let ventura = ventura_db();
-        assert_paths_agree(&ventura, &ios_16_newer_query(None));
-        assert_paths_agree(&ventura, &ios_14_15_query(None));
-        assert_paths_agree(&ventura, &ios_13_older_query(None));
+        let capabilities = Capabilities::determine(&ventura).unwrap();
+        assert_paths_agree(&ventura, &message_query(&capabilities, None));
 
         let scrambled = scrambled_db();
-        assert_paths_agree(&scrambled, &ios_27_newer_query(None));
-        assert_paths_agree(&scrambled, &ios_16_newer_query(None));
-        assert_paths_agree(&scrambled, &ios_13_older_query(None));
+        let capabilities = Capabilities::determine(&scrambled).unwrap();
+        assert_paths_agree(&scrambled, &message_query(&capabilities, None));
     }
 
     #[test]
@@ -670,7 +708,7 @@ mod tests {
         // No mapped field occupies its explicit-projection ordinal. Correct
         // values therefore depend on name resolution.
         let db = scrambled_db();
-        let mut stmt = db.prepare(&ios_13_older_query(None)).unwrap();
+        let mut stmt = prepared(&db);
         let messages: Vec<Message> = Message::rows(&mut stmt, [])
             .unwrap()
             .map(Result::unwrap)
@@ -710,10 +748,12 @@ mod tests {
         )
         .unwrap();
 
-        let mut stmt = db.prepare(&ios_13_older_query(None)).unwrap();
+        let mut stmt = prepared(&db);
         let columns = MessageColumns::resolve(&stmt).expect("required columns are present");
         assert_eq!(columns.date_edited, None);
-        assert_eq!(columns.filter_action, None);
+        // The composer always projects the filter aliases, so their ordinals
+        // resolve even though the schema lacks the columns.
+        assert!(columns.filter_action.is_some());
 
         let messages: Vec<Message> = Message::rows(&mut stmt, [])
             .unwrap()

--- a/imessage-database/src/tables/messages/message.rs
+++ b/imessage-database/src/tables/messages/message.rs
@@ -154,18 +154,17 @@ use crate::{
         variants::{Announcement, BalloonProvider, CustomBalloon, Tapback, TapbackAction, Variant},
     },
     tables::{
+        capabilities::Capabilities,
         diagnostic::{MessageDiagnostic, count_query, table_exists},
         messages::{
             body::{parse_body_legacy, parse_body_typedstream},
-            columns::{COMMON_COLS, MessageColumns},
+            columns::MessageColumns,
             models::{BubbleComponent, FilterAction, GroupAction, Service, SharedLocation},
-            query_parts::{
-                ios_13_older_query, ios_14_15_query, ios_16_newer_query, prepare_ios_27_newer,
-            },
+            query_parts::{from_clause, message_query, prepare_message_query},
         },
         table::{
-            ATTRIBUTED_BODY, CHAT_MESSAGE_JOIN, Cacheable, MESSAGE, MESSAGE_ATTACHMENT_JOIN,
-            MESSAGE_PAYLOAD, MESSAGE_SUMMARY_INFO, RECENTLY_DELETED, Table, flatten_row,
+            ATTRIBUTED_BODY, CHAT_MESSAGE_JOIN, Cacheable, MESSAGE, MESSAGE_PAYLOAD,
+            MESSAGE_SUMMARY_INFO, RECENTLY_DELETED, Table, flatten_row,
         },
     },
     util::{
@@ -255,10 +254,15 @@ pub struct Message {
 /// Use [`Message::apply_body()`] to apply the parsed body back to the message:
 ///
 /// ```no_run
-/// # use imessage_database::tables::{messages::Message, table::get_connection};
+/// # use imessage_database::tables::{
+/// #     capabilities::Capabilities,
+/// #     messages::Message,
+/// #     table::get_connection,
+/// # };
 /// # use imessage_database::util::dirs::default_db_path;
 /// # let conn = get_connection(&default_db_path()).unwrap();
-/// # let mut message = Message::from_guid("example", &conn).unwrap();
+/// # let capabilities = Capabilities::determine(&conn).unwrap();
+/// # let mut message = Message::from_guid("example", &conn, &capabilities).unwrap();
 /// if let Ok(body) = message.parse_body(&conn) {
 ///     message.apply_body(body);
 /// }
@@ -287,12 +291,14 @@ impl Table for Message {
         Self::from_row_named(row)
     }
 
-    /// Prepare the first message query compatible with the database schema.
+    /// Prepare the message query for the database's probed schema.
+    ///
+    /// Convenience wrapper over [`stream_rows`](Self::stream_rows) that probes
+    /// the schema itself; prefer threading [`Capabilities`] when calling
+    /// repeatedly.
     fn get(db: &'_ Connection) -> Result<CachedStatement<'_>, TableError> {
-        Ok(prepare_ios_27_newer(db, None)
-            .or_else(|_| db.prepare_cached(&ios_16_newer_query(None)))
-            .or_else(|_| db.prepare_cached(&ios_14_15_query(None)))
-            .or_else(|_| db.prepare_cached(&ios_13_older_query(None)))?)
+        let capabilities = Capabilities::determine(db)?;
+        prepare_message_query(db, &capabilities, None)
     }
 
     /// Resolve the column layout after the first step, then deserialize every
@@ -444,47 +450,30 @@ impl Cacheable for Message {
         // Create cache for user IDs
         let mut map: HashMap<Self::K, Self::V> = HashMap::new();
 
-        // Create query
-        let statement = db.prepare(&format!(
-            "SELECT
-                 {COMMON_COLS},
-                 c.chat_id,
-                 (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
-                 NULL as deleted_from,
-                 0 as num_replies,
-                 NULL as filter_action,
-                 NULL as filter_sub_action
-             FROM
-                 {MESSAGE} as m
-             LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-             WHERE m.associated_message_guid IS NOT NULL
-            "
-        )).or_else(|_| db.prepare(&format!(
-            "SELECT
-                 *,
-                 c.chat_id,
-                 (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
-                 NULL as deleted_from,
-                 0 as num_replies
-             FROM
-                 {MESSAGE} as m
-             LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-             WHERE m.associated_message_guid IS NOT NULL
-            "
-        )));
+        let capabilities = Capabilities::determine(db)?;
+        if !capabilities.associated_message_guids {
+            return Ok(map);
+        }
 
-        if let Ok(mut statement) = statement {
-            for message in Self::rows(&mut statement, [])? {
-                let message = message?;
-                if message.is_tapback()
-                    && let Some((idx, tapback_target_guid)) = message.clean_associated_guid()
-                {
-                    map.entry(tapback_target_guid.to_string())
-                        .or_insert_with(HashMap::new)
-                        .entry(idx)
-                        .or_insert_with(Vec::new)
-                        .push(message);
-                }
+        // The cache only maps each tapback to its target GUID and component
+        // index, so the derived features stay off: this full scan skips their
+        // correlated subqueries and the recoverable-message join.
+        let cache_capabilities = capabilities.without_derived_features();
+        let mut statement = db.prepare_cached(&message_query(
+            &cache_capabilities,
+            Some("WHERE m.associated_message_guid IS NOT NULL"),
+        ))?;
+
+        for message in Self::rows(&mut statement, [])? {
+            let message = message?;
+            if message.is_tapback()
+                && let Some((idx, tapback_target_guid)) = message.clean_associated_guid()
+            {
+                map.entry(tapback_target_guid.to_string())
+                    .or_insert_with(HashMap::new)
+                    .entry(idx)
+                    .or_insert_with(Vec::new)
+                    .push(message);
             }
         }
 
@@ -504,10 +493,15 @@ impl Message {
     /// # Example
     ///
     /// ```no_run
-    /// # use imessage_database::tables::{messages::Message, table::get_connection};
+    /// # use imessage_database::tables::{
+    /// #     capabilities::Capabilities,
+    /// #     messages::Message,
+    /// #     table::get_connection,
+    /// # };
     /// # use imessage_database::util::dirs::default_db_path;
     /// # let conn = get_connection(&default_db_path()).unwrap();
-    /// # let mut message = Message::from_guid("example", &conn).unwrap();
+    /// # let capabilities = Capabilities::determine(&conn).unwrap();
+    /// # let mut message = Message::from_guid("example", &conn, &capabilities).unwrap();
     /// if let Ok(body) = message.parse_body(&conn) {
     ///     message.apply_body(body);
     /// }
@@ -977,37 +971,35 @@ impl Message {
     /// # Example
     ///
     /// ```no_run
+    /// use imessage_database::tables::{
+    ///     capabilities::Capabilities,
+    ///     messages::Message,
+    ///     table::get_connection,
+    /// };
     /// use imessage_database::util::dirs::default_db_path;
-    /// use imessage_database::tables::table::get_connection;
-    /// use imessage_database::tables::messages::Message;
     /// use imessage_database::util::query_context::QueryContext;
     ///
     /// let db_path = default_db_path();
     /// let conn = get_connection(&db_path).unwrap();
+    /// let capabilities = Capabilities::determine(&conn).unwrap();
     /// let context = QueryContext::default();
-    /// Message::get_count(&conn, &context);
+    /// Message::get_count(&conn, &capabilities, &context);
     /// ```
-    pub fn get_count(db: &Connection, context: &QueryContext) -> Result<i64, TableError> {
+    pub fn get_count(
+        db: &Connection,
+        capabilities: &Capabilities,
+        context: &QueryContext,
+    ) -> Result<i64, TableError> {
+        // The unfiltered count skips the chat join: `chat_message_join` can
+        // associate one message with several chats, and every extra
+        // association would inflate `COUNT(*)`.
         let mut statement = if context.has_filters() {
+            let filters =
+                Self::generate_filter_statement(context, capabilities.recoverable_messages);
             db.prepare_cached(&format!(
-                "SELECT
-                     COUNT(*)
-                 FROM {MESSAGE} as m
-                 LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-                 LEFT JOIN {RECENTLY_DELETED} as d ON m.ROWID = d.message_id
-                 {}",
-                Self::generate_filter_statement(context, true)
-            ))
-            .or_else(|_| {
-                db.prepare_cached(&format!(
-                    "SELECT
-                         COUNT(*)
-                     FROM {MESSAGE} as m
-                     LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-                    {}",
-                    Self::generate_filter_statement(context, false)
-                ))
-            })?
+                "SELECT COUNT(*){}\n{filters}",
+                from_clause(capabilities)
+            ))?
         } else {
             db.prepare_cached(&format!("SELECT COUNT(*) FROM {MESSAGE}"))?
         };
@@ -1022,16 +1014,20 @@ impl Message {
     /// # Example
     ///
     /// ```no_run
+    /// use imessage_database::tables::{
+    ///     capabilities::Capabilities,
+    ///     messages::Message,
+    ///     table::{get_connection, Table},
+    /// };
     /// use imessage_database::util::dirs::default_db_path;
-    /// use imessage_database::tables::table::get_connection;
-    /// use imessage_database::tables::{messages::Message, table::Table};
     /// use imessage_database::util::query_context::QueryContext;
     ///
     /// let db_path = default_db_path();
     /// let conn = get_connection(&db_path).unwrap();
+    /// let capabilities = Capabilities::determine(&conn).unwrap();
     /// let context = QueryContext::default();
     ///
-    /// let mut statement = Message::stream_rows(&conn, &context).unwrap();
+    /// let mut statement = Message::stream_rows(&conn, &capabilities, &context).unwrap();
     ///
     /// for message in Message::rows(&mut statement, []).unwrap() {
     ///     println!("{:#?}", message);
@@ -1039,29 +1035,13 @@ impl Message {
     /// ```
     pub fn stream_rows<'a>(
         db: &'a Connection,
+        capabilities: &Capabilities,
         context: &'a QueryContext,
     ) -> Result<CachedStatement<'a>, TableError> {
-        if !context.has_filters() {
-            return Self::get(db);
-        }
-        Ok(
-            prepare_ios_27_newer(db, Some(&Self::generate_filter_statement(context, true)))
-                .or_else(|_| {
-                    db.prepare_cached(&ios_16_newer_query(Some(&Self::generate_filter_statement(
-                        context, true,
-                    ))))
-                })
-                .or_else(|_| {
-                    db.prepare_cached(&ios_14_15_query(Some(&Self::generate_filter_statement(
-                        context, false,
-                    ))))
-                })
-                .or_else(|_| {
-                    db.prepare_cached(&ios_13_older_query(Some(&Self::generate_filter_statement(
-                        context, false,
-                    ))))
-                })?,
-        )
+        let filters = context
+            .has_filters()
+            .then(|| Self::generate_filter_statement(context, capabilities.recoverable_messages));
+        prepare_message_query(db, capabilities, filters.as_deref())
     }
 
     /// Parse the target body component index and GUID from `associated_message_guid`.
@@ -1094,18 +1074,20 @@ impl Message {
     }
 
     /// Group replies by target body component index.
-    pub fn get_replies(&self, db: &Connection) -> Result<HashMap<usize, Vec<Self>>, TableError> {
+    pub fn get_replies(
+        &self,
+        db: &Connection,
+        capabilities: &Capabilities,
+    ) -> Result<HashMap<usize, Vec<Self>>, TableError> {
         let mut out_h: HashMap<usize, Vec<Self>> = HashMap::new();
 
-        // No need to hit the DB if we know we don't have replies
+        // No need to hit the DB if we know we don't have replies. A nonzero
+        // `num_replies` also proves the schema has `thread_originator_guid`,
+        // so the filter below always prepares.
         if self.has_replies() {
             // Use a parameterized filter so the prepared statement can be cached/reused
             let filters = "WHERE m.thread_originator_guid = ?1";
-
-            // `thread_originator_guid` is absent from the iOS 13-era schema.
-            let mut statement = prepare_ios_27_newer(db, Some(filters))
-                .or_else(|_| db.prepare_cached(&ios_16_newer_query(Some(filters))))
-                .or_else(|_| db.prepare_cached(&ios_14_15_query(Some(filters))))?;
+            let mut statement = prepare_message_query(db, capabilities, Some(filters))?;
 
             for message in Message::rows(&mut statement, [self.guid.as_str()])? {
                 let m = message?;
@@ -1124,18 +1106,20 @@ impl Message {
 
     // MARK: Polls
     /// Load messages that vote on or update the parent poll.
-    pub fn get_votes(&self, db: &Connection) -> Result<Vec<Self>, TableError> {
+    pub fn get_votes(
+        &self,
+        db: &Connection,
+        capabilities: &Capabilities,
+    ) -> Result<Vec<Self>, TableError> {
         let mut out_v: Vec<Self> = Vec::new();
 
-        // No need to hit the DB if we know we don't have a poll
+        // No need to hit the DB if we know we don't have a poll. Polls carry
+        // app payload data, which postdates `associated_message_guid`, so the
+        // filter below always prepares.
         if self.is_poll() {
             // Use a parameterized filter so the prepared statement can be cached/reused
             let filters = "WHERE m.associated_message_guid = ?1";
-
-            // `associated_message_guid` is absent from the iOS 13-era schema.
-            let mut statement = prepare_ios_27_newer(db, Some(filters))
-                .or_else(|_| db.prepare_cached(&ios_16_newer_query(Some(filters))))
-                .or_else(|_| db.prepare_cached(&ios_14_15_query(Some(filters))))?;
+            let mut statement = prepare_message_query(db, capabilities, Some(filters))?;
 
             for message in Message::rows(&mut statement, [self.guid.as_str()])? {
                 out_v.push(message?);
@@ -1146,14 +1130,18 @@ impl Message {
     }
 
     /// Parse this message as a poll, including vote counts and option updates.
-    pub fn as_poll(&self, db: &Connection) -> Result<Option<Poll>, MessageError> {
+    pub fn as_poll(
+        &self,
+        db: &Connection,
+        capabilities: &Capabilities,
+    ) -> Result<Option<Poll>, MessageError> {
         if self.is_poll()
             && let Some(payload) = self.payload_data(db)
         {
             let mut poll = Poll::from_payload(&payload)?;
 
             // Get all votes associated with this poll
-            let votes = self.get_votes(db).unwrap_or_default();
+            let votes = self.get_votes(db, capabilities).unwrap_or_default();
 
             // Later poll-option updates are stored as messages referencing the original poll.
             for vote in votes.iter().rev() {
@@ -1417,6 +1405,7 @@ impl Message {
     /// ```no_run
     /// use imessage_database::{
     ///     tables::{
+    ///         capabilities::Capabilities,
     ///         messages::Message,
     ///         table::get_connection,
     ///     },
@@ -1425,19 +1414,21 @@ impl Message {
     ///
     /// let db_path = default_db_path();
     /// let conn = get_connection(&db_path).unwrap();
+    /// let capabilities = Capabilities::determine(&conn).unwrap();
     ///
-    /// if let Ok(mut message) = Message::from_guid("example-guid", &conn) {
+    /// if let Ok(mut message) = Message::from_guid("example-guid", &conn, &capabilities) {
     ///     if let Ok(body) = message.parse_body(&conn) {
     ///         message.apply_body(body);
     ///     }
     ///     println!("{:#?}", message)
     /// }
     /// ```
-    pub fn from_guid(guid: &str, db: &Connection) -> Result<Self, TableError> {
-        let mut statement = prepare_ios_27_newer(db, Some("WHERE m.guid = ?1"))
-            .or_else(|_| db.prepare_cached(&ios_16_newer_query(Some("WHERE m.guid = ?1"))))
-            .or_else(|_| db.prepare_cached(&ios_14_15_query(Some("WHERE m.guid = ?1"))))
-            .or_else(|_| db.prepare_cached(&ios_13_older_query(Some("WHERE m.guid = ?1"))))?;
+    pub fn from_guid(
+        guid: &str,
+        db: &Connection,
+        capabilities: &Capabilities,
+    ) -> Result<Self, TableError> {
+        let mut statement = prepare_message_query(db, capabilities, Some("WHERE m.guid = ?1"))?;
 
         Message::row(&mut statement, [guid])
     }

--- a/imessage-database/src/tables/messages/query_parts.rs
+++ b/imessage-database/src/tables/messages/query_parts.rs
@@ -1,158 +1,204 @@
 /*!
- Message query templates for supported database schemas.
+ Compose `message` queries from probed schema [`Capabilities`].
 
- - If the database has `chat_recoverable_message_join`, we can restore some deleted messages.
- - If the database has `thread_originator_guid`, we can count replies.
- - If the database has `filter_action` and `filter_sub_action`, we can read message filter categories.
-
- [`Message::rows`](super::Message::rows) maps each head's column names to
- ordinals before decoding. A head may therefore select columns in any order and
- omit columns that [`Message`](super::Message) reads with a default. See
- `MessageColumns` in [`message`](super::columns).
+The projection contains exactly the columns the schema declares, and every
+schema-specific fragment (`deleted_from`, `num_replies`, the filter codes)
+degrades to a neutral placeholder when its capability is absent, so one
+statement shape serves every schema. Queries are built from what the database
+supports, never from which OS release wrote it.
 */
 
-use std::sync::LazyLock;
+use rusqlite::{CachedStatement, Connection};
 
-use rusqlite::{CachedStatement, Connection, Result};
-
-use crate::tables::{
-    messages::columns::COMMON_COLS,
-    table::{CHAT_MESSAGE_JOIN, MESSAGE, MESSAGE_ATTACHMENT_JOIN, RECENTLY_DELETED},
+use crate::{
+    error::table::TableError,
+    tables::{
+        capabilities::Capabilities,
+        table::{CHAT_MESSAGE_JOIN, MESSAGE, MESSAGE_ATTACHMENT_JOIN, RECENTLY_DELETED},
+    },
 };
 
-// MARK: Queries
-/// Query head for schemas with `filter_action` and `filter_sub_action` columns.
-static IOS_27_NEWER_HEAD: LazyLock<String> = LazyLock::new(|| {
-    format!("
-SELECT
-    {COMMON_COLS},
-    c.chat_id,
-    (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    m.filter_action,
-    m.filter_sub_action
-FROM
-    {MESSAGE} as m
-LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-LEFT JOIN {RECENTLY_DELETED} as d ON m.ROWID = d.message_id
-")
-});
+const ORDER_BY: &str = "\nORDER BY\n    m.date;";
 
-/// Probe whose preparation requires both filter columns.
-static FILTER_COLUMN_PROBE: LazyLock<String> = LazyLock::new(|| {
-    format!("SELECT m.filter_action, m.filter_sub_action FROM {MESSAGE} m LIMIT 0")
-});
-
-/// Query head that reads recoverable-message and reply data and substitutes
-/// `NULL` filter values.
-static IOS_16_NEWER_HEAD: LazyLock<String> = LazyLock::new(|| {
-    format!("
-SELECT
-    {COMMON_COLS},
-    c.chat_id,
-    (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    NULL as filter_action,
-    NULL as filter_sub_action
-FROM
-    {MESSAGE} as m
-LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-LEFT JOIN {RECENTLY_DELETED} as d ON m.ROWID = d.message_id
-")
-});
-
-/// Query head that reads reply data without joining recoverable messages.
+/// Prepare the message query for the probed schema.
 ///
-/// `m.*` preserves filter columns when present. When absent, resolution
-/// leaves their ordinals unset and deserialization yields `None`. Adding `NULL`
-/// aliases would create duplicate names when the columns exist.
-static IOS_14_15_HEAD: LazyLock<String> = LazyLock::new(|| {
-    format!("
-SELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    (SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
-FROM
-    {MESSAGE} as m
-LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-")
-});
-
-/// Query head without recoverable-message or reply data.
-static IOS_13_OLDER_HEAD: LazyLock<String> = LazyLock::new(|| {
-    format!("
-SELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    0 as num_replies
-FROM
-    {MESSAGE} as m
-LEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id
-")
-});
-
-const ORDER_BY: &str = "
-ORDER BY
-    m.date;
-";
-
-// MARK: Functions
-/// Prepare [`ios_27_newer_query`] after verifying that both filter columns
-/// exist.
-///
-/// A failed probe returns [`rusqlite::Error`], so callers can fall back to an
-/// older query with `or_else`. The full query is built only after the probe
-/// succeeds.
-pub(crate) fn prepare_ios_27_newer<'db>(
+/// `filters` is an optional rendered `WHERE` clause, e.g. from
+/// [`Message::generate_filter_statement`](crate::tables::messages::Message::generate_filter_statement).
+pub(crate) fn prepare_message_query<'db>(
     db: &'db Connection,
+    capabilities: &Capabilities,
     filters: Option<&str>,
-) -> Result<CachedStatement<'db>> {
-    db.prepare_cached(&FILTER_COLUMN_PROBE)?;
-    db.prepare_cached(&ios_27_newer_query(filters))
+) -> Result<CachedStatement<'db>, TableError> {
+    Ok(db.prepare_cached(&message_query(capabilities, filters))?)
 }
 
-/// Build a query for schemas with message filter columns.
-pub(crate) fn ios_27_newer_query(filters: Option<&str>) -> String {
+/// Build the `FROM`/`JOIN` fragment shared by every message query that reads
+/// chat associations.
+pub(crate) fn from_clause(capabilities: &Capabilities) -> String {
+    let recoverable_join = if capabilities.recoverable_messages {
+        format!("\nLEFT JOIN {RECENTLY_DELETED} as d ON m.ROWID = d.message_id")
+    } else {
+        String::new()
+    };
     format!(
-        "{}{}{}",
-        *IOS_27_NEWER_HEAD,
-        filters.unwrap_or_default(),
-        ORDER_BY
+        "\nFROM\n    {MESSAGE} as m\nLEFT JOIN {CHAT_MESSAGE_JOIN} as c ON m.ROWID = c.message_id{recoverable_join}"
     )
 }
 
-/// Build a query that reads recoverable-message and reply data.
-pub(crate) fn ios_16_newer_query(filters: Option<&str>) -> String {
+/// Build the message query for the probed schema.
+///
+/// The projection lists the recognized columns the schema declares (qualified
+/// with `m.`), the derived `chat_id`/`num_attachments` values, and the
+/// capability-gated fragments.
+pub(crate) fn message_query(capabilities: &Capabilities, filters: Option<&str>) -> String {
+    let mut projection: Vec<String> = capabilities
+        .message_columns()
+        .iter()
+        .map(|column| format!("m.{column}"))
+        .collect();
+    projection.push("c.chat_id".to_owned());
+    projection.push(format!(
+        "(SELECT COUNT(*) FROM {MESSAGE_ATTACHMENT_JOIN} a WHERE m.ROWID = a.message_id) as num_attachments"
+    ));
+    projection.push(
+        if capabilities.recoverable_messages {
+            "d.chat_id as deleted_from"
+        } else {
+            "NULL as deleted_from"
+        }
+        .to_owned(),
+    );
+    projection.push(if capabilities.replies {
+        format!("(SELECT COUNT(*) FROM {MESSAGE} m2 WHERE m2.thread_originator_guid = m.guid) as num_replies")
+    } else {
+        "0 as num_replies".to_owned()
+    });
+    if capabilities.filter_actions {
+        projection.push("m.filter_action".to_owned());
+        projection.push("m.filter_sub_action".to_owned());
+    } else {
+        projection.push("NULL as filter_action".to_owned());
+        projection.push("NULL as filter_sub_action".to_owned());
+    }
+
     format!(
-        "{}{}{}",
-        *IOS_16_NEWER_HEAD,
+        "\nSELECT\n    {}{}\n{}{ORDER_BY}",
+        projection.join(",\n    "),
+        from_clause(capabilities),
         filters.unwrap_or_default(),
-        ORDER_BY
     )
 }
 
-/// Build a query that reads reply data without joining recoverable messages.
-pub(crate) fn ios_14_15_query(filters: Option<&str>) -> String {
-    format!(
-        "{}{}{}",
-        *IOS_14_15_HEAD,
-        filters.unwrap_or_default(),
-        ORDER_BY
-    )
-}
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
 
-/// Build a query without recoverable-message or reply data.
-pub(crate) fn ios_13_older_query(filters: Option<&str>) -> String {
-    format!(
-        "{}{}{}",
-        *IOS_13_OLDER_HEAD,
-        filters.unwrap_or_default(),
-        ORDER_BY
-    )
+    use super::{from_clause, message_query};
+    use crate::{
+        tables::{capabilities::Capabilities, messages::Message},
+        test_support::schema_db,
+        util::query_context::QueryContext,
+    };
+
+    #[test]
+    fn full_capabilities_read_real_values() {
+        let db = schema_db(true, true, true);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let query = message_query(&capabilities, None);
+
+        assert!(query.contains("m.filter_action,\n    m.filter_sub_action"));
+        assert!(query.contains("d.chat_id as deleted_from"));
+        assert!(query.contains(
+            "(SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies"
+        ));
+        assert!(
+            query
+                .contains("LEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id")
+        );
+        // Every recognized column is projected, qualified with the source alias.
+        assert!(query.contains("    m.rowid,\n    m.guid,"));
+    }
+
+    #[test]
+    fn absent_capabilities_degrade_to_placeholders() {
+        let db = schema_db(false, false, false);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let query = message_query(&capabilities, None);
+
+        assert!(query.contains("NULL as filter_action,\n    NULL as filter_sub_action"));
+        assert!(query.contains("NULL as deleted_from"));
+        assert!(query.contains("0 as num_replies"));
+        assert!(!query.contains("chat_recoverable_message_join"));
+        // Neither the projection nor the reply subquery may reference a
+        // column the schema lacks.
+        assert!(!query.contains("m.thread_originator_guid"));
+        assert!(!query.contains("thread_originator_guid = m.guid"));
+    }
+
+    #[test]
+    fn capabilities_degrade_independently() {
+        // Replies exist but the recoverable table does not: the subquery and
+        // the placeholder must coexist.
+        let db = schema_db(true, false, true);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let query = message_query(&capabilities, None);
+
+        assert!(query.contains(
+            "(SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies"
+        ));
+        assert!(query.contains("NULL as deleted_from"));
+        assert!(query.contains("m.filter_action,\n    m.filter_sub_action"));
+        assert!(!query.contains("LEFT JOIN chat_recoverable_message_join"));
+    }
+
+    #[test]
+    fn filters_are_appended_verbatim() {
+        let db = schema_db(false, false, false);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let query = message_query(&capabilities, Some("WHERE m.guid = \"fake\""));
+
+        assert!(query.contains("WHERE m.guid = \"fake\"\nORDER BY\n    m.date;"));
+    }
+
+    #[test]
+    fn context_filters_follow_recoverable_capability() {
+        let mut context = QueryContext::default();
+        context.set_start("2020-01-01").unwrap();
+        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
+        let start_ns = context.start.unwrap();
+
+        // With the table present, chat filters also match deleted rows.
+        let db = schema_db(false, true, false);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let filters =
+            Message::generate_filter_statement(&context, capabilities.recoverable_messages);
+        assert!(filters.contains(&format!(
+            "WHERE  m.date >= {start_ns} AND  (c.chat_id IN (1, 2, 3) OR d.chat_id IN (1, 2, 3))"
+        )));
+
+        // Without it, filtering against `d.chat_id` would fail to prepare.
+        let db = schema_db(false, false, false);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let filters =
+            Message::generate_filter_statement(&context, capabilities.recoverable_messages);
+        assert!(filters.contains(&format!(
+            "WHERE  m.date >= {start_ns} AND  c.chat_id IN (1, 2, 3)"
+        )));
+        assert!(!filters.contains("d.chat_id IN"));
+    }
+
+    #[test]
+    fn from_clause_matches_recoverable_capability() {
+        let db = schema_db(false, true, false);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        assert!(
+            from_clause(&capabilities).contains(
+                "\nLEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id"
+            )
+        );
+
+        let db = schema_db(false, false, false);
+        let capabilities = Capabilities::determine(&db).unwrap();
+        assert!(!from_clause(&capabilities).contains("chat_recoverable_message_join"));
+    }
 }

--- a/imessage-database/src/tables/messages/tests/filter_action_tests.rs
+++ b/imessage-database/src/tables/messages/tests/filter_action_tests.rs
@@ -58,58 +58,13 @@ mod filter_action_mapping_tests {
 mod filter_action_query_tests {
     use rusqlite::Connection;
 
-    use crate::tables::messages::{
-        Message, models::FilterAction, query_parts::prepare_ios_27_newer,
+    use crate::{
+        tables::{
+            capabilities::Capabilities,
+            messages::{Message, models::FilterAction},
+        },
+        test_support::schema_db,
     };
-
-    /// Build the minimum schema consumed by the message query. `macos_27`
-    /// controls whether the filter columns are present and which query can prepare.
-    fn schema_db(macos_27: bool) -> Connection {
-        let filter_columns = if macos_27 {
-            ", filter_action INTEGER DEFAULT 0, filter_sub_action INTEGER DEFAULT 0"
-        } else {
-            ""
-        };
-
-        let db = Connection::open_in_memory().unwrap();
-        db.execute_batch(&format!(
-            "
-            CREATE TABLE message (
-                ROWID INTEGER PRIMARY KEY,
-                guid TEXT,
-                text TEXT,
-                service TEXT,
-                handle_id INTEGER,
-                destination_caller_id TEXT,
-                subject TEXT,
-                date INTEGER,
-                date_read INTEGER,
-                date_delivered INTEGER,
-                is_from_me INTEGER,
-                is_read INTEGER,
-                item_type INTEGER,
-                other_handle INTEGER,
-                share_status INTEGER,
-                share_direction INTEGER,
-                group_title TEXT,
-                group_action_type INTEGER,
-                associated_message_guid TEXT,
-                associated_message_type INTEGER,
-                balloon_bundle_id TEXT,
-                expressive_send_style_id TEXT,
-                thread_originator_guid TEXT,
-                thread_originator_part TEXT,
-                date_edited INTEGER,
-                associated_message_emoji TEXT{filter_columns}
-            );
-            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
-            CREATE TABLE message_attachment_join (attachment_id INTEGER, message_id INTEGER);
-            CREATE TABLE chat_recoverable_message_join (chat_id INTEGER, message_id INTEGER, delete_date INTEGER);
-            "
-        ))
-        .unwrap();
-        db
-    }
 
     fn insert(db: &Connection, guid: &str, filter_action: Option<i32>) {
         match filter_action {
@@ -126,19 +81,20 @@ mod filter_action_query_tests {
     }
 
     #[test]
-    fn can_read_filter_action_from_macos_27_schema() {
-        let db = schema_db(true);
+    fn can_read_filter_action_from_schema_with_filters() {
+        let db = schema_db(true, true, true);
         insert(&db, "junk", Some(2));
 
-        let message = Message::from_guid("junk", &db).unwrap();
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let message = Message::from_guid("junk", &db, &capabilities).unwrap();
 
         assert_eq!(message.filter_action, Some(2));
         assert_eq!(message.filter_action(), Some(FilterAction::Junk));
     }
 
     #[test]
-    fn can_read_every_category_from_macos_27_schema() {
-        let db = schema_db(true);
+    fn can_read_every_category_from_schema_with_filters() {
+        let db = schema_db(true, true, true);
         let cases = [
             ("unfiltered", 0, FilterAction::Unfiltered),
             ("allow", 1, FilterAction::Allow),
@@ -151,20 +107,22 @@ mod filter_action_query_tests {
             insert(&db, guid, Some(code));
         }
 
+        let capabilities = Capabilities::determine(&db).unwrap();
         for (guid, _, expected) in cases {
-            let message = Message::from_guid(guid, &db).unwrap();
+            let message = Message::from_guid(guid, &db, &capabilities).unwrap();
             assert_eq!(message.filter_action(), Some(expected), "guid: {guid}");
         }
     }
 
     #[test]
     fn older_schema_reports_no_filter_action() {
-        let db = schema_db(false);
+        let db = schema_db(false, true, true);
         insert(&db, "old", None);
 
-        let message = Message::from_guid("old", &db).unwrap();
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let message = Message::from_guid("old", &db, &capabilities).unwrap();
 
-        // The compatible query head pads both missing filter columns with `NULL`.
+        // The composed query pads both missing filter columns with `NULL`.
         // `None` remains distinct from `Unfiltered`.
         assert_eq!(message.filter_action, None);
         assert_eq!(message.filter_action(), None);
@@ -172,10 +130,11 @@ mod filter_action_query_tests {
 
     #[test]
     fn older_schema_still_reads_the_rest_of_the_row() {
-        let db = schema_db(false);
+        let db = schema_db(false, true, true);
         insert(&db, "old", None);
 
-        let message = Message::from_guid("old", &db).unwrap();
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let message = Message::from_guid("old", &db, &capabilities).unwrap();
 
         assert_eq!(message.guid, "old");
         assert_eq!(message.date, 0);
@@ -184,58 +143,17 @@ mod filter_action_query_tests {
 
     #[test]
     fn filter_sub_action_is_read_raw() {
-        let db = schema_db(true);
+        let db = schema_db(true, true, true);
         db.execute(
             "INSERT INTO message (guid, date, is_from_me, filter_action, filter_sub_action) VALUES ('sub', 0, 0, 4, 2)",
             [],
         )
         .unwrap();
 
-        let message = Message::from_guid("sub", &db).unwrap();
+        let capabilities = Capabilities::determine(&db).unwrap();
+        let message = Message::from_guid("sub", &db, &capabilities).unwrap();
 
         assert_eq!(message.filter_action(), Some(FilterAction::Transaction));
         assert_eq!(message.filter_sub_action, Some(2));
-    }
-
-    #[test]
-    fn can_prepare_filter_head_on_macos_27_schema() {
-        let db = schema_db(true);
-
-        assert!(prepare_ios_27_newer(&db, None).is_ok());
-    }
-
-    #[test]
-    fn cannot_prepare_filter_head_on_older_schema() {
-        let db = schema_db(false);
-
-        assert!(prepare_ios_27_newer(&db, None).is_err());
-    }
-
-    #[test]
-    fn cannot_prepare_filter_head_with_only_one_filter_column() {
-        let db = schema_db(false);
-        db.execute_batch("ALTER TABLE message ADD COLUMN filter_action INTEGER")
-            .unwrap();
-
-        assert!(prepare_ios_27_newer(&db, None).is_err());
-    }
-
-    #[test]
-    fn half_a_filter_schema_reads_no_filter_action() {
-        let db = schema_db(false);
-        db.execute_batch("ALTER TABLE message ADD COLUMN filter_action INTEGER")
-            .unwrap();
-        db.execute(
-            "INSERT INTO message (guid, date, is_from_me, filter_action) VALUES ('half', 0, 0, 2)",
-            [],
-        )
-        .unwrap();
-
-        // The iOS 16 head projects `NULL` for both filter fields, even when the
-        // schema contains `filter_action` alone.
-        let message = Message::from_guid("half", &db).unwrap();
-
-        assert_eq!(message.filter_action, None);
-        assert_eq!(message.filter_sub_action, None);
     }
 }

--- a/imessage-database/src/tables/messages/tests/query_tests.rs
+++ b/imessage-database/src/tables/messages/tests/query_tests.rs
@@ -219,7 +219,7 @@ mod include_recoverable_tests {
 mod guid_query_tests {
     use std::env::current_dir;
 
-    use crate::tables::{messages::Message, table::get_connection};
+    use crate::tables::{capabilities::Capabilities, messages::Message, table::get_connection};
 
     #[test]
     fn test_cant_query_bad_guid() {
@@ -230,7 +230,9 @@ mod guid_query_tests {
             .join("imessage-database/test_data/db/test.db");
         let conn = get_connection(&db_path).unwrap();
 
-        let message = Message::from_guid("fake-guid", &conn);
+        let capabilities = Capabilities::determine(&conn).unwrap();
+
+        let message = Message::from_guid("fake-guid", &conn, &capabilities);
 
         assert!(message.is_err());
     }
@@ -244,8 +246,11 @@ mod guid_query_tests {
             .join("imessage-database/test_data/db/test.db");
         let conn = get_connection(&db_path).unwrap();
 
+        let capabilities = Capabilities::determine(&conn).unwrap();
+
         let mut message =
-            Message::from_guid("0355C6E1-D0C8-4212-AA87-DD8AE4FD1203", &conn).unwrap();
+            Message::from_guid("0355C6E1-D0C8-4212-AA87-DD8AE4FD1203", &conn, &capabilities)
+                .unwrap();
 
         let body = message.parse_body(&conn).unwrap();
         message.apply_body(body);
@@ -263,7 +268,9 @@ mod guid_query_tests {
             .join("imessage-database/test_data/db/test.db");
         let conn = get_connection(&db_path).unwrap();
 
-        let message = Message::from_guid("", &conn);
+        let capabilities = Capabilities::determine(&conn).unwrap();
+
+        let message = Message::from_guid("", &conn, &capabilities);
         assert!(message.is_err());
     }
 
@@ -276,289 +283,9 @@ mod guid_query_tests {
             .join("imessage-database/test_data/db/test.db");
         let conn = get_connection(&db_path).unwrap();
 
-        let message = Message::from_guid("not-a-valid-guid-format", &conn);
+        let capabilities = Capabilities::determine(&conn).unwrap();
+
+        let message = Message::from_guid("not-a-valid-guid-format", &conn, &capabilities);
         assert!(message.is_err());
-    }
-}
-
-#[cfg(test)]
-mod query_string_tests {
-    use std::collections::BTreeSet;
-
-    use crate::{
-        tables::messages::{Message, query_parts},
-        util::query_context::QueryContext,
-    };
-
-    #[test]
-    fn can_generate_no_filters_27() {
-        let query_string = query_parts::ios_27_newer_query(None);
-        let expected = "\nSELECT
-    m.rowid, m.guid, m.text, m.service, m.handle_id, m.destination_caller_id, m.subject, m.date, m.date_read, m.date_delivered, m.is_from_me, m.is_read, m.item_type, m.other_handle, m.share_status, m.share_direction, m.group_title, m.group_action_type, m.associated_message_guid, m.associated_message_type, m.balloon_bundle_id, m.expressive_send_style_id, m.thread_originator_guid, m.thread_originator_part, m.date_edited, m.associated_message_emoji,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    m.filter_action,
-    m.filter_sub_action
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-LEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id
-
-ORDER BY
-    m.date;\n";
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_27() {
-        let query_string = query_parts::ios_27_newer_query(Some("WHERE m.guid = \"fake\""));
-        let expected = "\nSELECT
-    m.rowid, m.guid, m.text, m.service, m.handle_id, m.destination_caller_id, m.subject, m.date, m.date_read, m.date_delivered, m.is_from_me, m.is_read, m.item_type, m.other_handle, m.share_status, m.share_direction, m.group_title, m.group_action_type, m.associated_message_guid, m.associated_message_type, m.balloon_bundle_id, m.expressive_send_style_id, m.thread_originator_guid, m.thread_originator_part, m.date_edited, m.associated_message_emoji,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    m.filter_action,
-    m.filter_sub_action
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-LEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id
-WHERE m.guid = \"fake\"
-ORDER BY
-    m.date;\n";
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_27_context() {
-        let mut context = QueryContext::default();
-        context.set_start("2020-01-01").unwrap();
-        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
-        let start_ns = context.start.unwrap();
-
-        let filters = Message::generate_filter_statement(&context, true);
-
-        let query_string = query_parts::ios_27_newer_query(Some(&filters));
-        let expected = format!(
-            "\nSELECT
-    m.rowid, m.guid, m.text, m.service, m.handle_id, m.destination_caller_id, m.subject, m.date, m.date_read, m.date_delivered, m.is_from_me, m.is_read, m.item_type, m.other_handle, m.share_status, m.share_direction, m.group_title, m.group_action_type, m.associated_message_guid, m.associated_message_type, m.balloon_bundle_id, m.expressive_send_style_id, m.thread_originator_guid, m.thread_originator_part, m.date_edited, m.associated_message_emoji,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    m.filter_action,
-    m.filter_sub_action
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-LEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id
-WHERE  m.date >= {start_ns} AND  (c.chat_id IN (1, 2, 3) OR d.chat_id IN (1, 2, 3))
-ORDER BY
-    m.date;\n"
-        );
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_no_filters_16() {
-        let query_string = query_parts::ios_16_newer_query(None);
-        let expected = "\nSELECT
-    m.rowid, m.guid, m.text, m.service, m.handle_id, m.destination_caller_id, m.subject, m.date, m.date_read, m.date_delivered, m.is_from_me, m.is_read, m.item_type, m.other_handle, m.share_status, m.share_direction, m.group_title, m.group_action_type, m.associated_message_guid, m.associated_message_type, m.balloon_bundle_id, m.expressive_send_style_id, m.thread_originator_guid, m.thread_originator_part, m.date_edited, m.associated_message_emoji,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    NULL as filter_action,
-    NULL as filter_sub_action
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-LEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id
-
-ORDER BY
-    m.date;\n";
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_16() {
-        let query_string = query_parts::ios_16_newer_query(Some("WHERE m.guid = \"fake\""));
-        let expected = "\nSELECT
-    m.rowid, m.guid, m.text, m.service, m.handle_id, m.destination_caller_id, m.subject, m.date, m.date_read, m.date_delivered, m.is_from_me, m.is_read, m.item_type, m.other_handle, m.share_status, m.share_direction, m.group_title, m.group_action_type, m.associated_message_guid, m.associated_message_type, m.balloon_bundle_id, m.expressive_send_style_id, m.thread_originator_guid, m.thread_originator_part, m.date_edited, m.associated_message_emoji,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    NULL as filter_action,
-    NULL as filter_sub_action
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-LEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id
-WHERE m.guid = \"fake\"
-ORDER BY
-    m.date;\n";
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_16_context() {
-        let mut context = QueryContext::default();
-        context.set_start("2020-01-01").unwrap();
-        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
-        let start_ns = context.start.unwrap();
-
-        let filters = Message::generate_filter_statement(&context, true);
-
-        let query_string = query_parts::ios_16_newer_query(Some(&filters));
-        let expected = format!(
-            "\nSELECT
-    m.rowid, m.guid, m.text, m.service, m.handle_id, m.destination_caller_id, m.subject, m.date, m.date_read, m.date_delivered, m.is_from_me, m.is_read, m.item_type, m.other_handle, m.share_status, m.share_direction, m.group_title, m.group_action_type, m.associated_message_guid, m.associated_message_type, m.balloon_bundle_id, m.expressive_send_style_id, m.thread_originator_guid, m.thread_originator_part, m.date_edited, m.associated_message_emoji,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    d.chat_id as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies,
-    NULL as filter_action,
-    NULL as filter_sub_action
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-LEFT JOIN chat_recoverable_message_join as d ON m.ROWID = d.message_id
-WHERE  m.date >= {start_ns} AND  (c.chat_id IN (1, 2, 3) OR d.chat_id IN (1, 2, 3))
-ORDER BY
-    m.date;\n"
-        );
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_no_filters_14_15() {
-        let query_string = query_parts::ios_14_15_query(None);
-        let expected = "\nSELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-
-ORDER BY
-    m.date;\n";
-        println!("{query_string}");
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_14_15() {
-        let query_string = query_parts::ios_14_15_query(Some("WHERE m.guid = \"fake\""));
-        let expected = "\nSELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-WHERE m.guid = \"fake\"
-ORDER BY
-    m.date;\n";
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_14_15_context() {
-        let mut context = QueryContext::default();
-        context.set_start("2020-01-01").unwrap();
-        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
-        let start_ns = context.start.unwrap();
-
-        let filters = Message::generate_filter_statement(&context, false);
-
-        let query_string = query_parts::ios_14_15_query(Some(&filters));
-        let expected = format!(
-            "\nSELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    (SELECT COUNT(*) FROM message m2 WHERE m2.thread_originator_guid = m.guid) as num_replies
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-WHERE  m.date >= {start_ns} AND  c.chat_id IN (1, 2, 3)
-ORDER BY
-    m.date;\n"
-        );
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_no_filters_13() {
-        let query_string = query_parts::ios_13_older_query(None);
-        let expected = "\nSELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    0 as num_replies
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-
-ORDER BY
-    m.date;\n";
-        println!("{query_string}");
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_13() {
-        let query_string = query_parts::ios_13_older_query(Some("WHERE m.guid = \"fake\""));
-        let expected = "\nSELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    0 as num_replies
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-WHERE m.guid = \"fake\"
-ORDER BY
-    m.date;\n";
-        assert_eq!(query_string, expected);
-    }
-
-    #[test]
-    fn can_generate_filters_13_context() {
-        let mut context = QueryContext::default();
-        context.set_start("2020-01-01").unwrap();
-        context.set_selected_chat_ids(BTreeSet::from([1, 2, 3]));
-        let start_ns = context.start.unwrap();
-
-        let filters = Message::generate_filter_statement(&context, false);
-
-        let query_string = query_parts::ios_13_older_query(Some(&filters));
-        let expected = format!(
-            "\nSELECT
-    m.*,
-    c.chat_id,
-    (SELECT COUNT(*) FROM message_attachment_join a WHERE m.ROWID = a.message_id) as num_attachments,
-    NULL as deleted_from,
-    0 as num_replies
-FROM
-    message as m
-LEFT JOIN chat_message_join as c ON m.ROWID = c.message_id
-WHERE  m.date >= {start_ns} AND  c.chat_id IN (1, 2, 3)
-ORDER BY
-    m.date;\n"
-        );
-        assert_eq!(query_string, expected);
     }
 }

--- a/imessage-database/src/tables/mod.rs
+++ b/imessage-database/src/tables/mod.rs
@@ -6,6 +6,7 @@ of macOS, the schema of the iMessage database can vary.
 */
 
 pub mod attachment;
+pub mod capabilities;
 pub mod chat;
 pub mod chat_handle;
 pub mod diagnostic;

--- a/imessage-database/src/test_support.rs
+++ b/imessage-database/src/test_support.rs
@@ -1,0 +1,67 @@
+//! Shared in-memory schema builders for capability-driven tests.
+
+use rusqlite::Connection;
+
+/// Build an in-memory database whose `message` table carries the oldest
+/// supported core layout, with each optional feature appended independently.
+///
+/// The toggles mirror [`Capabilities`](crate::tables::capabilities::Capabilities)
+/// probes: `filters` adds the `filter_action`/`filter_sub_action` pair,
+/// `recoverable` creates `chat_recoverable_message_join`, and `replies` adds
+/// the `thread_originator_*` columns. `associated_message_guid` is always
+/// present.
+#[must_use]
+pub(crate) fn schema_db(filters: bool, recoverable: bool, replies: bool) -> Connection {
+    let filter_columns = if filters {
+        ",\n                filter_action INTEGER DEFAULT 0,\n                filter_sub_action INTEGER DEFAULT 0"
+    } else {
+        ""
+    };
+    let reply_columns = if replies {
+        "thread_originator_guid TEXT,\n                thread_originator_part TEXT,\n                "
+    } else {
+        ""
+    };
+    let recoverable_table = if recoverable {
+        "CREATE TABLE chat_recoverable_message_join (chat_id INTEGER, message_id INTEGER);"
+    } else {
+        ""
+    };
+
+    let db = Connection::open_in_memory().unwrap();
+    db.execute_batch(&format!(
+        "
+        CREATE TABLE message (
+            ROWID INTEGER PRIMARY KEY,
+            guid TEXT,
+            text TEXT,
+            service TEXT,
+            handle_id INTEGER,
+            destination_caller_id TEXT,
+            subject TEXT,
+            date INTEGER,
+            date_read INTEGER,
+            date_delivered INTEGER,
+            is_from_me INTEGER,
+            is_read INTEGER,
+            item_type INTEGER,
+            other_handle INTEGER,
+            share_status INTEGER,
+            share_direction INTEGER,
+            group_title TEXT,
+            group_action_type INTEGER,
+            associated_message_guid TEXT,
+            associated_message_type INTEGER,
+            balloon_bundle_id TEXT,
+            expressive_send_style_id TEXT,{reply_columns}
+            date_edited INTEGER,
+            associated_message_emoji TEXT{filter_columns}
+        );
+        CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+        CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+        {recoverable_table}
+        "
+    ))
+    .unwrap();
+    db
+}

--- a/imessage-exporter/src/app/data_source.rs
+++ b/imessage-exporter/src/app/data_source.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use crabapple::Backup;
-use imessage_database::{tables::table::get_connection, util::platform::Platform};
+use imessage_database::{
+    tables::{capabilities::Capabilities, table::get_connection},
+    util::platform::Platform,
+};
 use rusqlite::Connection;
 
 use crate::app::{
@@ -43,6 +46,8 @@ pub struct DataSource {
     /// This is wrapped in `Option` to allow for taking/dropping it when cleaning up temporary files,
     /// but should always be `Some` during normal operation.
     messages_connection: Option<Connection>,
+    /// Schema capabilities probed from the Messages database at construction.
+    pub capabilities: Capabilities,
     /// Contacts index keyed by email and phone number.
     ///
     /// If construction fails, this will be an empty index, and a warning will be logged.
@@ -61,20 +66,16 @@ impl DataSource {
     /// Options constructor determines the platform and database location logic already,
     /// so this just uses that to create the appropriate connections and indexes.
     pub fn from(options: &Options) -> Result<Self, RuntimeError> {
-        match options.platform {
-            Platform::macOS => {
-                let messages_path = options.get_db_path();
-
-                let contacts_index =
-                    Self::get_contacts_index(options.contacts_path.as_deref()).unwrap_or_default();
-
-                Ok(Self {
-                    messages_connection: Some(get_connection(&messages_path)?),
-                    contacts_index,
-                    backup: None,
-                    temp_messages_db: None,
-                })
-            }
+        // Resolve the per-platform inputs first; the connection is opened and
+        // probed once below, so the messages path for an encrypted backup must
+        // point at the decrypted temporary file.
+        let (messages_path, contacts_index, backup, temp_messages_db) = match options.platform {
+            Platform::macOS => (
+                options.get_db_path(),
+                Self::get_contacts_index(options.contacts_path.as_deref()).unwrap_or_default(),
+                None,
+                None,
+            ),
             Platform::iOS => match decrypt_backup(options)? {
                 Some(backup) => {
                     let messages_db = TempDatabase(get_decrypted_message_database(&backup)?);
@@ -97,29 +98,33 @@ impl DataSource {
                         );
                     }
 
-                    let messages_connection = get_connection(messages_db.path())?;
-                    Ok(Self {
-                        messages_connection: Some(messages_connection),
+                    (
+                        messages_db.path().to_path_buf(),
                         contacts_index,
-                        backup: Some(backup),
-                        temp_messages_db: Some(messages_db),
-                    })
+                        Some(backup),
+                        Some(messages_db),
+                    )
                 }
-                None => {
-                    let messages_path = options.get_db_path();
-                    let contacts_index =
-                        Self::get_contacts_index(Some(&options.db_path.join(DEFAULT_PATH_IOS)))
-                            .unwrap_or_default();
-
-                    Ok(Self {
-                        messages_connection: Some(get_connection(&messages_path)?),
-                        contacts_index,
-                        backup: None,
-                        temp_messages_db: None,
-                    })
-                }
+                None => (
+                    options.get_db_path(),
+                    Self::get_contacts_index(Some(&options.db_path.join(DEFAULT_PATH_IOS)))
+                        .unwrap_or_default(),
+                    None,
+                    None,
+                ),
             },
-        }
+        };
+
+        let messages_connection = get_connection(&messages_path)?;
+        let capabilities = Capabilities::determine(&messages_connection)?;
+
+        Ok(Self {
+            messages_connection: Some(messages_connection),
+            capabilities,
+            contacts_index,
+            backup,
+            temp_messages_db,
+        })
     }
 
     /// Build a contacts index, logging a warning on failure.

--- a/imessage-exporter/src/app/runtime.rs
+++ b/imessage-exporter/src/app/runtime.rs
@@ -448,10 +448,8 @@ impl Config {
                 message_diag.messages_in_multiple_chats
             );
         }
-        if let Some(recoverable_messages) = message_diag.recoverable_messages
-            && recoverable_messages > 0
-        {
-            println!("    Recoverable deleted messages: {}", recoverable_messages);
+        if let Some(recoverable_messages) = message_diag.recoverable_messages {
+            println!("    Recoverable messages: {}", recoverable_messages);
         }
         if let (Some(first), Some(last)) = (
             message_diag.first_message_date,
@@ -538,6 +536,41 @@ impl Config {
             "    Handles with resolved names: {}/{} ({resolved_percent}%)",
             total_resolved,
             self.participants.len(),
+        );
+
+        println!("    Schema capabilities:");
+        let capabilities = &self.data_source.capabilities;
+        println!(
+            "        Recoverable deleted messages: {}",
+            if capabilities.recoverable_messages {
+                "Detected"
+            } else {
+                "Not found"
+            }
+        );
+        println!(
+            "        Reply threads: {}",
+            if capabilities.replies {
+                "Detected"
+            } else {
+                "Not found"
+            }
+        );
+        println!(
+            "        Tapbacks and poll votes: {}",
+            if capabilities.associated_message_guids {
+                "Detected"
+            } else {
+                "Not found"
+            }
+        );
+        println!(
+            "        Message filter categories: {}",
+            if capabilities.filter_actions {
+                "Detected"
+            } else {
+                "Not found"
+            }
         );
 
         println!("\nEnvironment Diagnostics\n");

--- a/imessage-exporter/src/exporters/html/balloons.rs
+++ b/imessage-exporter/src/exporters/html/balloons.rs
@@ -52,10 +52,14 @@ fn digital_touch_attachment(
     state: &ExportState,
     msg: &Message,
 ) -> Option<Attachment> {
-    let mut attachment = Attachment::from_message(config.data_source.db(), msg)
-        .ok()?
-        .into_iter()
-        .next()?;
+    let mut attachment = Attachment::from_message(
+        config.data_source.db(),
+        msg,
+        &config.data_source.capabilities,
+    )
+    .ok()?
+    .into_iter()
+    .next()?;
 
     // Prepare this as a normal attachment. Depending on the attachment-manager
     // mode this may copy, convert, reuse an existing export copy, or leave the

--- a/imessage-exporter/src/exporters/html/mod.rs
+++ b/imessage-exporter/src/exporters/html/mod.rs
@@ -480,7 +480,11 @@ impl<'a> MessageFormatter<'a> for HTML<'a> {
         out: &mut String,
     ) -> Result<(), RuntimeError> {
         let is_reply = matches!(context, RenderContext::Reply);
-        let mut ctx = MessageContext::resolve(message, self.config.data_source.db())?;
+        let mut ctx = MessageContext::resolve(
+            message,
+            self.config.data_source.db(),
+            &self.config.data_source.capabilities,
+        )?;
         let parts = self.build_message_parts(message, &mut ctx)?;
 
         let (date, read_after) = self.get_time(message);

--- a/imessage-exporter/src/exporters/shared/balloon.rs
+++ b/imessage-exporter/src/exporters/shared/balloon.rs
@@ -59,7 +59,7 @@ pub fn dispatch_app_balloon<F: BalloonFormatter>(
 
     // Poll messages use a different payload type
     if message.is_poll() {
-        let poll = message.as_poll(config.data_source.db())?;
+        let poll = message.as_poll(config.data_source.db(), &config.data_source.capabilities)?;
         return match poll {
             Some(poll) => Ok(formatter.format_poll(&poll)),
             None => Err(PlistParseError::PollError.into()),

--- a/imessage-exporter/src/exporters/shared/driver.rs
+++ b/imessage-exporter/src/exporters/shared/driver.rs
@@ -296,12 +296,14 @@ where
     let mut failures: u64 = 0;
     let total_messages = Message::get_count(
         writer.config().data_source.db(),
+        &writer.config().data_source.capabilities,
         &writer.config().options.query_context,
     )?;
     writer.state().pb.start(total_messages);
 
     let mut statement = Message::stream_rows(
         writer.config().data_source.db(),
+        &writer.config().data_source.capabilities,
         &writer.config().options.query_context,
     )?;
 
@@ -411,8 +413,12 @@ mod tests {
     /// Read the fixture's earliest and latest message dates through the same
     /// conversion path as the exporter.
     fn expected_span(config: &Config) -> (i64, i64) {
-        let mut statement =
-            Message::stream_rows(config.data_source.db(), &config.options.query_context).unwrap();
+        let mut statement = Message::stream_rows(
+            config.data_source.db(),
+            &config.data_source.capabilities,
+            &config.options.query_context,
+        )
+        .unwrap();
         let dates: Vec<i64> = Message::rows(&mut statement, [])
             .unwrap()
             .map(|message| message.unwrap().date(config.offset).unwrap().timestamp())

--- a/imessage-exporter/src/exporters/shared/message.rs
+++ b/imessage-exporter/src/exporters/shared/message.rs
@@ -4,7 +4,7 @@ use rusqlite::Connection;
 
 use imessage_database::{
     message_types::expressives::Expressive,
-    tables::{attachment::Attachment, messages::Message},
+    tables::{attachment::Attachment, capabilities::Capabilities, messages::Message},
 };
 
 use crate::app::error::RuntimeError;
@@ -23,10 +23,14 @@ pub(crate) struct MessageContext<'a> {
 }
 
 impl<'a> MessageContext<'a> {
-    pub fn resolve(message: &'a Message, db: &Connection) -> Result<Self, RuntimeError> {
+    pub fn resolve(
+        message: &'a Message,
+        db: &Connection,
+        capabilities: &Capabilities,
+    ) -> Result<Self, RuntimeError> {
         Ok(Self {
-            attachments: Attachment::from_message(db, message)?,
-            replies_map: message.get_replies(db)?,
+            attachments: Attachment::from_message(db, message, capabilities)?,
+            replies_map: message.get_replies(db, capabilities)?,
             expressive: match message.get_expressive() {
                 Expressive::None | Expressive::Unknown("") => None,
                 other => Some(other),

--- a/imessage-exporter/src/exporters/shared/tapback.rs
+++ b/imessage-exporter/src/exporters/shared/tapback.rs
@@ -49,7 +49,11 @@ pub(crate) fn resolve_tapback<'a, S>(
     let who = config.who(msg.handle_id, msg.is_from_me(), &msg.destination_caller_id);
     let kind = match tapback {
         Tapback::Sticker => {
-            let mut paths = Attachment::from_message(config.data_source.db(), msg)?;
+            let mut paths = Attachment::from_message(
+                config.data_source.db(),
+                msg,
+                &config.data_source.capabilities,
+            )?;
             match paths.get_mut(0) {
                 Some(sticker) => TapbackKind::Sticker {
                     payload: sticker_renderer(sticker),

--- a/imessage-exporter/src/exporters/txt/mod.rs
+++ b/imessage-exporter/src/exporters/txt/mod.rs
@@ -300,7 +300,11 @@ impl<'a> MessageFormatter<'a> for TXT<'a> {
         context: RenderContext,
         out: &mut String,
     ) -> Result<(), RuntimeError> {
-        let mut ctx = MessageContext::resolve(message, self.config.data_source.db())?;
+        let mut ctx = MessageContext::resolve(
+            message,
+            self.config.data_source.db(),
+            &self.config.data_source.capabilities,
+        )?;
         let mut resolver = AttachmentResolver::new(&ctx.attachments);
 
         let mut parts = Vec::with_capacity(message.components.len());


### PR DESCRIPTION
- Schema detection is now capability-based
  - The reader probes the schema once at startup
  - Queries are built from the tables and columns the database declares
  - Replaces the newest-first cascade of version-specific queries
  - All supported OS versions read through one code path
- Tapbacks and tapback stickers render in chronological order
  - Previously rendered in database insertion order
  - Insertion order can diverge from send order for messages synced across devices
- Diagnostics report detected schema capabilities
  - Recoverable deleted messages
  - Reply threads
  - Tapbacks and poll votes
  - Message filter categories
- Query failures surface as errors instead of degrading silently
  - The old fallback chain swallowed every preparation error
  - A transient failure could silently drop recoverable-message or filter data from an export
  - A tapback cache failure produced an export with no tapbacks at all
  - Both now stop with an error
- New `tables::capabilities::Capabilities` type
  - `Capabilities::determine(&Connection)` probes a schema once
  - Query construction derives from the result
- Breaking: query methods now take `&Capabilities`
  - `Message::from_guid`, `stream_rows`, `get_count`, `get_replies`, `get_votes`, `as_poll`
  - `Attachment::from_message`
  - Probe once per connection and pass it through